### PR TITLE
allow plugins to attach commands

### DIFF
--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -1,5 +1,7 @@
+import os
 import click
 
+from praetorian_cli.handlers.cli_decorators import load_raw_script
 from praetorian_cli.sdk.chariot import Chariot
 
 
@@ -8,3 +10,13 @@ from praetorian_cli.sdk.chariot import Chariot
 def chariot(ctx):
     """ Chariot API access in the new and different file """
     ctx.obj = Chariot(keychain=ctx.obj)
+
+
+def load_cli_scripts():
+    plugins = [load_raw_script(os.path.join('scripts/', filename))
+               for filename in os.listdir('scripts/') if filename.endswith('.py')]
+    for plugin in filter(lambda p: hasattr(p, 'register') and callable(p.register), plugins):
+        plugin.register(chariot)
+
+
+load_cli_scripts()

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -12,11 +12,15 @@ def chariot(ctx):
     ctx.obj = Chariot(keychain=ctx.obj)
 
 
+import importlib.util
+
+
 def load_cli_scripts():
-    plugins = [load_raw_script(os.path.join('scripts/', filename))
-               for filename in os.listdir('scripts/')+ os.listdir(os.path.expanduser('~/.praetorian/')) if filename.endswith('.py')]
+    module_dir = os.path.dirname(importlib.util.find_spec('praetorian_cli').origin)
+    scripts_dir = os.path.join(module_dir, 'scripts')
+    plugins = [load_raw_script(os.path.join(scripts_dir, filename))
+            for filename in os.listdir(scripts_dir) if filename.endswith('.py')]
     for plugin in filter(lambda p: hasattr(p, 'register') and callable(p.register), plugins):
         plugin.register(chariot)
-
 
 load_cli_scripts()

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -1,6 +1,7 @@
 import os
 import click
 
+import importlib.util
 from praetorian_cli.handlers.cli_decorators import load_raw_script
 from praetorian_cli.sdk.chariot import Chariot
 
@@ -12,15 +13,14 @@ def chariot(ctx):
     ctx.obj = Chariot(keychain=ctx.obj)
 
 
-import importlib.util
-
-
 def load_cli_scripts():
-    module_dir = os.path.dirname(importlib.util.find_spec('praetorian_cli').origin)
+    module_dir = os.path.dirname(
+        importlib.util.find_spec('praetorian_cli').origin)
     scripts_dir = os.path.join(module_dir, 'scripts')
     plugins = [load_raw_script(os.path.join(scripts_dir, filename))
-            for filename in os.listdir(scripts_dir) if filename.endswith('.py')]
+               for filename in os.listdir(scripts_dir) if filename.endswith('.py')]
     for plugin in filter(lambda p: hasattr(p, 'register') and callable(p.register), plugins):
         plugin.register(chariot)
+
 
 load_cli_scripts()

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -14,7 +14,7 @@ def chariot(ctx):
 
 def load_cli_scripts():
     plugins = [load_raw_script(os.path.join('scripts/', filename))
-               for filename in os.listdir('scripts/') if filename.endswith('.py')]
+               for filename in os.listdir('scripts/')+ os.listdir(os.path.expanduser('~/.praetorian/')) if filename.endswith('.py')]
     for plugin in filter(lambda p: hasattr(p, 'register') and callable(p.register), plugins):
         plugin.register(chariot)
 

--- a/praetorian_cli/scripts/hello.py
+++ b/praetorian_cli/scripts/hello.py
@@ -1,0 +1,13 @@
+import click
+
+
+@click.command()
+@click.pass_context
+@click.argument('name', type=str, required=True)
+def hello(ctx: click.Context, name: str):
+    """ This is a simple hello command """
+    click.echo(f'Hello {name}')
+
+
+def register(chariot: click.MultiCommand):
+    chariot.add_command(hello)

--- a/praetorian_cli/scripts/hello.py
+++ b/praetorian_cli/scripts/hello.py
@@ -1,7 +1,15 @@
 import click
 
+""" 
+For developers: 
+You can use this as a template for testing new commands/scripts.
+It is hidden from the help menu, but can still be called from the command line. 
+Usage : 
+    praetorian chariot hello <name>
+"""
 
-@click.command()
+
+@click.command(hidden=True)
 @click.pass_context
 @click.argument('name', type=str, required=True)
 def hello(ctx: click.Context, name: str):


### PR DESCRIPTION
### Summary

The current plugins mechanism doesn't fit all workflows .e.g https://github.com/praetorian-inc/praetorian-cli/pull/30. It would be useful to allow plugins to register their own commands. 

It would allow engineers to automate common workflows, and store them in the scripts dir, to make them available via a CLI as opposed to making them create their own CLI on top of the SDK.
