### PR TITLE
[CHA-876] Query size backoff

### DIFF
--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -69,7 +69,7 @@ class Chariot:
         while i < pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
-            if check_query_limit_failure(resp):
+            if is_query_limit_failure(resp):
                 query.limit //= 2
                 continue
             else: 
@@ -177,7 +177,7 @@ class Chariot:
         return self.keychain.base_url() + path
 
 
-def check_query_limit_failure(response):
+def is_query_limit_failure(response):
     return response.status_code == 413 and 'reduce page size' in response.text
 
 

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,9 +64,16 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        for _ in range(pages):
+        desired_limit = query.limit
+        i = 0
+        while i < pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
+            if check_query_limit_failure(resp):
+                query.limit //= 2
+                continue
+            else: 
+                query.limit = desired_limit
             process_failure(resp)
             resp = resp.json()
             extend(final_resp, resp)
@@ -74,6 +81,7 @@ class Chariot:
                 query.page = int(resp['offset'])
             else:
                 break
+            i += 1
 
         if 'offset' in resp:
             final_resp['offset'] = resp['offset']
@@ -167,6 +175,10 @@ class Chariot:
 
     def url(self, path: str):
         return self.keychain.base_url() + path
+
+
+def check_query_limit_failure(response):
+    return response.status_code == 413 and 'reduce page size' in response.text
 
 
 def process_failure(response):

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from praetorian_cli.sdk.model.globals import GLOBAL_FLAG, Kind
 
-DEFAULT_PAGE_SIZE = 1500
+DEFAULT_PAGE_SIZE = 5000
 
 class Filter:
     class Operator(Enum):


### PR DESCRIPTION
Implements a simple backoff for the `my_by_query` function to handle if the requested data is too large for the backend to handle. 

My current understanding of when this issue occurs leads me to believe we do not need to keep the reduced query limit for future pages, rather there are a few "bad chunks" to work through before we can return to the larger query limit.

Technically, it is possible to get stuck in an infinite loop if a single object for which we are querying is too large for a single request. However, I think we have bigger problems if that occurs and do not need to handle it here.

Speed tests here are slightly slower than in v2.0.2 but I think that is due to changes Chariot side