### PR TITLE
Bugfix for Query Offset

### DIFF
--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,18 +64,18 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        requested_pages = pages + query.page 
-        while query.page < requested_pages:
+        while pages > 0:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
             if is_query_limit_failure(resp):
                 query.limit //= 2
                 query.page *= 2
-                requested_pages *= 2
+                pages *= 2
                 continue
             process_failure(resp)
             resp = resp.json()
             extend(final_resp, resp)
+            pages -= 1
             if 'offset' in resp:
                 query.page = int(resp['offset'])
             else:

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -71,7 +71,7 @@ class Chariot:
             if is_query_limit_failure(resp):
                 query.limit //= 2
                 query.page *= 2
-                pages *= 2
+                requested_pages *= 2
                 continue
             process_failure(resp)
             resp = resp.json()

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -64,7 +64,8 @@ class Chariot:
 
     def my_by_query(self, query: Query, pages=1) -> {}:
         final_resp = dict()
-        while query.page < pages:
+        requested_pages = pages + query.page 
+        while query.page < requested_pages:
             resp = requests.post(self.url('/my'), json=query.to_dict(), params=query.params(),
                                  headers=self.keychain.headers())
             if is_query_limit_failure(resp):


### PR DESCRIPTION
Bug in `my_by_query` where if we requested a `query.page` > 0 (i.e. from an offset) and `pages` was just 1 we would not execute the `while` loop. 

Therefore we need to ensure we request at least `query.page + pages` 

I could also solve this with a dedicated loop variable instead of reusing `query.page`