### PR TITLE
Adjusted asset status as 'priority'

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -2,7 +2,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, status_options
-from praetorian_cli.handlers.utils import Status
+from praetorian_cli.handlers.utils import Status, AssetPriorities
 
 
 @chariot.group()
@@ -16,11 +16,13 @@ def add(ctx):
 @cli_handler
 @click.option('-name', '--name', required=True, help='The name of the asset, e.g, IP address, GitHub repo URL')
 @click.option('-dns', '--dns', required=False, help='The DNS of the asset')
-def asset(controller, name, dns):
+@click.option('-priority', '--priority', type=click.Choice(AssetPriorities.keys()),
+              default='standard', help='The priority of the asset. Default: standard')
+def asset(controller, name, dns, priority):
     """ Add an asset """
     if dns is None:
         dns = name
-    controller.add('asset', dict(name=name, dns=dns))
+    controller.add('asset', dict(name=name, dns=dns, status=AssetPriorities[priority]))
 
 
 @add.command('file')

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -1,8 +1,8 @@
 import click
 
 from praetorian_cli.handlers.chariot import chariot
-from praetorian_cli.handlers.cli_decorators import cli_handler, status_options
-from praetorian_cli.handlers.utils import Status, AssetPriorities
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import AssetPriorities, AddRisk
 
 
 @chariot.group()
@@ -13,11 +13,11 @@ def add(ctx):
 
 
 @add.command('asset')
-@cli_handler
 @click.option('-name', '--name', required=True, help='The name of the asset, e.g, IP address, GitHub repo URL')
 @click.option('-dns', '--dns', required=False, help='The DNS of the asset')
