### PR TITLE
Fix asset key handling in add.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ By contributing, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Support
 
-If you have any questions or need support, please open an issue or reach out via
+If you have any questions or need support, please open an
+issue [here](https://github.com/praetorian-inc/chariot-ui/issues) or reach out via
 [support@praetorian.com](mailto:support@praetorian.com).
 
 ## License

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -63,11 +63,12 @@ def risk(controller, name, asset, clss, status, comment):
 
 
 @add.command('job')
+@cli_handler
 @click.argument('capability', required=True)
 @click.option('-asset', '--asset', required=True, help='Key of an existing asset')
-def job(controller, capability, key):
+def job(controller, capability, asset):
     """ Add a job for an asset """
-    controller.add('job', dict(key=key, name=capability))
+    controller.add('job', dict(key=asset, name=capability))
 
 
 @add.command('attribute')


### PR DESCRIPTION
### Summary
Fixes the `add job` command
### Type
[Bug Fix] 
[(minor) Documentation update]

### Context
While variable renaming, asset option was not passed to the function causing failures when running the command.
Also `@cli-handler` decorator was missing which prevented context passing. 

