### PR TITLE
Tweaks to the `add risk` command

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -56,7 +56,7 @@ def webhook(controller):
 @click.option('-class', '--class', 'clss', default='weakness',
               type=click.Choice(['weakness', 'exposure', 'misconfiguration']),
               help='Class of the risk. Default is weakness')
-@status_options(Status['add-risk'], 'risk')
+@status_options(Status['add-risk'], 'risk', True)
 def risk(controller, name, asset, clss, status, comment):
     """ Add a risk """
     controller.add('risk', {'key': asset, 'name': name, 'status': status, 'comment': comment, 'class': clss})

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -54,9 +54,9 @@ def webhook(controller):
 @click.argument('name', required=True)
 @click.option('-asset', '--asset', required=True, help='Key of an existing asset')
 @status_options(Status['add-risk'], 'risk')
-def risk(controller, name, key, status, comment):
+def risk(controller, name, asset, status, comment):
     """ Add a risk """
-    controller.add('risk', dict(key=key, name=name, status=status, comment=comment))
+    controller.add('risk', dict(key=asset, name=name, status=status, comment=comment))
 
 
 @add.command('job')

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -53,10 +53,13 @@ def webhook(controller):
 @add.command('risk')
 @click.argument('name', required=True)
 @click.option('-asset', '--asset', required=True, help='Key of an existing asset')
+@click.option('-class', '--class', 'clss', default='weakness',
+              type=click.Choice(['weakness', 'exposure', 'misconfiguration']),
+              help='Class of the risk. Default is weakness')
 @status_options(Status['add-risk'], 'risk')
-def risk(controller, name, asset, status, comment):
+def risk(controller, name, asset, clss, status, comment):
     """ Add a risk """
-    controller.add('risk', dict(key=asset, name=name, status=status, comment=comment))
+    controller.add('risk', {'key': asset, 'name': name, 'status': status, 'comment': comment, 'class': clss})
 
 
 @add.command('job')

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -36,11 +36,11 @@ def list_options(filter_name):
     return decorator
 
 
-def status_options(status_choices, item_type='object'):
+def status_options(status_choices, item_type='object', required=False):
     def decorator(func):
         func = cli_handler(func)
         func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]),
-                            required=False, help=f'Status of the {item_type}')(func)
+                            required=required, help=f'Status of the {item_type}')(func)
         func = click.option('-comment', '--comment', default="", help="Add a comment")(func)
         return func
 


### PR DESCRIPTION
### Summary
- Fix a bug where the asset key had the wrong variable name.
- Added the class field to allow people to add non-weakness risks.
- Made the status field mandatory (picking up from where we left off with Marek's observation a couple of weeks ago)


