### PR TITLE
Fixed directory where the test py files are loaded from

### DIFF
--- a/praetorian_cli/handlers/test.py
+++ b/praetorian_cli/handlers/test.py
@@ -4,6 +4,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
+import praetorian_cli.sdk.test as test_module
 
 
 @chariot.command('test')
@@ -15,10 +16,11 @@ def trigger_all_tests(controller, key, suite):
     try:
         import pytest
     except ModuleNotFoundError:
-        print("Install pytest using 'pip install pytest' to run this command")
-    test_directory = os.path.relpath("praetorian_cli/sdk/test", os.getcwd())
+        click.echo("Install pytest using 'pip install pytest' to run this command", err=True)
+        return
+
     os.environ['CHARIOT_PROFILE'] = controller.keychain.profile
-    command = [test_directory]
+    command = [test_module.__path__[0]]
     if key:
         command.extend(['-k', key])
     if suite:


### PR DESCRIPTION
### Summary
Use the `__path__` property of the praetorian_cli.sdk.test module as root directory for running pytest. This method works for both PyPI and editable installations.

Issue: https://github.com/praetorian-inc/chariot-ui/issues/70

### Type
Bug fix

### Context
When the CLI is installed from PyPI, the tests won't run at all.