### PR TITLE
Updated the 'add attribute' command to use name/value pair

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -94,9 +94,9 @@ def job(controller, capability, asset):
 
 @add.command('attribute')
 @cli_handler
-@click.option('-key', '--key', required=True, help='Key of an existing asset or risk')
-@click.option('-name', '--name', required=True, help='Name of the attribute')
-@click.option('-value', '--value', required=True, help='Value of the attribute')
+@click.option('-k', '--key', required=True, help='Key of an existing asset or risk')
+@click.option('-n', '--name', required=True, help='Name of the attribute')
+@click.option('-v', '--value', required=True, help='Value of the attribute')
 def attribute(controller, key, name, value):
     """ Add an attribute for an asset or risk"""
     params = {

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -94,12 +94,14 @@ def job(controller, capability, asset):
 
 @add.command('attribute')
 @cli_handler
-@click.argument('name', required=True)
 @click.option('-key', '--key', required=True, help='Key of an existing asset or risk')
-def attribute(controller, name, key):
+@click.option('-name', '--name', required=True, help='Name of the attribute')
+@click.option('-value', '--value', required=True, help='Value of the attribute')
+def attribute(controller, key, name, value):
     """ Add an attribute for an asset or risk"""
     params = {
         'key': key,
         'name': name,
+        'value': value
     }
     print(controller.add('attribute', params))


### PR DESCRIPTION
### Summary
The schema of attribute changed from class/name pair to name/value pair as of 7/15. Updating the `add attribute` command to match that.