-@click.option('-priority', '--priority', type=click.Choice(AssetPriorities.keys()),
+@click.option('--priority', type=click.Choice(AssetPriorities.keys()),
               default='standard', help='The priority of the asset. Default: standard')
+@cli_handler
 def asset(controller, name, dns, priority):
     """ Add an asset """
     if dns is None:
@@ -58,10 +58,16 @@ def webhook(controller):
 @click.option('-class', '--class', 'clss', default='weakness',
               type=click.Choice(['weakness', 'exposure', 'misconfiguration']),
               help='Class of the risk. Default is weakness')
+@click.option('-status', '--status', type=click.Choice([s.value for s in AddRisk]), required=True,
+              help=f'Status of the risk')
 @click.option('-comment', '--comment', default='', help='Comment for the risk')
-@status_options(Status['add-risk'], 'risk', True)
+@cli_handler
 def risk(controller, name, asset, clss, status, comment):
-    """ Add a risk """
+    """
+    Add a risk
+
+    NAME is the name of the risk
+    """
     controller.add('risk', {'key': asset, 'name': name, 'status': status, 'comment': comment, 'class': clss})
 
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -36,16 +36,6 @@ def list_options(filter_name):
     return decorator
 
 
-def status_options(status_choices, item_type='object', required=False):
-    def decorator(func):
-        func = cli_handler(func)
-        func = click.option('-status', '--status', type=click.Choice([s.value for s in status_choices]),
-                            required=required, help=f'Status of the {item_type}')(func)
-        return func
-
-    return decorator
-
-
 def page_options(func):
     func = click.option('-offset', '--offset', default='', help='List results from an offset')(func)
     func = click.option('-page', '--page', type=click.Choice(('no', 'interactive', 'all')), default='no',

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -2,7 +2,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, status_options
-from praetorian_cli.handlers.utils import Status
+from praetorian_cli.handlers.utils import Status, AssetPriorities
 
 
 @chariot.group()
@@ -14,9 +14,11 @@ def update(ctx):
 
 @update.command('asset', help='Update an asset\n\nKEY is the key of the asset')
 @click.argument('key', required=True)
-@status_options(Status['asset'], 'asset')
-def asset(controller, key, status):
-    controller.update('asset', dict(key=key, status=status))
+@click.option('-priority', '--priority', type=click.Choice(AssetPriorities.keys()),
+              required=True, help='The priority of the asset')
+@cli_handler
+def update_asset_command(controller, key, priority):
+    controller.update('asset', dict(key=key, status=AssetPriorities[priority]))
 
 
 @update.command('risk', help='Update a risk\n\nKEY is the key of the risk')

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -1,8 +1,8 @@
 import click
 
 from praetorian_cli.handlers.chariot import chariot
-from praetorian_cli.handlers.cli_decorators import cli_handler, status_options
-from praetorian_cli.handlers.utils import Status, AssetPriorities
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import AssetPriorities, Risk
 
 
 @chariot.group()
@@ -12,18 +12,28 @@ def update(ctx):
     pass
 
 
-@update.command('asset', help='Update an asset\n\nKEY is the key of the asset')
+@update.command('asset')
 @click.argument('key', required=True)
-@click.option('-p', '--priority', type=click.Choice(AssetPriorities.keys()),
-              required=True, help='The priority of the asset')
+@click.option('--priority', type=click.Choice(AssetPriorities.keys()), required=True, help='The priority of the asset')
 @cli_handler
-def update_asset_command(controller, key, priority):
+def asset(controller, key, priority):
+    """
+    Update an asset
+
+    KEY is the key of the asset
+    """
     controller.update('asset', dict(key=key, status=AssetPriorities[priority]))
 
 
-@update.command('risk', help='Update a risk\n\nKEY is the key of the risk')
+@update.command('risk')
 @click.argument('key', required=True)
-@status_options(Status['risk'], 'risk')
+@click.option('-status', '--status', type=click.Choice([s.value for s in Risk]), help=f'Status of the risk')
 @click.option('-comment', '--comment', default='', help='Comment for the risk')
+@cli_handler
 def risk(controller, key, status, comment):
+    """
+    Update a risk
+
+    KEY is the key of the risk
+    """
     controller.update('risk', dict(key=key, status=status, comment=comment))

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -14,7 +14,7 @@ def update(ctx):
 
 @update.command('asset', help='Update an asset\n\nKEY is the key of the asset')
 @click.argument('key', required=True)
-@click.option('-priority', '--priority', type=click.Choice(AssetPriorities.keys()),
+@click.option('-p', '--priority', type=click.Choice(AssetPriorities.keys()),
               required=True, help='The priority of the asset')
 @cli_handler
 def update_asset_command(controller, key, priority):

--- a/praetorian_cli/handlers/utils.py
+++ b/praetorian_cli/handlers/utils.py
@@ -7,9 +7,8 @@ import click
 class Asset(Enum):
     ACTIVE = "A"
     ACTIVE_HIGH = "AH"
+    ACTIVE_LOW = "AL"
     FROZEN = "F"
-    FROZEN_HIGH = "FH"
-    UNKNOWN = "U"
 
 
 class Risk(Enum):
@@ -54,6 +53,9 @@ Status = {'asset': Asset, 'risk': Risk, 'add-risk': AddRisk}
 key_set = {'assets': '#asset#', 'jobs': '#job#', 'risks': '#risk#', 'accounts': '#account#',
            'definitions': '#file#definitions/', 'integrations': '#account#', 'attributes': '#attribute#',
            'files': '#file#'}
+
+AssetPriorities = {'comprehensive': Asset.ACTIVE_HIGH.value, 'standard': Asset.ACTIVE.value,
+                   'discovery-only': Asset.ACTIVE_LOW.value, 'frozen': Asset.FROZEN.value}
 
 
 def my_result(controller, key, filter="", offset="", pages=1):

--- a/praetorian_cli/handlers/utils.py
+++ b/praetorian_cli/handlers/utils.py
@@ -55,7 +55,7 @@ key_set = {'assets': '#asset#', 'jobs': '#job#', 'risks': '#risk#', 'accounts': 
            'files': '#file#'}
 
 AssetPriorities = {'comprehensive': Asset.ACTIVE_HIGH.value, 'standard': Asset.ACTIVE.value,
-                   'discovery-only': Asset.ACTIVE_LOW.value, 'frozen': Asset.FROZEN.value}
+                   'discover': Asset.ACTIVE_LOW.value, 'frozen': Asset.FROZEN.value}
 
 
 def my_result(controller, key, filter="", offset="", pages=1):


### PR DESCRIPTION
### Summary
The status field of assets has morphed to mostly mean the scan priority. This is to map the wording of the CLI parameter closer to the update in the UI that went in on 7/10. It will be a breaking change for people who use the `update asset` command.

### Type
Breaking change.