### PR TITLE
Include pytest.ini in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include praetorian_cli/sdk/test/pytest.ini 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
+options.package_data =
+    praetorian_cli.sdk.test = pytest.ini
 python_requires = >=3.9
 install_requires =
     click >= 8.1.7


### PR DESCRIPTION
## Summary (required)

In an attempt to get rid of the `praetorian chariot test` warnings, I added the `pytest.ini` to the MANIFEST so that it is packaged and included in the `pip` package
