### PR TITLE
Return file content when no path is specified.

### DIFF
--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import os
 
 import click
 
@@ -17,7 +18,7 @@ def get(ctx):
 @get.command('file')
 @cli_handler
 @click.argument('name')
-@click.option('-path', '--path', default="", help="Download path. Default: save to current directory")
+@click.option('-path', '--path', default=os.getcwd(), help="Download path. Default: save to current directory")
 def download_file(controller, name, path):
     """ Download a file using key or name."""
     if name.startswith('#'):

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -104,10 +104,12 @@ class Chariot:
         return filename
 
     @verify_credentials
-    def download(self, name: str, download_path: str) -> bool:
+    def download(self, name: str, download_path: str = ""):
         resp = requests.get(f"{self.keychain.api}/file", params={"name": name}, allow_redirects=True,
                             headers=self.keychain.headers)
         process_failure(resp)
+        if not download_path:
+            return resp.content.decode('utf-8')
 
         name = self.sanitize_filename(name)
         directory = os.path.expanduser(download_path)
@@ -115,10 +117,8 @@ class Chariot:
             os.makedirs(directory)
 
         download_path = os.path.join(directory, name)
-
         with open(download_path, 'wb') as file:
             file.write(resp.content)
-
         return download_path
 
     @verify_credentials

--- a/praetorian_cli/sdk/test/test_files.py
+++ b/praetorian_cli/sdk/test/test_files.py
@@ -42,5 +42,9 @@ class TestFile(BaseTest):
         assert os.path.exists(self.download_dir) is True
         utils.assert_files_equal(self.upload_file, os.path.join(self.download_dir, self.file_name))
 
+    def test_download_content(self):
+        content = self.chariot.download(self.upload_file)
+        assert content == self.asset
+
     def teardown_class(self):
         shutil.rmtree('resources')


### PR DESCRIPTION
### Summary
Allow SDK users to get file content directly without file operations. 
### Type
[New Feature]
### Context
This keeps the original CLI behaviour intact and makes it easier for power users to get the file content into the program directly without expensive file IO. 

