### PR TITLE
allow users to specify the surface of an asset

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -20,7 +20,8 @@ def add():
 @click.option('-n', '--name', required=False, help='The name of the asset, e.g, IP address, GitHub repo URL')
 @click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), required=False,
               default=Asset.ACTIVE.value, help=f'Status of the asset', show_default=True)
-def asset(sdk, name, dns, status):
+@click.option('-f', '--surface', required=False, default='', help=f'Attack surface of the asset', show_default=False)
+def asset(sdk, name, dns, status, surface):
     """ Add an asset
 
     Add an asset to the Chariot database. This command requires a DNS name for the asset.
@@ -40,7 +41,7 @@ def asset(sdk, name, dns, status):
     """
     if not name:
         name = dns
-    sdk.assets.add(dns, name, status)
+    sdk.assets.add(dns, name, status, surface)
 
 
 @add.command()

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -38,6 +38,7 @@ def asset(sdk, name, dns, status, surface):
     Example usages:
         - praetorian chariot add asset --dns example.com
         - praetorian chariot add asset --dns example.com --name 1.2.3.4
+        - praetorian chariot add asset --dns internal.example.com --name 10.2.3.4 --surface internal
     """
     if not name:
         name = dns
@@ -145,6 +146,7 @@ def risk(sdk, name, asset, status, comment, capability):
     Example usages:
         - praetorian chariot add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TI
         - praetorian chariot add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC
+        - praetorian chariot add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC --capability red-team
     """
     sdk.risks.add(asset, name, status, comment, capability)
 

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -129,7 +129,8 @@ def webhook(sdk):
 @click.option('-s', '--status', type=click.Choice([s.value for s in AddRisk]), required=True,
               help=f'Status of the risk')
 @click.option('-comment', '--comment', default='', help='Comment for the risk')
-def risk(sdk, name, asset, status, comment):
+@click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
+def risk(sdk, name, asset, status, comment, capability):
     """ Add a risk
 
     This command adds a risk to Chariot. A risk must have an associated asset.
@@ -145,7 +146,7 @@ def risk(sdk, name, asset, status, comment):
         - praetorian chariot add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TI
         - praetorian chariot add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC
     """
-    sdk.risks.add(asset, name, status, comment)
+    sdk.risks.add(asset, name, status, comment, capability)
 
 
 @add.command()

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -128,7 +128,7 @@ def webhook(sdk):
 @click.option('-a', '--asset', required=True, help='Key of an existing asset')
 @click.option('-s', '--status', type=click.Choice([s.value for s in AddRisk]), required=True,
               help=f'Status of the risk')
-@click.option('-comment', '--comment', default='', help='Comment for the risk')
+@click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
 def risk(sdk, name, asset, status, comment, capability):
     """ Add a risk

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -14,10 +14,10 @@ def update():
 @update.command()
 @cli_handler
 @click.argument('key', required=True)
-@click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), required=True,
-              help='The status of the asset')
-def asset(chariot, key, status):
-    """ Update the status of an asset
+@click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), help='The status of the asset')
+@click.option('-f', '--surface', type=click.Choice([s.value for s in Asset]), help='The attack surface of the asset')
+def asset(chariot, key, status, surface):
+    """ Update the status or surface of an asset
 
     \b
     Argument:
@@ -27,7 +27,10 @@ def asset(chariot, key, status):
     Example usages:
         - praetorian chariot update asset "#asset#www.example.com#1.2.3.4" -s F
     """
-    chariot.assets.update(key, status)
+    if status:
+        chariot.assets.update(key, status)
+    if surface:
+        chariot.attributes.add(key, 'surface', surface)
 
 
 @update.command()

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -15,7 +15,7 @@ def update():
 @cli_handler
 @click.argument('key', required=True)
 @click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), help='The status of the asset')
-@click.option('-f', '--surface', type=click.Choice([s.value for s in Asset]), help='The attack surface of the asset')
+@click.option('-f', '--surface', required=False, default='', help=f'Attack surface of the asset', show_default=False)
 def asset(chariot, key, status, surface):
     """ Update the status or surface of an asset
 
@@ -26,11 +26,9 @@ def asset(chariot, key, status, surface):
     \b
     Example usages:
         - praetorian chariot update asset "#asset#www.example.com#1.2.3.4" -s F
+        - praetorian chariot update asset "#asset#www.example.com#1.2.3.4" -f internal
     """
-    if status:
-        chariot.assets.update(key, status)
-    if surface:
-        chariot.attributes.add(key, 'surface', surface)
+    chariot.assets.update(key, status, surface)
 
 
 @update.command()

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -39,16 +39,21 @@ class Assets:
             asset['associated_risks'] = self.associated_risks(key)
         return asset
 
