### PR TITLE
remove the --seed option when adding asset

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -16,10 +16,9 @@ def add(ctx):
 @cli_handler
 @click.option('-name', '--name', required=True, help='The name of the asset, e.g, IP address, GitHub repo URL')
 @click.option('-dns', '--dns', required=True, help='The DNS of the asset')
-@click.option('-seed', '--seed', is_flag=True, default=False, help='Enumerate for other assets from this asset')
-def asset(controller, name, dns, seed):
+def asset(controller, name, dns):
     """ Add an asset """
-    controller.add('asset', dict(name=name, dns=dns, seed=seed))
+    controller.add('asset', dict(name=name, dns=dns))
 
 
 @add.command('file')


### PR DESCRIPTION
### Summary
Backend always treat new assets as seeds. So, removing this option.

