### PR TITLE
[CHA-1190] Keep accurate SKIP number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.6
+
+- [Bug fix] Fixed the offset calculation for automatic backoffs on large queries.
+
 ## 2.0.5
 
 - [New feature] Ability to set a manual surface on an asset and manual capability on a risk. 

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,7 +64,7 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        while query.page< pages:
+        while query.page < pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
             if is_query_limit_failure(resp):

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,15 +64,13 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        i = 0
-        while i < pages:
+        while query.page< pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
             if is_query_limit_failure(resp):
                 query.limit //= 2
                 query.page *= 2
                 pages *= 2
-                i *= 2
                 continue
             process_failure(resp)
             resp = resp.json()
@@ -81,7 +79,6 @@ class Chariot:
                 query.page = int(resp['offset'])
             else:
                 break
-            i += 1
 
         if 'offset' in resp:
             final_resp['offset'] = resp['offset']

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,16 +64,14 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        desired_limit = query.limit
         i = 0
         while i < pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
             if is_query_limit_failure(resp):
                 query.limit //= 2
+                query.page *= 2
                 continue
-            else: 
-                query.limit = desired_limit
             process_failure(resp)
             resp = resp.json()
             extend(final_resp, resp)

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -71,6 +71,7 @@ class Chariot:
             if is_query_limit_failure(resp):
                 query.limit //= 2
                 query.page *= 2
+                pages *= 2
                 continue
             process_failure(resp)
             resp = resp.json()

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -72,6 +72,7 @@ class Chariot:
                 query.limit //= 2
                 query.page *= 2
                 pages *= 2
+                i *= 2
                 continue
             process_failure(resp)
             resp = resp.json()

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from praetorian_cli.sdk.model.globals import GLOBAL_FLAG, Kind
 
-DEFAULT_PAGE_SIZE = 5000
+DEFAULT_PAGE_SIZE = 4096
 
 class Filter:
     class Operator(Enum):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = praetorian-cli
-version = 2.0.5
+version = 2.0.6
 author = Praetorian
 author_email = support@praetorian.com
 description = For interacting with the Chariot API


### PR DESCRIPTION
Backend uses an Offset to do pagination in the query which is equal to page * limit. Thus, when we cut limit in half we need to double page. We also need to double the amount of pages we are querying for to make sure we get all the items we requested.

Example for Requesting 5 pages of size 4096 = 20,480 objects.
Limit = 4096, Page = 0, Pages = 5 -> Offset = 0
Limit = 4096, Page = 1, Pages = 5 -> Offset = 4096
Limit = 4096, Page = 2, Pages = 5 -> Offset = 8192
Limit = 4096, Page = 3, Pages = 5 -> Offset = 12288
*413 Failure*
Retry -> Limit = 2048, Page = 6, Pages = 10 -> Offset = 12288
Limit = 2048, Page = 7, Pages = 10 -> Offset = 14336
Limit = 2048, Page = 8, Pages = 10 -> Offset = 16384
Limit = 2048, Page = 9, Pages = 10 -> Offset = 18432
-> Done Page = 10, Pages = 10, Total returned is `18432 + 2048 = 20480`