-    def update(self, key, status):
-        """ Update an asset; only status field makes sense to be updated.
+    def update(self, key, status=None, surface=None):
+        """ Update an asset
         Arguments:
         key: str
             The key of an asset. If you supply a prefix that matches multiple assets,
             all of them will be updated.
         status: str
             See globals.py for list of valid statuses
+        surface: str
+            The attack surface of the asset, for example, 'internal', 'external'
         """
-        return self.api.upsert('asset', dict(key=key, status=status))
+        if status:
+            self.api.upsert('asset', dict(key=key, status=status))
+        if surface:
+            self.api.attributes.add(key, 'surface', surface)
 
     def delete(self, key):
         """ Delete an asset

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -22,7 +22,7 @@ class Assets:
         surface: str
             The attack surface of the asset
         """
-        return self.api.upsert('asset', dict(dns=dns, name=name, status=status, surface=surface))[0]
+        return self.api.upsert('asset', dict(dns=dns, name=name, status=status, source=surface))[0]
 
     def get(self, key, details=False):
         """ Get details of an asset

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -9,7 +9,7 @@ class Assets:
     def __init__(self, api):
         self.api = api
 
-    def add(self, dns, name, status=Asset.ACTIVE.value):
+    def add(self, dns, name, status=Asset.ACTIVE.value, surface=''):
         """ Add an asset
 
         Arguments:
@@ -17,8 +17,12 @@ class Assets:
             The DNS name of the asset
         name: str
             The name of the asset
+        status: str
+            The status of the asset
+        surface: str
+            The attack surface of the asset
         """
-        return self.api.upsert('asset', dict(dns=dns, name=name, status=status))[0]
+        return self.api.upsert('asset', dict(dns=dns, name=name, status=status, surface=surface))[0]
 
     def get(self, key, details=False):
         """ Get details of an asset

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -9,7 +9,7 @@ class Risks:
     def __init__(self, api):
         self.api = api
 
-    def add(self, asset_key, name, status, comment=None):
+    def add(self, asset_key, name, status, comment=None, capability=''):
         """ Add a risk
 
         Arguments:
@@ -21,8 +21,10 @@ class Risks:
             See globals.py for list of valid statuses
         comment: str
             Optional comment
+        capability: str
+            Optional capability that discovered this risk
         """
-        return self.api.upsert('risk', dict(key=asset_key, name=name, status=status, comment=comment))['risks'][0]
+        return self.api.upsert('risk', dict(key=asset_key, name=name, status=status, comment=comment, source=capability))['risks'][0]
 
     def get(self, key, details=False):
         """ Get details of a risk

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -27,8 +27,11 @@ class TestAsset:
         assert any([a['dns'] == self.asset_dns for a in results])
 
     def test_update_asset(self):
-        self.sdk.assets.update(self.asset_key, Asset.FROZEN.value)
+        self.sdk.assets.update(self.asset_key, status=Asset.FROZEN.value)
         assert self.get_asset()['status'] == Asset.FROZEN.value
+        self.sdk.assets.update(self.asset_key, surface='abc')
+        attributes = self.sdk.assets.attributes(self.asset_key)
+        assert any([a['name'] == 'surface' and a['value'] == 'abc' for a in attributes])
 
     def test_delete_asset(self):
         self.sdk.assets.delete(self.asset_key)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -30,8 +30,9 @@ class TestZCli:
         self.verify(f'get asset "{o.asset_key}"', [o.asset_key, f'"status": "{Asset.ACTIVE.value}"'])
         self.verify(f'get asset -d "{o.asset_key}"', ['"attributes"', '"associated_risks"'])
 
-        self.verify(f'update asset -s F "{o.asset_key}"')
-        self.verify(f'get asset "{o.asset_key}"', [o.asset_key, f'"status": "{Asset.FROZEN.value}"'])
+        self.verify(f'update asset -s F "{o.asset_key}" -f internal')
+        self.verify(f'get asset "{o.asset_key}" -d', [o.asset_key,
+                    f'"status": "{Asset.FROZEN.value}"', f'#surface#internal'])
 
         self.verify(f'delete asset "{o.asset_key}"')
         self.verify(f'get asset "{o.asset_key}"')


### PR DESCRIPTION
This PR accompanies https://github.com/praetorian-inc/chariot/pull/1584, and allows users to specify the attack surface a manually added asset belongs to.

For https://praetorianlabs.atlassian.net/browse/CHA-724 and https://praetorianlabs.atlassian.net/browse/CHA-723