### PR TITLE
Added user_pool_id for the 'configure' command

### DIFF
--- a/praetorian_cli/handlers/configure.py
+++ b/praetorian_cli/handlers/configure.py
@@ -1,22 +1,24 @@
 import click
 
-from praetorian_cli.sdk.keychain import DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_PROFILE
+from praetorian_cli.sdk.keychain import DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_PROFILE, DEFAULT_USER_POOL_ID
 
 
 @click.command('configure')
-@click.option('--email', required=True, help='Email you used to register for Chariot',
+@click.option('--email', help='Email you used to register for Chariot', required=True,
               prompt='Enter your email')
-@click.option('--password', required=True, help='Password you used to register for Chariot', hide_input=True,
-              prompt='Enter your password')
-@click.option('--profile-name', required=True, help='Profile name. Default provided.', default=DEFAULT_PROFILE,
-              prompt='Enter the profile name')
-@click.option('--url', required=True, help='URL to the backend API. Default provided.', default=DEFAULT_API,
-              prompt='Enter the URL of backend API')
-@click.option('--client-id', required=True, help='Client ID of the backend. Default provided.',
-              default=DEFAULT_CLIENT_ID, prompt='Enter the client ID')
-@click.option('--assume-role', help='Email address of the account to assume-role into', default='',
-              prompt='Enter the assume-role account, if any')
+@click.option('--password', help='Password you used to register for Chariot', required=True,
+              prompt='Enter your password', hide_input=True)
+@click.option('--profile-name', help='Profile name. Default provided.', required=True,
+              prompt='Enter the profile name', default=DEFAULT_PROFILE)
+@click.option('--url', help='URL to the backend API. Default provided.', required=True,
+              prompt='Enter the URL of backend API', default=DEFAULT_API)
+@click.option('--client-id', help='Client ID of the backend. Default provided.', required=True,
+              prompt='Enter the client ID', default=DEFAULT_CLIENT_ID)
+@click.option('--user-pool-id', help='User pool ID of the backend. Default provided.', required=True,
+              prompt='Enter the user pool ID', default=DEFAULT_USER_POOL_ID)
+@click.option('--assume-role', help='Email address of the account to assume-role into', required=True,
+              prompt='Enter the assume-role account, if any', default='')
 @click.pass_context
-def configure(ctx, email, password, profile_name, url, client_id, assume_role):
+def configure(ctx, email, password, profile_name, url, client_id, user_pool_id, assume_role):
     """ Configure the CLI """
-    ctx.obj.configure(email, password, profile_name, url, client_id, assume_role)
+    ctx.obj.configure(email, password, profile_name, url, client_id, user_pool_id, assume_role)

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -9,7 +9,8 @@ import click
 
 DEFAULT_API = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
 DEFAULT_CLIENT_ID = '795dnnr45so7m17cppta0b295o'
-DEFAULT_PROFILE = "United States"
+DEFAULT_PROFILE = 'United States'
+DEFAULT_USER_POOL_ID = 'us-east-2_BJ6QHVG2L'
 
 
 def verify_credentials(func):
@@ -67,12 +68,13 @@ class Keychain:
         return cfg
 
     def configure(self, username, password, profile=DEFAULT_PROFILE, api=DEFAULT_API, client_id=DEFAULT_CLIENT_ID,
-                  account=''):
+                  user_pool_id=DEFAULT_USER_POOL_ID, account=''):
         cfg = configparser.ConfigParser()
         cfg[profile] = {
             'name': 'chariot',
             'client_id': client_id,
             'api': api,
+            'user_pool_id': user_pool_id,
             'username': username,
             'password': password
         }


### PR DESCRIPTION
### Summary
Reason for adding it is that we want all users, including the likes of Steve to never need to copy and edit the keychain file directly, including setting it up for their personal stack.