### PR TITLE
Updated CLI to match the removal of DELETE /asset in the backend

### DIFF
--- a/praetorian_cli/handlers/delete.py
+++ b/praetorian_cli/handlers/delete.py
@@ -11,6 +11,18 @@ def delete(ctx):
     pass
 
 
+@delete.command('asset')
+@click.argument('key', required=True)
+@cli_handler
+def delete_asset(controller, key):
+    """
+    Delete asset
+
+    KEY is the key of an existing asset
+    """
+    controller.update('asset', dict(key=key, status='D'))
+
+
 def delete_command(item):
     @delete.command(item, help=f"Delete {item}")
     @click.argument('key', required=True)
@@ -20,7 +32,7 @@ def delete_command(item):
         print(f"Key: {key} \nDeleted successfully")
 
 
-for item in ['asset', 'attribute', 'file']:
+for item in ['attribute', 'file']:
     delete_command(item)
 
 

--- a/praetorian_cli/handlers/utils.py
+++ b/praetorian_cli/handlers/utils.py
@@ -9,6 +9,7 @@ class Asset(Enum):
     ACTIVE_HIGH = "AH"
     ACTIVE_LOW = "AL"
     FROZEN = "F"
+    DELETED = "D"
 
 
 class Risk(Enum):

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -42,6 +42,6 @@ class TestAsset(BaseTest):
         assert response['status'] == Asset.FROZEN.value, "Response does not have correct status"
 
     def test_delete_asset(self):
-        self.chariot.delete('asset', key=f'#asset#{self.asset}')
+        self.chariot.update('asset', dict(key=f'#asset#{self.asset}', status='D'))
         response = self.chariot.my(dict(key=f'#asset#{self.asset}'))
-        assert response == {}
+        assert response['assets'][0]['status'] == 'D'


### PR DESCRIPTION
### Summary
We have changed to soft-delete in the backend for assets by setting the status. I will want to preserve the `delete asset` command, which reads the most natural to the end users of the CLI. The underlying implementation is updated to change the status, instead of calling DELETE /asset