### PR TITLE
feat: add CLI commands for scanner data exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/dist
 env/
 test-*.*
+venv

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -278,3 +278,20 @@ def credential(chariot, credential_id, category, type, format, parameters):
     result = chariot.credentials.get(credential_id, category, type, [format], **params)
     output = chariot.credentials.format_output(result)
     click.echo(output)
+
+
+@get.command()
+@cli_handler
+@click.argument('key', required=True)
+def scanner(chariot, key):
+    """ Get scanner details
+
+    \b
+    Argument:
+        - KEY: the key of an existing scanner record
+
+    \b
+    Example usage:
+        - praetorian chariot get scanner "#scanner#127.0.0.1"
+    """
+    print_json(chariot.scanners.get(key))

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -336,3 +336,20 @@ def capabilities(chariot, name, target, executor):
         - praetorian chariot list capabilities --name nuclei --target attribute --executor chariot
     """
     print_json(chariot.capabilities.list(name, target, executor))
+
+
+@list.command()
+@list_params('IP address')
+def scanners(chariot, filter, details, offset, page):
+    """ List scanners
+
+    Retrieve and display a list of scanner records that track IP addresses used by chariot.
+
+    \b
+    Example usages:
+        - praetorian chariot list scanners
+        - praetorian chariot list scanners --filter 127.0.0.1
+        - praetorian chariot list scanners --details
+        - praetorian chariot list scanners --page all
+    """
+    render_list_results(chariot.scanners.list(filter, offset, pagination_size(page)), details)

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -14,6 +14,7 @@ from praetorian_cli.sdk.entities.jobs import Jobs
 from praetorian_cli.sdk.entities.keys import Keys
 from praetorian_cli.sdk.entities.preseeds import Preseeds
 from praetorian_cli.sdk.entities.risks import Risks
+from praetorian_cli.sdk.entities.scanners import Scanners
 from praetorian_cli.sdk.entities.search import Search
 from praetorian_cli.sdk.entities.seeds import Seeds
 from praetorian_cli.sdk.entities.settings import Settings
@@ -39,6 +40,7 @@ class Chariot:
         self.definitions = Definitions(self)
         self.attributes = Attributes(self)
         self.search = Search(self)
+        self.scanners = Scanners(self)
         self.webhook = Webhook(self)
         self.statistics = Statistics(self)
         self.agents = Agents(self)

--- a/praetorian_cli/sdk/entities/scanners.py
+++ b/praetorian_cli/sdk/entities/scanners.py
@@ -9,5 +9,5 @@ class Scanners:
 
     def list(self, filter='', offset='', page_size=100):
         """ List scanners with optional filtering """
-        search_term = filter if filter else '#scanner'
+        search_term = f"#scanner#{filter}"
         return self.api.search.by_term(search_term, None, offset, page_size)

--- a/praetorian_cli/sdk/entities/scanners.py
+++ b/praetorian_cli/sdk/entities/scanners.py
@@ -1,0 +1,13 @@
+class Scanners:
+
+    def __init__(self, api):
+        self.api = api
+
+    def get(self, key):
+        """ Get scanner details by exact key """
+        return self.api.search.by_exact_key(key)
+
+    def list(self, filter='', offset='', page_size=100):
+        """ List scanners with optional filtering """
+        search_term = filter if filter else '#scanner'
+        return self.api.search.by_term(search_term, None, offset, page_size)


### PR DESCRIPTION
## Summary

This PR adds CLI functionality to expose scanner data, which tracks IP addresses used by Chariot backend jobs. This provides users with visibility into the scanning infrastructure and enables programmatic access to scanner information.

## Changes Made

- **New Scanner Entity**: Added `praetorian_cli/sdk/entities/scanners.py` with `Scanners` class containing:
  - `get(key)` method for retrieving specific scanner details by exact key
  - `list(filter, offset, page_size)` method for listing scanners with optional filtering

- **SDK Integration**: Updated `praetorian_cli/sdk/chariot.py` to:
  - Import the new Scanners entity
  - Instantiate scanners in the main Chariot client

- **CLI Commands**: Added new commands following established patterns:
  - `praetorian chariot get scanner <key>` - Get specific scanner details
  - `praetorian chariot list scanners` - List all scanners with filtering support

## New CLI Commands

### Get Scanner
```bash
praetorian chariot get scanner "#scanner#127.0.0.1"
```
Retrieves detailed information about a specific scanner by its exact key.

### List Scanners
```bash
# List all scanners
praetorian chariot list scanners

# Filter by IP address
praetorian chariot list scanners --filter 127.0.0.1

# Show detailed output
praetorian chariot list scanners --details

# Paginate results
praetorian chariot list scanners --page 50
praetorian chariot list scanners --page all
```

## Use Cases

- **Infrastructure Visibility**: View which IP addresses Chariot is using for scanning operations
- **Monitoring**: Track scanner usage and availability
- **Debugging**: Identify specific scanners when troubleshooting scan issues
- **Automation**: Programmatically access scanner data for reporting or integration

## Implementation Notes

- Follows existing CLI patterns and conventions
- Uses the search API backend with `#scanner` term filtering
- Supports standard CLI options (filtering, pagination, detailed output)
- Outputs JSON format for programmatic consumption
- Maintains consistency with other entity commands (assets, risks, etc.)

## Testing

The commands can be tested with:
```bash
praetorian chariot list scanners
praetorian chariot get scanner <scanner-key>
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Added a CLI command to fetch scanner details by key.
  - Added a CLI command to list scanners with optional filtering, pagination, and detailed output.
  - Enabled scanner interactions in the SDK for broader tooling support.

* Chores
  - Updated ignore settings to exclude virtual environment directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->