### PR TITLE
Always set `value` for integrations

### DIFF
--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -71,7 +71,9 @@ class Chariot:
         return resp.text
 
     @verify_credentials
-    def link_account(self, username: str, config: dict, id: str = ""):
+    def link_account(self, username: str, config: dict, id: str = None):
+        if not id:
+            id = username
         resp = requests.post(f"{self.keychain.api}/account/{username}", json={'config': config, 'value': id},
                              headers=self.keychain.headers)
         if not resp.ok:


### PR DESCRIPTION
### Summary

Ensures that `value` is always set for integrations. This prevents the issue noted in https://github.com/praetorian-inc/chaos/pull/850. Also ensures that results from the integration are searchable.

### Type

Bug Fix
