### PR TITLE
Reduce page size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+- [Bug fix] Lowered the page size for graph queries.
+
 ## 2.0.2
 
 - [New feature] The Chariot.my() function now optimizes the search query when feasible.

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from praetorian_cli.sdk.model.globals import GLOBAL_FLAG, Kind
 
+DEFAULT_PAGE_SIZE = 1500
 
 class Filter:
     class Operator(Enum):
@@ -179,4 +180,4 @@ def my_params_to_query(params: dict):
     page = int(params.get('offset', 0))
     global_ = bool(params.get('global', False))
 
-    return Query(node=node, page=page, limit=5000, global_=global_)
+    return Query(node=node, page=page, limit=DEFAULT_PAGE_SIZE, global_=global_)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = praetorian-cli
-version = 2.0.2
+version = 2.0.3
 author = Praetorian
 author_email = support@praetorian.com
 description = For interacting with the Chariot API


### PR DESCRIPTION
Temporary bugfix that reduces default page size from 5000 to 1500. There is a limit of 6MB of content per API call the Chariot backend supports. This can occur when querying certain entities that may have a long history or whatnot. 

