### PR TITLE
Added the ability to import script from any location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="https://github.com/praetorian-inc/chariot-ui/blob/main/public/icons/logo.png" alt="Praetorian Logo" width="200" height="200">
-
 # Praetorian CLI and SDK
 
 [![Python Version](https://img.shields.io/badge/Python-v3.8+-blue)](https://www.python.org/)
@@ -91,7 +89,7 @@ praetorian chariot get seed <SEED_KEY>
 To try one of our plugin scripts, run:
 
 ```zsh
-praetorian chariot get assets --script example
+praetorian chariot get assets --script hello-world
 ````
 
 See the [Contributing](#contributing) section for more information on how to add your own plugin scripts.
@@ -126,18 +124,20 @@ For more examples and API documentation, visit [our documentation](https://docs.
 The CLI has a plugin engine for you to extend the CLI without changing its internals. Your script
 is imported to the CLI context so it has full and authenticated access to the SDK.
 
-To write a script, clone this repository and install the CLI locally:
+To run a script, add the `--script` option after the CLI command, for example:
 
 ```zsh
-$ git clone git@github.com:praetorian-inc/praetorian-cli.git
-$ cd praetorian-cli
-$ pip install -e .
+$ praetorian chariot list seeds --script ~/code/my-process-seeds.py
 ```
 
-Place your scripts in the `praetorian-cli/scripts/` directory in the cloned repository. There are also example
-scripts in the directory.
+The CLI [ships with scripts](https://github.com/praetorian-inc/praetorian-cli/tree/main/praetorian_cli/scripts) for
+common tasks. For those, you only need the script name to invoke them:
 
-Your script needs to implement a `process` function that takes 4 arguments. They are:
+```zsh
+$ praetorian chariot get seed 'SEED_KEY' --script list-assets
+```
+
+To work with the plugin engine, the script needs to implement a `process` function that takes 4 arguments. They are:
    - `controller`: This object holds the authentication context and provide functions for accessing the
       Chariot backend API
    - `cmd`: This dictionary holds the information of which CLI command is executed. It tells you the product,
@@ -148,8 +148,7 @@ Your script needs to implement a `process` function that takes 4 arguments. They
    - `output`: This is the raw output of the CLI.
 
 Try out the [`hello-world`](https://github.com/praetorian-inc/praetorian-cli/blob/main/praetorian_cli/scripts/hello-world.py)
-script to have a concrete look at the content of those arguments, using the following command at the root directory
-of your cloned repository:
+script to have a concrete look at the content of those arguments, using the following command:
 
  ```zsh
 praetorian chariot list seeds --details --script hello-world
@@ -166,6 +165,7 @@ See this in action in the
 [`validate-secrets.py`](https://github.com/praetorian-inc/praetorian-cli/blob/main/praetorian_cli/scripts/validate-secrets.py)
 scripts.
 
+If you think your script will be useful for the offensive security community, contribute it!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For built in [scripts](https://github.com/praetorian-inc/praetorian-cli/tree/mai
 ```zsh
 $ praetorian chariot get seed 'SEED_KEY' --script list-assets
 
-To work with the plugin engine, the script needs to implement a `process` function that takes 4 arguments. They are:
+To work with the plugin engine, the script needs to implement a `process` function that takes 4 arguments:
    - `controller`: This object holds the authentication context and provide functions for accessing the
       Chariot backend API
    - `cmd`: This dictionary holds the information of which CLI command is executed. It tells you the product,

--- a/README.md
+++ b/README.md
@@ -130,12 +130,9 @@ To run a script, add the `--script` option after the CLI command, for example:
 $ praetorian chariot list seeds --script ~/code/my-process-seeds.py
 ```
 
-The CLI [ships with scripts](https://github.com/praetorian-inc/praetorian-cli/tree/main/praetorian_cli/scripts) for
-common tasks. For those, you only need the script name to invoke them:
-
+For built in [scripts](https://github.com/praetorian-inc/praetorian-cli/tree/main/praetorian_cli/scripts) you only need the script name:
 ```zsh
 $ praetorian chariot get seed 'SEED_KEY' --script list-assets
-```
 
 To work with the plugin engine, the script needs to implement a `process` function that takes 4 arguments. They are:
    - `controller`: This object holds the authentication context and provide functions for accessing the

--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ $ praetorian chariot list seeds --script ~/code/my-process-seeds.py
 ```
 
 For built in [scripts](https://github.com/praetorian-inc/praetorian-cli/tree/main/praetorian_cli/scripts) you only need the script name:
+
 ```zsh
 $ praetorian chariot get seed 'SEED_KEY' --script list-assets
+```
 
 To work with the plugin engine, the script needs to implement a `process` function that takes 4 arguments:
    - `controller`: This object holds the authentication context and provide functions for accessing the

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,6 +1,6 @@
 import importlib
 import sys
-import types
+from types import ModuleType
 from functools import wraps
 from inspect import signature
 from io import StringIO
@@ -112,7 +112,7 @@ def process_with_script(script_name, output, cli_kwargs):
 
 
 def load_raw_script(path):
-    module = types.ModuleType('cli-plugin-script')
+    module = ModuleType('cli-plugin-script')
     module.__file__ = path
     with open(path, 'r') as code_file:
         source = code_file.read()

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -86,16 +86,9 @@ def scripts(f):
 
 
 def process_with_script(script_name, output, cli_kwargs):
-    try:
-        # attempt to import it as a script that is shipped with the CLI package
-        script_module = importlib.import_module(f'.scripts.{script_name}', 'praetorian_cli')
-    except ImportError as e:
-        try:
-            # in this case, script_name is used as a full path, such as ~/code/my_script.py
-            script_module = load_raw_script(script_name)
-        except Exception as e:
-            click.echo(f'Error importing script {script_name}: {e}', err=True)
-            return
+    script_module = import_script(script_name)
+    if not script_module:
+        return
 
     if hasattr(script_module, 'process') and len(signature(script_module.__dict__['process']).parameters) == 4:
         ctx = click.get_current_context()
@@ -111,13 +104,23 @@ def process_with_script(script_name, output, cli_kwargs):
         click.echo(f"The script {script_name} does not have a 'process' function that takes 4 arguments.", err=True)
 
 
+def import_script(script_name):
+    # try importing from the praetorian_cli/scripts package
+    try:
+        return importlib.import_module(f'.scripts.{script_name}', 'praetorian_cli')
+    except ImportError:
+        # try importing from the current directory as a raw script
+        try:
+            return load_raw_script(script_name)
+        except Exception as e:
+            click.echo(f'Error importing script {script_name}: {e}', err=True)
+            return None
+
+
 def load_raw_script(path):
     module = ModuleType('cli-plugin-script')
     module.__file__ = path
     with open(path, 'r') as code_file:
-        source = code_file.read()
-
-    code = compile(source, path, 'exec')
-    exec(code, module.__dict__)
+        exec(compile(code_file.read(), path, 'exec'), module.__dict__)
     sys.modules['cli-plugin-script"'] = module
     return module

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import types
 from functools import wraps
 from inspect import signature
 from io import StringIO
@@ -86,18 +87,37 @@ def scripts(f):
 
 def process_with_script(script_name, output, cli_kwargs):
     try:
+        # attempt to import it as a script that is shipped with the CLI package
         script_module = importlib.import_module(f'.scripts.{script_name}', 'praetorian_cli')
-        if hasattr(script_module, 'process') and len(signature(script_module.__dict__['process']).parameters) == 4:
-            ctx = click.get_current_context()
-            controller = ctx.obj
-            if ctx.command.name == 'search':
-                cmd = dict(product=ctx.parent.command.name, action=ctx.command.name, type=None)
-            else:
-                cmd = dict(product=ctx.parent.parent.command.name, action=ctx.parent.command.name,
-                           type=ctx.command.name)
-
-            script_module.process(controller, cmd, cli_kwargs, output)
-        else:
-            click.echo(f"The script {script_name} does not have a 'process' function that takes 4 arguments.")
     except ImportError as e:
-        click.echo(f'Error importing script {script_name}: {e}')
+        try:
+            # in this case, script_name is used as a full path, such as ~/code/my_script.py
+            script_module = load_raw_script(script_name)
+        except Exception as e:
+            click.echo(f'Error importing script {script_name}: {e}')
+            return
+
+    if hasattr(script_module, 'process') and len(signature(script_module.__dict__['process']).parameters) == 4:
+        ctx = click.get_current_context()
+        controller = ctx.obj
+        if ctx.command.name == 'search':
+            cmd = dict(product=ctx.parent.command.name, action=ctx.command.name, type=None)
+        else:
+            cmd = dict(product=ctx.parent.parent.command.name, action=ctx.parent.command.name,
+                       type=ctx.command.name)
+
+        script_module.process(controller, cmd, cli_kwargs, output)
+    else:
+        click.echo(f"The script {script_name} does not have a 'process' function that takes 4 arguments.")
+
+
+def load_raw_script(path):
+    module = types.ModuleType('cli-plugin-script')
+    module.__file__ = path
+    with open(path, 'r') as code_file:
+        source = code_file.read()
+
+    code = compile(source, path, 'exec')
+    exec(code, module.__dict__)
+    sys.modules['cli-plugin-script"'] = module
+    return module

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -39,8 +39,8 @@ def list_options(filter_name):
 def status_options(status_choices):
     def decorator(func):
         func = cli_handler(func)
-        func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]), required=False,
-                            help="Status of the object")(func)
+        func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]),
+                            required=False, help="Status of the object")(func)
         func = click.option('-comment', '--comment', default="", help="Add a comment")(func)
         return func
 
@@ -63,7 +63,7 @@ def scripts(f):
             return f(*args, **kwargs)
 
         if 'page' in kwargs and kwargs['page'] == 'interactive':
-            print("Scripts can only be used with 'no' or 'all' pagination mode.")
+            click.echo("Scripts can only be used with 'no' or 'all' pagination mode.", err=True)
             exit(1)
 
         old_stdout = sys.stdout
@@ -94,7 +94,7 @@ def process_with_script(script_name, output, cli_kwargs):
             # in this case, script_name is used as a full path, such as ~/code/my_script.py
             script_module = load_raw_script(script_name)
         except Exception as e:
-            click.echo(f'Error importing script {script_name}: {e}')
+            click.echo(f'Error importing script {script_name}: {e}', err=True)
             return
 
     if hasattr(script_module, 'process') and len(signature(script_module.__dict__['process']).parameters) == 4:
@@ -108,7 +108,7 @@ def process_with_script(script_name, output, cli_kwargs):
 
         script_module.process(controller, cmd, cli_kwargs, output)
     else:
-        click.echo(f"The script {script_name} does not have a 'process' function that takes 4 arguments.")
+        click.echo(f"The script {script_name} does not have a 'process' function that takes 4 arguments.", err=True)
 
 
 def load_raw_script(path):


### PR DESCRIPTION
### Summary
Previously, we can only import scripts in the praetorian_cli/scripts location. This means if a user wants to use their own scripts, they will need to place the scripts where the installed package is. If they don't want to tinker with the central location where the praetorian-cli package is installed, they can do a local editable installation using `pip install -e .`. Both are somewhat clumsy and prone to get tripped up by Python environment.

What I want to support out of the box is that someone can simply put their script anywhere and the `--script` option should work as expected. This should lower the barrier to use scripts because they don't need to deal with the pip packaging system.

### HOW THIS WORK?
The logic is as follows:
- First attempt to import it from the `.scripts` module. This will work for the built-in scripts that are shipped with the CLI.
- Second attempt is to assume the argument provided after `--script` is a file path to a script. This script needs to be loaded "raw" using `compile()` and `exec()`.
- I also updated README.md since it is now simpler.