### PR TITLE
Fix two bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- [Bug fix] Fixed an unhandled exception (`NameError: name 'chariot' is
+  not defined`) that occurred when getting a non-200 HTTP response from
+  Chariot
+
 ## 2.1.0
 
 - [New Feature] Add job now supports an inline JSON with the `--config` option

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -1,11 +1,12 @@
 import click
 
-from praetorian_cli.sdk.chariot import Chariot
-
 
 @click.group()
 @click.pass_context
 def chariot(click_context):
+    # import done here to avoid circular import errors in praetorian_cli/handlers/cli_decorators.py
+    from praetorian_cli.sdk.chariot import Chariot
+
     """ Command group for interacting with the Chariot product """
     # Replace the click context (previously a Keychain instance) with a Chariot
     # instance, after creating it using the Keychain instance.

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -6,6 +6,7 @@ import click
 import requests
 from packaging.version import Version
 
+from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.utils import error
 
 
@@ -17,7 +18,7 @@ def handle_error(func):
             return func(*args, **kwargs)
         except Exception as e:
             error(str(e), quit=False)
-            if ctx.obj.is_debug:
+            if chariot.is_debug:
                 click.echo(traceback.format_exc())
 
     return wrapper

--- a/praetorian_cli/scripts/commands/nmap-example.py
+++ b/praetorian_cli/scripts/commands/nmap-example.py
@@ -59,7 +59,7 @@ def nmap_command(sdk, host):
         sdk.add('asset', dict(name=host, dns=host))
         print(f'Added asset {asset_key}')
         for l in lines[5:]:
-            match = re.match('^(\d+)/[a-z]+\s+open\s+([a-z]+)$', l)
+            match = re.match(r'^(\d+)/[a-z]+\s+open\s+([a-z]+)$', l)
             if match:
                 (port, protocol) = match.groups()
                 sdk.add('attribute', dict(key=asset_key, name=protocol, value=port))


### PR DESCRIPTION
## Summary 

Fix two bugs: an invalid string escape in example code, and an unhandled exception upon HTTP error from `praetorian chariot`.
