### PR TITLE
Set default status option to first element

### DIFF
--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -39,7 +39,7 @@ def status_options(status_choices):
     def decorator(func):
         func = cli_handler(func)
         func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]), required=False,
-                            help="Status of the object")(func)
+                            default=list(status_choices)[0].value, help="Status of the object")(func)
         func = click.option('-comment', '--comment', default="", help="Add a comment")(func)
         return func
 


### PR DESCRIPTION
### Summary

Fixes an issue where `status` is required by the API; however, the CLI does not require it as an argument. The temporary solution is to set the first element as the default (in the case of the status, that would be `TRIAGE_INFO`)

### Type

Bug fix

### Context

[Internal Slack discussion](https://praetorianlabs.slack.com/archives/C06RDPMGZJS/p1718728890076189?thread_ts=1718728329.970239&cid=C06RDPMGZJS)