### PR TITLE
Add capability to list attributes by asset or risk

### DIFF
--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -28,8 +28,8 @@ def cli_handler(func):
 def list_options(filter_name):
     def decorator(func):
         func = cli_handler(func)
-        func = click.option('-filter', '--filter', default="", help=f"Filter by {filter_name}")(func)
-        func = click.option('-details', '--details', is_flag=True, default=False, help="Show detailed information")(
+        func = click.option('-f', '--filter', default="", help=f"Filter by {filter_name}")(func)
+        func = click.option('-d', '--details', is_flag=True, default=False, help="Show detailed information")(
             func)
         return func
 
@@ -37,8 +37,8 @@ def list_options(filter_name):
 
 
 def page_options(func):
-    func = click.option('-offset', '--offset', default='', help='List results from an offset')(func)
-    func = click.option('-page', '--page', type=click.Choice(('no', 'interactive', 'all')), default='no',
+    func = click.option('-o', '--offset', default='', help='List results from an offset')(func)
+    func = click.option('-p', '--page', type=click.Choice(('no', 'interactive', 'all')), default='no',
                         help="Pagination mode. 'all' pages up to 100 pages. Default: 'no'")(func)
 
     return func

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -16,8 +16,7 @@ def list(ctx):
     pass
 
 
-list_filter = {'jobs': 'updated', 'files': 'name', 'accounts': 'name', 'integrations': 'name', 'definitions': 'name',
-               'attributes': 'name'}
+list_filter = {'jobs': 'updated', 'files': 'name', 'accounts': 'name', 'integrations': 'name', 'definitions': 'name'}
 
 
 def attribute_filter(controller, key, offset, details, page):
@@ -57,6 +56,22 @@ def risks(controller, filter, offset, details, page, attr):
         return
 
     paginate(controller, f'#risk#{filter}', 'risks', "", offset, details, page)
+
+
+@list.command('attributes')
+@list_options('name')
+@page_options
+@click.option('-a', '--asset', help='Filter by asset key')
+@click.option('-r', '--risk', help='Filter by risk key')
+def attributes(controller, filter, offset, details, page, asset, risk):
+    """List attributes\n
+    You can only filter by one of the following : attribute name, asset or risk"""
+    key = f'#attribute#{filter}'
+    if asset:
+        key = f'source:{asset}'
+    elif risk:
+        key = f'source:{risk}'
+    paginate(controller, key, 'attributes', "", offset, details, page)
 
 
 def create_list_command(item_type, item_filter):


### PR DESCRIPTION
### Summary

List attributes by name, asset, or risk
### Type

New Feature
### Context

With attributes having a generic key string, a normal list attributes will end up with more than required entries, added an option to list attributes of a specific asset or risk for usability. 