### PR TITLE
Moved the options for pytest to another location

### DIFF
--- a/praetorian_cli/sdk/test/pytest.ini
+++ b/praetorian_cli/sdk/test/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -p no:cacheprovider
+markers =
+    coherence: these are tests on product workflows via the backend API
+    cli: these are tests on the CLI interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,3 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.pytest.ini_options]
-addopts = "-p no:cacheprovider"
-markers = [
-    "coherence: these are tests on product workflows via the backend API",
-    "cli: these are tests on the CLI interface",
-]


### PR DESCRIPTION
When running `chariot test` with a pip-installed CLI, it does two annoying things:

1. It warn that @pytest.mark.coherence is a typo.
2. It generate \_\_pycache\_\_ directories. This in turn causes the CLI to be unable to be cleanly uninstalled.

I can't test whether it would work without publishing it. So, we just have to get it published and see.