### PR TITLE
example usage of the package prerequisite decorator [DONT MERGE]

### DIFF
--- a/praetorian_cli/plugins/scripts/list_assets.py
+++ b/praetorian_cli/plugins/scripts/list_assets.py
@@ -11,9 +11,16 @@ Example usage:
 
 """
 import json
+from praetorian_cli.plugins.utils import requires_package
 
 
+@requires_package('numpy', '2.0.0')
 def process(controller, cmd, cli_kwargs, output):
+
+    from numpy.random import default_rng
+
+    print(f'Using numpy here: {default_rng().random()}')
+
     # Verify the upstream CLI command is compatible with the script
     if cmd['product'] != 'chariot' or cmd['action'] != 'get' or cmd['type'] != 'asset':
         print("This script works with the 'get asset' command only.")


### PR DESCRIPTION
This is only used as an example on how to use the @requires_package decorator.

- Don't import the package at beginning of your file. It will force an import when the file is loaded and will fail the entire CLI even if the user never wanted to execute the plugin that requires the package.
- Add @requires_package to the function(s) you want to use the package
- Specify the minimum version optionally.
- _Inside_ the function, import the package. This is key. The idea is that the import will only happen when this function is executed. Therefore, for users who aren't going to execute the plugin, they will not be affected.
