### PR TITLE
Pull key from fn argument instead of from API response when deleting

### DIFF
--- a/praetorian_cli/handlers/delete.py
+++ b/praetorian_cli/handlers/delete.py
@@ -22,4 +22,4 @@ for item in delete_list:
             resp = controller.delete('asset/attribute', key)
         else:
             resp = controller.delete(item, key)
-        print(f"Key: {resp['key']} \nDeleted successfully")
+        print(f"Key: {key} \nDeleted successfully")


### PR DESCRIPTION
### Summary

Fixes the client-side error that occurs when trying to grab the key value from the DELETE response body. The response body is not a map, and does not contain a key entry. The value is instead pulled from the function argument.

### Type

Bug Fix
