### PR TITLE
Limit statuses to triage for new risks; improve intuitiveness of the add and update commands

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -58,8 +58,8 @@ def webhook(controller):
 
 @add.command('risk')
 @click.argument('name', required=True)
-@click.option('-key', '--key', required=True, help='Key of an existing asset')
-@status_options(Status['risk'], 'risk')
+@click.option('-asset', '--asset', required=True, help='Key of an existing asset')
+@status_options(Status['add-risk'], 'risk')
 def risk(controller, name, key, status, comment):
     """ Add a risk """
     controller.add('risk', dict(key=key, name=name, status=status, comment=comment))
@@ -67,19 +67,19 @@ def risk(controller, name, key, status, comment):
 
 @add.command('job')
 @click.argument('capability', required=True)
-@click.option('-key', '--key', required=True, help='Key of an existing asset')
+@click.option('-asset', '--asset', required=True, help='Key of an existing asset')
 def job(controller, capability, key):
-    """ Add a job """
+    """ Add a job for an asset """
     controller.add('job', dict(key=key, name=capability))
 
 
 @add.command('attribute')
 @cli_handler
 @click.argument('name', required=True)
-@click.option('-key', '--key', required=True, help='Key of an existing asset')
+@click.option('-asset', '--asset', required=True, help='Key of an existing asset')
 @click.option('-class', '--class', 'clss', required=True, help='Class of the attribute')
 def attribute(controller, name, key, clss):
-    """ Add an attribute """
+    """ Add an attribute for an asset """
     params = {
         'key': key,
         'name': name,
@@ -90,10 +90,10 @@ def attribute(controller, name, key, clss):
 @add.command('reference')
 @cli_handler
 @click.argument('name', required=True)
-@click.option('-key', '--key', required=True, help='Key of an existing risk')
+@click.option('-risk', '--risk', required=True, help='Key of an existing risk')
 @click.option('-class', '--class', 'clss', required=True, help='Class of the reference')
 def reference(controller, name, key, clss):
-    """ Add a reference """
+    """ Add a reference for a risk """
     params = {
         'key': key,
         'name': name,

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -36,11 +36,11 @@ def list_options(filter_name):
     return decorator
 
 
-def status_options(status_choices, type='object'):
+def status_options(status_choices, item_type='object'):
     def decorator(func):
         func = cli_handler(func)
         func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]),
-                            required=False, help=f'Status of the {type}')(func)
+                            required=False, help=f'Status of the {item_type}')(func)
         func = click.option('-comment', '--comment', default="", help="Add a comment")(func)
         return func
 

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -12,14 +12,14 @@ def update(ctx):
     pass
 
 
-def create_update_command(item_type, status_choices):
-    @update.command(item_type, help=f"Update {item_type} using object key")
+def create_update_command(item_type):
+    @update.command(item_type, help=f'Update a {item_type}\n\nKEY is the key of the {item_type}')
     @click.argument('key', required=True)
-    @status_options(status_choices)
+    @status_options(Status[item_type], item_type)
     def command(controller, key, status, comment):
         controller.update(item_type, dict(key=key, status=status, comment=comment))
 
 
-create_update_command('asset', Status['asset'])
-create_update_command('risk', Status['risk'])
-create_update_command('job', Status['job'])
+create_update_command('asset')
+create_update_command('risk')
+create_update_command('job')

--- a/praetorian_cli/handlers/utils.py
+++ b/praetorian_cli/handlers/utils.py
@@ -47,7 +47,16 @@ class Risk(Enum):
     CLOSED_CRITICAL_REJECTED = "CCR"
 
 
-Status = {'asset': Asset, 'seed': Asset, 'job': Job, 'risk': Risk}
+class AddRisk(Enum):
+    """ AddRisk is a subset of Risk. These are the only valid statuses when creating manual risks """
+    TRIAGE_INFO = "TI"
+    TRIAGE_LOW = "TL"
+    TRIAGE_MEDIUM = "TM"
+    TRIAGE_HIGH = "TH"
+    TRIAGE_CRITICAL = "TC"
+
+
+Status = {'asset': Asset, 'seed': Asset, 'job': Job, 'risk': Risk, 'add-risk': AddRisk}
 
 key_set = {'assets': '#asset#', 'seeds': '#seed#', 'jobs': '#job#', 'risks': '#risk#', 'accounts': '#account#',
            'definitions': '#file#definitions/', 'integrations': '#account#', 'attributes': '#attribute#',


### PR DESCRIPTION
When risks are first created, they are always in the Triage state, regardless of what the state is supplied in the CLI. 

This change limits the valid statuses to only those in "T" in the CLI for the `add risk` command.

Also, included minor changes to the other add and update commands to improve usability.