### PR TITLE
Add configure command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,12 @@ Install the Python package using this command:
 pip install praetorian-cli
 ```
 
-## Signing up
+## Signing up and configuration
 
 1. Register for an account for [Chariot](http://preview.chariot.praetorian.com) using the instructions
    in [our documentation](https://docs.praetorian.com/hc/en-us/articles/25784233986587-Account-Setup-and-Initial-Seeding).
-2. Download the keychain file using [this link](https://preview.chariot.praetorian.com/keychain.ini).
-3. Place the keychain file at ``~/.praetorian/keychain.ini``.
-4. Add your username and password to the keychain file. Your file should read like this:
+2. Run `praetorian configure` and follow the prompts.
+3. It generates `~/.praetorian/keychain.ini` that reads similarly as follows:
 
 ```
 [United States]
@@ -66,31 +65,9 @@ username = lara.lynch@acme.com
 password = 8epu9bQ2kqb8qwd.GR
 ```
 
-### Authentication in organizations that use SSO
+For more advanced configuration options, as well as authentication in organizations that use SSO. See [the documentation on
+the keychain file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/plugin-development.md).
 
-SSO-enabled accounts can use CLI by inviting password-based accounts as collaborators.
-These collaborator accounts can assume into the main account using the `--account` option
-in the CLI, or including that information in the keychain file. For example, you can assume
-into the `security.team@acme.com` main account using the **account** entry:
-```
-[United States]
-name = chariot
-client_id = 795dnnr45so7m17cppta0b295o
-api = https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot
-username = lara.lynch@acme.com
-password = 8epu9bQ2kqb8qwd.GR
-account = security.team@acme.com
-```
-
-There are two common approaches to manage CLI access in SSO organizations:
-
-1. Sign up a service account for CLI access, e.g. security.team+cli@acme.com. In the master
-   account, invite security-team+cli@acme.com as a collaborator. All CLI users share the
-   keychain for the service account.
-3. Add each CLI user as a collaborator in the master account. Every CLI user signs up using
-   password-based authentication.
-
-We recommend the first approach.
 
 ## Using the CLI
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ password = 8epu9bQ2kqb8qwd.GR
 ```
 
 For more advanced configuration options, as well as SSO. See [the documentation on
-the keychain file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/plugin-development.md).
+the keychain file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/configure.md).
 
 
 ## Using the CLI

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install praetorian-cli
 1. Register for an account for [Chariot](http://preview.chariot.praetorian.com) using the instructions
    in [our documentation](https://docs.praetorian.com/hc/en-us/articles/25784233986587-Account-Setup-and-Initial-Seeding).
 2. Run `praetorian configure` and follow the prompts.
-3. It generates `~/.praetorian/keychain.ini` that reads similarly as follows:
+3. It creates `~/.praetorian/keychain.ini`, which should read like this:
 
 ```
 [United States]
@@ -65,7 +65,7 @@ username = lara.lynch@acme.com
 password = 8epu9bQ2kqb8qwd.GR
 ```
 
-For more advanced configuration options, as well as authentication in organizations that use SSO. See [the documentation on
+For more advanced configuration options, as well as SSO. See [the documentation on
 the keychain file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/plugin-development.md).
 
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -7,12 +7,12 @@ The `configure` command asks questions as follows:
 ```
 $ praetorian configure
 Enter your Praetorian credentials to store in the keychain
-Enter username/email: lara.lynch@acme.com
-Enter password:
-Enter profile name [United States]:
-Enter URL of backend API [https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot]:
-Enter client ID [795dnnr45so7m17cppta0b295o]:
-Enter assume-role account, if any []:
+Enter your email: lara.lynch@acme.com
+Enter your password:
+Enter the profile name [United States]:
+Enter the URL of backend API [https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot]:
+Enter the client ID [795dnnr45so7m17cppta0b295o]:
+Enter the assume-role account, if any []:
 ```
 
 They have the following meanings:

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,6 +1,6 @@
-# Deep dive into `praetorian configure` and the keychain file
+# How to configure the keychain file
 
-This page shows the advanced functions of the `configure` command. It is used to set
+This page illustrates the advanced functions of the `configure` command. It is used to set
 user credentials and update the keychain file located at `~/.praetorian/keychain.ini`.
 The `configure` command asks questions as follows:
 
@@ -15,25 +15,20 @@ Enter client ID [795dnnr45so7m17cppta0b295o]:
 Enter assume-role account, if any []:
 ```
 
-- **Username/email**: this is the email address you used to sign up for Chariot
-- **Password**: Your password
-- **profile name**: This is the name of a profile section in the keychain file. It is
+They have the following meanings:
+
+- **Email**: this is the email address you used to sign up.
+- **Password**: Your password.
+- **profile name**: The name of a profile section in the keychain file. It is
   useful when you have multiple accounts, or different assume-role settings (see below).
 - **URL of backend API**: The URL of the backend. In most cases, use the default value.
 - **Client ID**: The client ID of the backend. In most cases, use the default value.
-- **Assume-role account**: This is used 
-
+- **Assume-role account**: This is used for assuming role into your organization's main
+  account. This is the same as the `--account` option.
 
 Similar to the pattern used in AWS CLI configuration, the keychain file is 
-organized into sections of profiles in square brackets. Use 
-
-
-
-
-
-
-It is especially useful for organizations that use
-SSO for their UI authentication.
+organized into sections of profiles (names in square brackets). You can use this to configure
+multiple access credentials into a single keychain file.
 
 
 ## Authentication in organizations that use SSO
@@ -66,6 +61,3 @@ There are two common approaches to manage CLI access in SSO organizations:
    password-based authentication.
 
 We recommend the first approach.
-
-
-## Multiple profiles

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -19,7 +19,7 @@ They have the following meanings:
 
 - **Email**: this is the email address you used to sign up.
 - **Password**: Your password.
-- **profile name**: The name of a profile section in the keychain file. It is
+- **Profile name**: The name of a profile section in the keychain file. It is
   useful when you have multiple accounts, or different assume-role settings (see below).
 - **URL of backend API**: The URL of the backend. In most cases, use the default value.
 - **Client ID**: The client ID of the backend. In most cases, use the default value.

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,0 +1,71 @@
+# Deep dive into `praetorian configure` and the keychain file
+
+This page shows the advanced functions of the `configure` command. It is used to set
+user credentials and update the keychain file located at `~/.praetorian/keychain.ini`.
+The `configure` command asks questions as follows:
+
+```
+$ praetorian configure
+Enter your Praetorian credentials to store in the keychain
+Enter username/email: lara.lynch@acme.com
+Enter password:
+Enter profile name [United States]:
+Enter URL of backend API [https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot]:
+Enter client ID [795dnnr45so7m17cppta0b295o]:
+Enter assume-role account, if any []:
+```
+
+- **Username/email**: this is the email address you used to sign up for Chariot
+- **Password**: Your password
+- **profile name**: This is the name of a profile section in the keychain file. It is
+  useful when you have multiple accounts, or different assume-role settings (see below).
+- **URL of backend API**: The URL of the backend. In most cases, use the default value.
+- **Client ID**: The client ID of the backend. In most cases, use the default value.
+- **Assume-role account**: This is used 
+
+
+Similar to the pattern used in AWS CLI configuration, the keychain file is 
+organized into sections of profiles in square brackets. Use 
+
+
+
+
+
+
+It is especially useful for organizations that use
+SSO for their UI authentication.
+
+
+## Authentication in organizations that use SSO
+
+SSO-enabled accounts can use CLI by inviting password-based accounts as collaborators.
+These collaborator accounts can assume into the main account using the `--account` option
+in the CLI with the value of the email address of the main account.
+
+You can also set this in a profile in the keychain file. Run `praetorian configure` and
+answer the prompt `Enter assume-role account` with the email address of the main account.
+
+Your keychain file will then read like this:
+
+```
+[United States]
+name = chariot
+client_id = 795dnnr45so7m17cppta0b295o
+api = https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot
+username = lara.lynch@acme.com
+password = 8epu9bQ2kqb8qwd.GR
+account = security.team@acme.com
+```
+
+There are two common approaches to manage CLI access in SSO organizations:
+
+1. Sign up a service account for CLI access, e.g. security.team+cli@acme.com. In the master
+   account, invite security-team+cli@acme.com as a collaborator. All CLI users share the
+   keychain for the service account.
+3. Add each CLI user as a collaborator in the master account. Every CLI user signs up using
+   password-based authentication.
+
+We recommend the first approach.
+
+
+## Multiple profiles

--- a/praetorian_cli/cli.py
+++ b/praetorian_cli/cli.py
@@ -30,7 +30,7 @@ def cli(ctx, profile, account):
 def configure(ctx):
     """ Configure the CLI """
     click.echo('Enter your Praetorian credentials to store in the keychain')
-    ctx.obj.write_credentials()
+    ctx.obj.configure()
 
 
 cli.add_command(chariot)

--- a/praetorian_cli/cli.py
+++ b/praetorian_cli/cli.py
@@ -5,11 +5,11 @@ import praetorian_cli.handlers.delete  # noqa
 import praetorian_cli.handlers.get  # noqa
 import praetorian_cli.handlers.link  # noqa
 import praetorian_cli.handlers.list  # noqa
+import praetorian_cli.handlers.plugin  # noqa
 import praetorian_cli.handlers.search  # noqa
 import praetorian_cli.handlers.test  # noqa
 import praetorian_cli.handlers.unlink  # noqa
 import praetorian_cli.handlers.update  # noqa
-import praetorian_cli.handlers.plugin  # noqa
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.sdk.keychain import Keychain
 
@@ -23,6 +23,14 @@ def cli(ctx, profile, account):
     ctx.obj = Keychain(profile=profile, account=account)
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+@cli.command('configure')
+@click.pass_context
+def configure(ctx):
+    """ Configure the CLI """
+    click.echo('Enter your Praetorian credentials to store in the keychain')
+    ctx.obj.write_credentials()
 
 
 cli.add_command(chariot)

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -6,5 +6,5 @@ from praetorian_cli.sdk.chariot import Chariot
 @click.group()
 @click.pass_context
 def chariot(ctx):
-    """ Chariot API access in the new and different file """
+    """ Command group for interacting with the Chariot product """
     ctx.obj = Chariot(keychain=ctx.obj)

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -67,12 +67,12 @@ class Keychain:
         return cfg
 
     def configure(self):
-        username = click.prompt('Enter username')
-        password = click.prompt("Enter password", hide_input=True)
-        profile = click.prompt('Enter profile name', default=DEFAULT_PROFILE)
-        api = click.prompt('Enter URL of backend API', default=DEFAULT_API)
-        client_id = click.prompt('Enter client ID', default=DEFAULT_CLIENT_ID)
-        account = click.prompt('Enter assume-role account, if any', default='')
+        username = click.prompt('Enter your email')
+        password = click.prompt("Enter your password", hide_input=True)
+        profile = click.prompt('Enter the profile name', default=DEFAULT_PROFILE)
+        api = click.prompt('Enter the URL of backend API', default=DEFAULT_API)
+        client_id = click.prompt('Enter the client ID', default=DEFAULT_CLIENT_ID)
+        account = click.prompt('Enter the assume-role account, if any', default='')
 
         cfg = configparser.ConfigParser()
         cfg[profile] = {

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -1,12 +1,15 @@
 import configparser
-import getpass
 import os
 import time
 from functools import wraps
-from os.path import exists
 from pathlib import Path
 
 import boto3
+import click
+
+DEFAULT_API = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
+DEFAULT_CLIENT_ID = '795dnnr45so7m17cppta0b295o'
+DEFAULT_PROFILE = "United States"
 
 
 def verify_credentials(func):
@@ -15,16 +18,7 @@ def verify_credentials(func):
         try:
             keychain = args[0].keychain
             keychain.set_config()
-
-            if not (keychain.username and keychain.password):
-                new_credentials = keychain.write_credentials()
-                keychain.username = new_credentials['username']
-                keychain.password = new_credentials['password']
-
-            keychain.set_headers()
-            if keychain.account:
-                keychain.headers['account'] = keychain.account
-
+            keychain.set_headers(keychain.account)
             return func(*args, **kwargs)
 
         except KeyError as e:
@@ -38,7 +32,7 @@ def verify_credentials(func):
 
 class Keychain:
 
-    def __init__(self, profile='United States', account=None, data=None,
+    def __init__(self, profile=DEFAULT_PROFILE, account=None, data=None,
                  location=os.path.join(Path.home(), '.praetorian', 'keychain.ini')):
         self.profile = profile
         self.account = account
@@ -46,19 +40,21 @@ class Keychain:
         self.data = data
         self.token_cache = None
         self.token_expiry = 0
-        self.api = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
-        self.client_id = '795dnnr45so7m17cppta0b295o'
 
     def set_config(self):
         cfg = self.get()
         if not cfg.sections():
-            exit('Keychain is empty. Run "praetorian configure" to add credentials.')
-        self.username = cfg[self.profile]['username']
-        self.password = cfg[self.profile]['password']
-        self.api = cfg[self.profile]['api']
-        self.client_id = cfg[self.profile]['client_id']
-        if self.account is None:
-            self.account = cfg.get(self.profile, 'account', fallback=None)
+            exit('Keychain file is empty. Run "praetorian configure" to configure your profile and credentials.')
+        try:
+            self.username = cfg[self.profile]['username']
+            self.password = cfg[self.profile]['password']
+            self.api = cfg[self.profile]['api']
+            self.client_id = cfg[self.profile]['client_id']
+            if self.account is None:
+                self.account = cfg.get(self.profile, 'account', fallback=None)
+        except Exception as e:
+            exit(
+                f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
 
     def get(self):
         cfg = configparser.ConfigParser()
@@ -70,37 +66,39 @@ class Keychain:
 
         return cfg
 
-    def write_credentials(self):
-        username = input("Enter username: ")
-        password = getpass.getpass("Enter password: ")
-        if not exists(self.location):
-            head, _ = os.path.split(Path(self.location))
-            Path(head).mkdir(parents=True, exist_ok=True)
-            with open(self.location, 'w') as f:
-                f.write(f'[{self.profile}]\n')
-                f.write(f'name = chariot\n')
-                f.write(f'client_id = {self.client_id}\n')
-                f.write(f'api = {self.api}\n')
-            f.close()
+    def configure(self):
+        username = click.prompt('Enter username')
+        password = click.prompt("Enter password", hide_input=True)
+        profile = click.prompt('Enter profile name', default=DEFAULT_PROFILE)
+        api = click.prompt('Enter URL of backend API', default=DEFAULT_API)
+        client_id = click.prompt('Enter client ID', default=DEFAULT_CLIENT_ID)
+        account = click.prompt('Enter assume-role account, if any', default='')
 
         cfg = configparser.ConfigParser()
-        cfg[self.profile] = {
+        cfg[profile] = {
+            'name': 'chariot',
+            'client_id': client_id,
+            'api': api,
             'username': username,
             'password': password
         }
+        if account:
+            cfg[profile]['account'] = account
         combo = self._merge_configs(cfg, self.get())
+
+        Path(os.path.split(Path(self.location))[0]).mkdir(parents=True, exist_ok=True)
         with open(self.location, 'w') as f:
             combo.write(f)
-        return {
-            'username': username,
-            'password': password
-        }
 
-    def set_headers(self):
+        click.echo(f'\nKeychain data written to {self.location}')
+
+    def set_headers(self, account=None):
         self.headers = {
             'Authorization': f'Bearer {self.token()}',
             'Content-Type': 'application/json'
         }
+        if account:
+            self.headers['account'] = account
 
     def token(self):
         if not self.token_cache or time.time() >= self.token_expiry:

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -1,4 +1,5 @@
 import configparser
+import getpass
 import os
 import time
 from functools import wraps
@@ -45,10 +46,13 @@ class Keychain:
         self.data = data
         self.token_cache = None
         self.token_expiry = 0
-        self.set_config()
+        self.api = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
+        self.client_id = '795dnnr45so7m17cppta0b295o'
 
     def set_config(self):
         cfg = self.get()
+        if not cfg.sections():
+            exit('Keychain is empty. Run "praetorian configure" to add credentials.')
         self.username = cfg[self.profile]['username']
         self.password = cfg[self.profile]['password']
         self.api = cfg[self.profile]['api']
@@ -64,20 +68,20 @@ class Keychain:
         else:
             cfg.read(self.location)
 
-        if not cfg.sections():
-            exit(
-                '[!] Follow instructions at at https://docs.praetorian.com/hc/en-us/articles/25815154096667-The'
-                '-Praetorian-CLI to obtain a keychain.')
         return cfg
 
     def write_credentials(self):
         username = input("Enter username: ")
-        password = input("Enter password: ")
-
+        password = getpass.getpass("Enter password: ")
         if not exists(self.location):
             head, _ = os.path.split(Path(self.location))
             Path(head).mkdir(parents=True, exist_ok=True)
-            open(self.location, 'x').close()
+            with open(self.location, 'w') as f:
+                f.write(f'[{self.profile}]\n')
+                f.write(f'name = chariot\n')
+                f.write(f'client_id = {self.client_id}\n')
+                f.write(f'api = {self.api}\n')
+            f.close()
 
         cfg = configparser.ConfigParser()
         cfg[self.profile] = {


### PR DESCRIPTION
### Summary
Add a configure command allowing users to create keychain files using their username and password
### Type
[New Feature]
### Context
Allows users to easily create a keychain file to be used for interacting with the CLI

Usage `praetorian configure`

