### PR TITLE
fixed error in 'list' and 'search' commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.3 (2024-11-14)
+
+* [Bug] Fixed an error with the `list` and `search` commands.
+* [Misc] Additional status of 'P', 'PL' have been added for assets.
+
 ## 1.5.2 (2024-10-25)
 
 * [Breaking change] The `D` status for risks is expanded to `DE`, DI`, `DL`, `DM`,

--- a/praetorian_cli/sdk/entities/search.py
+++ b/praetorian_cli/sdk/entities/search.py
@@ -55,7 +55,7 @@ class Search:
 def flatten_results(results):
     if type(results) == list:
         return results
-    aggregate = []
+    flattened = []
     for key in results.keys():
-        aggregate.extend(flatten_results(results[key]))
-    return aggregate
+        flattened.extend(flatten_results(results[key]))
+    return flattened

--- a/praetorian_cli/sdk/entities/search.py
+++ b/praetorian_cli/sdk/entities/search.py
@@ -42,9 +42,20 @@ class Search:
         # extract all the different types of entities in the search results into a
         # flattened list of `hits`
         results = self.api.my(params, pages)
-        hits = []
-        for key in results.keys():
-            if key != 'offset':
-                hits.extend(results[key])
-        offset = results['offset'] if 'offset' in results else None
-        return hits, offset
+
+        if 'offset' in results:
+            offset = results['offset']
+            del results['offset']
+        else:
+            offset = None
+
+        return flatten_results(results), offset
+
+
+def flatten_results(results):
+    if type(results) == list:
+        return results
+    aggregate = []
+    for key in results.keys():
+        aggregate.extend(flatten_results(results[key]))
+    return aggregate

--- a/praetorian_cli/sdk/model/globals.py
+++ b/praetorian_cli/sdk/model/globals.py
@@ -1,3 +1,6 @@
+"""
+This file contains the global constants in the Chariot backend API
+"""
 from enum import Enum
 
 
@@ -9,6 +12,8 @@ class Asset(Enum):
     FROZEN_LOW = 'FL'
     FROZEN_HIGH = 'FH'
     DELETED = 'D'
+    PENDING = 'P'
+    PENDING_LOW = 'PL'
 
 
 class Risk(Enum):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = praetorian-cli
-version = 1.5.2
+version = 1.5.3
 author = Praetorian
 author_email = support@praetorian.com
 description = For interacting with the Chariot API


### PR DESCRIPTION
Since the deployment on 11/11, the backend returns seeds in a nested JSON, separating IP/CIDR and domain seeds. The original logic for flattening the search results assumes there isn't nested JSON. This PR updated the logic to generically flatten nested JSON.