### PR TITLE
Fallback Commands

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -1,6 +1,5 @@
 import datetime
 import os.path
-import json
 
 import click
 
@@ -332,3 +331,26 @@ def key(sdk, name, expires):
         return
     click.echo(f'API key created: {result.get("key", "N/A")}')
     click.echo(f'Secret (save this, it will not be shown again): {result["secret"]}')
+
+def get_dict_from_entries(entry):
+    config_dict = {}
+    for item in entry:
+        if '=' not in item:
+            click.echo(f"Error: Entry '{item}' is not in the format key=value")
+            return
+
+        if item.count('=') > 1:
+            click.echo(f"Error: Entry '{item}' contains multiple '=' characters. Format should be key=value")
+            return
+
+        key, value = item.split('=', 1)
+
+        if not key:
+            click.echo("Error: Key cannot be empty")
+            return
+
+        if not value:
+            click.echo("Error: Value cannot be empty")
+            return
+
+        config_dict[key] = value

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -1,18 +1,36 @@
 import datetime
 import os.path
+import json
 
 import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.handlers.utils import error, print_json
 from praetorian_cli.sdk.model.globals import AddRisk, Asset, Seed, Kind
+from praetorian_cli.sdk.entities.generic import Generic
+from praetorian_cli.sdk.model.utils import get_dict_from_entries
 
 
-@chariot.group()
-def add():
+@chariot.group(invoke_without_command=True)
+@cli_handler
+@click.pass_context
+@click.option('-l', '--label', required=False, help='Label/type of entity to add')
+@click.option('-e', '--entries', required=False, help='JSON string or file path containing entity data')
+def add(ctx, chariot, label, entries):
     """ Add an entity to Chariot """
-    pass
+    if ctx.invoked_subcommand is None:
+        if not label or not entries:
+            print("Both --label and --entries must be provided")
+            return
+        
+        entries_data = get_dict_from_entries(entries)
+
+        try:
+            results = chariot.generic.add(label, entries_data)
+            print_json(results)
+        except Exception as e:
+            error(f"Failed to add entity: {e}")
 
 
 @add.command()

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -22,7 +22,7 @@ class FallbackGroup(click.Group):
         @click.command(name=cmd_name)
         @click.option('-e', '--entries', required=True, help='JSON string or file path containing entity data')
         @cli_handler
-        def _dynamic(chariot, entries):  # noqa: ARG002
+        def _dynamic(chariot, entries): 
             entries_data = get_dict_from_entries(entries)
             try:
                 results = chariot.generic.add(cmd_name, entries_data)
@@ -33,7 +33,7 @@ class FallbackGroup(click.Group):
 
 @chariot.group(cls=FallbackGroup)
 def add():
-    """ Add an entity to Chariot (known subcommands or generic entities) """
+    """ Add an entity to Chariot """
     pass
 
 

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -21,11 +21,10 @@ class FallbackGroup(click.Group):
         @click.command(name=cmd_name)
         @click.option('-e', '--entries', required=True, help='JSON string or file path containing entity data')
         @cli_handler
-        def _dynamic(chariot, entries): 
-            entries_data = get_dict_from_entries(entries)
+        def _dynamic(chariot, entries):
             try:
-                results = chariot.generic.add(cmd_name, entries_data)
-                print_json(results)
+                entries_data = get_dict_from_entries(entries)
+                print_json(chariot.generic.add(cmd_name, entries_data))
             except Exception as e:
                 error(f"Failed to add entity: {e}")
         return _dynamic
@@ -334,23 +333,23 @@ def key(sdk, name, expires):
 
 def get_dict_from_entries(entry):
     config_dict = {}
-    for item in entry:
+    for idx, item in enumerate(entry, start=1):
         if '=' not in item:
-            click.echo(f"Error: Entry '{item}' is not in the format key=value")
+            error(f"Entry #{idx} ('{item}') is not in the format key=value")
             return
 
         if item.count('=') > 1:
-            click.echo(f"Error: Entry '{item}' contains multiple '=' characters. Format should be key=value")
+            error(f"Entry #{idx} ('{item}') contains multiple '=' characters. Format should be key=value")
             return
 
         key, value = item.split('=', 1)
 
         if not key:
-            click.echo("Error: Key cannot be empty")
+            error(f"Key #{idx} cannot be empty")
             return
 
         if not value:
-            click.echo("Error: Value cannot be empty")
+            error(f"Value for key #{idx} cannot be empty")
             return
 
         config_dict[key] = value

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -7,8 +7,6 @@ from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
 from praetorian_cli.handlers.utils import error, print_json
 from praetorian_cli.sdk.model.globals import AddRisk, Asset, Seed, Kind
-from praetorian_cli.sdk.entities.generic import Generic
-from praetorian_cli.sdk.model.utils import get_dict_from_entries
 
 
 class FallbackGroup(click.Group):

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -17,7 +17,7 @@ class FallbackGroup(click.Group):
 
         # Return a dynamic command that adds entities with the label=cmd_name
         @click.command(name=cmd_name)
-        @click.option('-e', '--entries', required=True, help='JSON string or file path containing entity data')
+        @click.option('-e', '--entries', required=True, help='key value pairs that make up the object')
         @cli_handler
         def _dynamic(chariot, entries):
             try:
@@ -328,6 +328,7 @@ def key(sdk, name, expires):
         return
     click.echo(f'API key created: {result.get("key", "N/A")}')
     click.echo(f'Secret (save this, it will not be shown again): {result["secret"]}')
+
 
 def get_dict_from_entries(entry):
     config_dict = {}

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -24,8 +24,6 @@ class FallbackGroup(click.Group):
 def get():
     """ Get entity by key (known subcommands or generic entities) """
     pass 
-        
-
 
 
 @get.command()

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -15,25 +15,9 @@ class FallbackGroup(click.Group):
 
         @click.command(name=cmd_name)
         @click.argument('entity_key', required=True)
-        @click.option('-f', '--filter', required=False, help='Additional filters')
         @cli_handler
-        def _dynamic(chariot, entity_key, filter):  # noqa: ARG002
-            result = chariot.generic.get(entity_key)
-            if result:
-                print_json(result)
-            else:
-                # If that fails, try searching by label for entities with this key
-                results, _ = chariot.generic.list(cmd_name, filter_text=entity_key, pages=1)
-                if results:
-                    # Find exact key match
-                    for item in results:
-                        if item.get('key') == entity_key:
-                            print_json(item)
-                            return
-                    # If no exact match, return first result
-                    print_json(results[0])
-                else:
-                    print_json(None)
+        def _dynamic(chariot, entity_key): 
+            print_json(chariot.generic.get(entity_key))
         return _dynamic
 
 @chariot.group(cls=FallbackGroup)

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -5,12 +5,24 @@ import click
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
 from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.sdk.entities.generic import Generic
 
 
-@chariot.group()
-def get():
-    """ Get entity details from Chariot """
-    pass
+@chariot.group(invoke_without_command=True)
+@cli_handler
+@click.pass_context
+@click.option('-k', '--key', required=False, help='The key of the entity to retrieve')
+def get(ctx, chariot, key):
+    """ Get entity by key or list entities by label from Chariot """
+    if ctx.invoked_subcommand is None:
+        if key == "":
+            print("No key provided")
+            return
+        generic = Generic(chariot)
+        result = generic.get(key)
+        print_json(result) 
+        
+
 
 
 @get.command()

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -22,7 +22,7 @@ class FallbackGroup(click.Group):
 
 @chariot.group(cls=FallbackGroup)
 def get():
-    """ Get entity by key (known subcommands or generic entities) """
+    """ Get entity details from Chariot """
     pass 
 
 

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -22,7 +22,7 @@ class FallbackGroup(click.Group):
 
 @chariot.group(cls=FallbackGroup)
 def list():
-    """List entities (known subcommands or generic labels)."""
+    """ Get a list of entities from Chariot """
     pass
 
 

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -5,31 +5,26 @@ from praetorian_cli.handlers.cli_decorators import list_params, pagination, cli_
 from praetorian_cli.handlers.utils import render_offset, render_list_results, pagination_size, error, print_json
 
 
-@chariot.group(invoke_without_command=True)
-@cli_handler  
-@click.pass_context
-@click.argument('label', required=True)
-@click.option('-k', '--key-prefix', required=False, help='Key prefix to search for')
-@click.option('-d', '--details', is_flag=True, help='Show detailed information')
-@pagination
-def list(ctx, chariot, label, key_prefix, details, offset, page):
-    """ Get a list of entities from Chariot """
-    if label in ctx.command.commands:
-        return ctx.invoke(ctx.command.commands[label])
-        
-    if not label and not key_prefix:
-        print("No label or key prefix provided")
-        return
-    
-    if label and key_prefix:
-        print("Cannot specify both --label and --key-prefix")
-        return
-    
-    if label:
-        results, next_offset = chariot.generic.list(label, offset=offset, pages=pagination_size(page))
-    else:
-        results, next_offset = chariot.search.by_key_prefix(key_prefix, offset, pagination_size(page))
-    render_list_results((results, next_offset), details)
+class FallbackGroup(click.Group):
+    def get_command(self, ctx, cmd_name):
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            return cmd
+
+        @click.command(name=cmd_name)
+        @click.option('-f', '--filter', required=False, help='Filter for the entities')
+        @click.option('-d', '--details', is_flag=True, help='Show detailed information')
+        @pagination
+        @cli_handler
+        def _dynamic(chariot, filter, details, offset, page):  # noqa: ARG002
+            results, next_offset = chariot.generic.list(cmd_name, filter_text=filter, offset=offset, pages=pagination_size(page))
+            render_list_results((results, next_offset), details)
+        return _dynamic
+
+@chariot.group(cls=FallbackGroup)
+def list():
+    """List entities (known subcommands or generic labels)."""
+    pass
 
 
 @list.command()

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -16,9 +16,8 @@ class FallbackGroup(click.Group):
         @click.option('-d', '--details', is_flag=True, help='Show detailed information')
         @pagination
         @cli_handler
-        def _dynamic(chariot, filter, details, offset, page):  # noqa: ARG002
-            results, next_offset = chariot.generic.list(cmd_name, filter_text=filter, offset=offset, pages=pagination_size(page))
-            render_list_results((results, next_offset), details)
+        def _dynamic(chariot, filter, details, offset, page): 
+            render_list_results(chariot.generic.list(cmd_name, filter_text=filter, offset=offset, pages=pagination_size(page)), details)
         return _dynamic
 
 @chariot.group(cls=FallbackGroup)

--- a/praetorian_cli/handlers/schema.py
+++ b/praetorian_cli/handlers/schema.py
@@ -28,10 +28,10 @@ def schema(chariot, details, entity_type):
     if not schema_data:
         error(f"Entity type '{entity_type}' not found")
 
-    if not details:
-        show_keys(schema_data)
-    else:
+    if details:
         print_json(schema_data)
+    else:
+        show_keys(schema_data)
 
 def show_keys(data):
     for type_name in sorted(data.keys()):

--- a/praetorian_cli/handlers/schema.py
+++ b/praetorian_cli/handlers/schema.py
@@ -1,0 +1,38 @@
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error, print_json
+
+
+@chariot.command()
+@click.option('-d', '--details', is_flag=True, help='Show detailed information including filterable fields')
+@click.option('-t', '--type', 'entity_type', help='Show schema for specific entity type')
+@cli_handler
+def schema(chariot, details, entity_type):
+    """ Display available entity types and their schemas
+    
+    Display the schema information available at the /schema/ endpoint.
+    By default shows just the type labels. Use --details to see filterable fields.
+    
+    \b
+    Example usages:
+        - praetorian chariot schema
+        - praetorian chariot schema --details
+        - praetorian chariot schema --type asset
+        - praetorian chariot schema --type asset --details
+    """
+    
+    schema_data = chariot.generic.get_schema(entity_type)
+
+    if not schema_data:
+        error(f"Entity type '{entity_type}' not found")
+
+    if not details:
+        show_keys(schema_data)
+    else:
+        print_json(schema_data)
+
+def show_keys(data):
+    for type_name in sorted(data.keys()):
+        click.echo(type_name)

--- a/praetorian_cli/handlers/utils.py
+++ b/praetorian_cli/handlers/utils.py
@@ -36,3 +36,22 @@ def error(message, quit=True):
     click.echo(message, err=True)
     if quit:
         exit(1)
+
+
+def parse_name_value_fields(field_list, sep=':'):
+    """Parse a sequence of name:value strings into a dict.
+    
+    - Splits on the first separator only to allow the value to contain it.
+    - Emits a user-facing error and returns None on invalid input.
+
+    Returns a dict on success, or None on error.
+    """
+    fields = {}
+    for field in field_list:
+        if sep in field:
+            name, value = field.split(sep, 1)
+            fields[name] = value
+        else:
+            error(f"Field '{field}' is not in the format name:value")
+            return None
+    return fields

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -8,6 +8,7 @@ import praetorian_cli.handlers.get
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.link
 import praetorian_cli.handlers.list
+import praetorian_cli.handlers.schema
 import praetorian_cli.handlers.script
 import praetorian_cli.handlers.search
 import praetorian_cli.handlers.test

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -22,12 +22,14 @@ from praetorian_cli.sdk.entities.webhook import Webhook
 from praetorian_cli.sdk.keychain import Keychain
 from praetorian_cli.sdk.model.globals import GLOBAL_FLAG
 from praetorian_cli.sdk.model.query import Query, my_params_to_query, DEFAULT_PAGE_SIZE
+from praetorian_cli.sdk.entities.generic import Generic
 
 
 class Chariot:
 
     def __init__(self, keychain: Keychain, proxy: str=''):
         self.keychain = keychain
+        self.generic = Generic(self)
         self.assets = Assets(self)
         self.seeds = Seeds(self)
         self.preseeds = Preseeds(self)

--- a/praetorian_cli/sdk/entities/generic.py
+++ b/praetorian_cli/sdk/entities/generic.py
@@ -71,11 +71,36 @@ class Generic:
             entry_with_type = entry.copy()
             entry_with_type['type'] = label
             
-            # Use the API to upsert the entity
-            result = self.api.upsert(label, entry_with_type)
+            # Use the /model endpoint for adding entities
+            result = self.api.upsert('model', entry_with_type)
             if isinstance(result, list):
                 results.extend(result)
             else:
                 results.append(result)
         
         return results
+
+    def get_schema(self, entity_type: str = None) -> dict:
+        """Get schema information for entity types
+        
+        Args:
+            entity_type: Optional specific entity type, if None returns all schemas
+            
+        Returns:
+            dict: Schema information
+        """
+        result = self.api.get('schema')
+        if entity_type:
+            if entity_type not in result:
+                return {}
+            return {entity_type: result[entity_type]}
+        return result
+    
+    def get_available_entity_types(self) -> list:
+        """Get list of all available entity types
+        
+        Returns:
+            list: Available entity type names
+        """
+        schema_data = self.get_schema()
+        return list(schema_data.keys()) if isinstance(schema_data, dict) else []

--- a/praetorian_cli/sdk/entities/generic.py
+++ b/praetorian_cli/sdk/entities/generic.py
@@ -1,0 +1,99 @@
+from praetorian_cli.sdk.model.query import Query, Node, Filter, KIND_TO_LABEL
+
+class Generic:
+
+    def __init__(self, api):
+        self.api = api
+
+    def get(self, key, filters=None):
+        """
+        Get entity by key with optional filters using graph queries.
+
+        :param key: Entity key to retrieve
+        :type key: str
+        :param filters: Additional search filters as dict of field:value pairs
+        :type filters: dict or None
+        :return: The matching entity as arbitrary JSON
+        :rtype: dict or None
+        """
+        query_filters = [Filter(Filter.Field.KEY, Filter.Operator.EQUAL, key)]
+        
+        if filters:
+            for field, value in filters.items():
+                try:
+                    field_enum = Filter.Field(field)
+                    query_filters.append(Filter(field_enum, Filter.Operator.EQUAL, value))
+                except ValueError:
+                    continue
+        
+        node = Node(filters=query_filters)
+        query = Query(node=node)
+        results, _ = self.api.search.by_query(query)
+        return results[0] if results else None
+
+    def list(self, label, filters=None, offset=None, pages=100000):
+        """
+        List entities by label with optional filters using graph queries.
+
+        :param label: Label/type of entities to search for
+        :type label: str
+        :param filters: Additional search filters as dict of field:value pairs
+        :type filters: dict or None
+        :param offset: The offset for pagination
+        :type offset: str or None
+        :param pages: The number of pages of results to retrieve
+        :type pages: int
+        :return: A tuple containing (list of matching entities, next page offset)
+        :rtype: tuple
+        """
+        query_filters = []
+        
+        if filters:
+            for field, value in filters.items():
+                try:
+                    field_enum = Filter.Field(field)
+                    query_filters.append(Filter(field_enum, Filter.Operator.EQUAL, value))
+                except ValueError:
+                    continue
+        
+        # Use enum value if available, otherwise use string directly
+        node_label = KIND_TO_LABEL.get(label)
+        if node_label:
+            labels = [node_label.value]
+        else:
+            labels = [label]
+        
+        node = Node(labels=labels, filters=query_filters if query_filters else None)
+        query = Query(node=node)
+        results, offset = self.api.search.by_query(query, pages)
+        
+        return results, offset
+
+    def add(self, label, entries):
+        """
+        Add entities with the given label and JSON entries.
+
+        :param label: The type/label of entities to add
+        :type label: str
+        :param entries: Dictionary or list of dictionaries containing entity data
+        :type entries: dict or list
+        :return: The entities that were added
+        :rtype: list
+        """
+        if isinstance(entries, dict):
+            entries = [entries]
+        
+        results = []
+        for entry in entries:
+            # Add the type/label to the entry
+            entry_with_type = entry.copy()
+            entry_with_type['type'] = label
+            
+            # Use the API to upsert the entity
+            result = self.api.upsert(label, entry_with_type)
+            if isinstance(result, list):
+                results.extend(result)
+            else:
+                results.append(result)
+        
+        return results

--- a/praetorian_cli/sdk/entities/generic.py
+++ b/praetorian_cli/sdk/entities/generic.py
@@ -1,5 +1,4 @@
-# Imports moved to search.by_label_with_filter method
-
+from praetorian_cli.sdk.model.query import Query, Node, Filter
 class Generic:
 
     def __init__(self, api):

--- a/praetorian_cli/sdk/entities/generic.py
+++ b/praetorian_cli/sdk/entities/generic.py
@@ -4,42 +4,25 @@ class Generic:
     def __init__(self, api):
         self.api = api
 
-    def get(self, key, filters=None):
+    def get(self, key):
         """
-        Get entity by key with optional filters using graph queries.
+        Get entity by key 
 
         :param key: Entity key to retrieve
         :type key: str
-        :param filters: Additional search filters as dict of field:value pairs
-        :type filters: dict or None
         :return: The matching entity as arbitrary JSON
         :rtype: dict or None
         """
-        query_filters = [Filter(Filter.Field.KEY, Filter.Operator.EQUAL, key)]
-        
-        if filters:
-            for field, value in filters.items():
-                try:
-                    field_enum = Filter.Field(field)
-                    query_filters.append(Filter(field_enum, Filter.Operator.EQUAL, value))
-                except ValueError:
-                    continue
-        
-        node = Node(filters=query_filters)
-        query = Query(node=node)
-        results, _ = self.api.search.by_query(query)
-        return results[0] if results else None
+        return self.api.search.by_exact_key(key)
 
-    def list(self, label, filter_text=None, filters=None, offset=None, pages=100000):
+    def list(self, label, prefix_filter=None, offset=None, pages=100000):
         """
         List entities by label with optional filters.
 
         :param label: Label/type of entities to search for
         :type label: str
-        :param filter_text: Text filter to search within entity keys
-        :type filter_text: str or None
-        :param filters: Additional search filters as dict of field:value pairs (not yet implemented)
-        :type filters: dict or None
+        :param prefix_filter: Text filter to search within entity keys
+        :type prefix_filter: str or None
         :param offset: The offset for pagination
         :type offset: str or None
         :param pages: The number of pages of results to retrieve
@@ -47,38 +30,19 @@ class Generic:
         :return: A tuple containing (list of matching entities, next page offset)
         :rtype: tuple
         """
-        # Build the key prefix like risks does: #label#{filter}
-        key_prefix = f"#{label.lower()}#{filter_text or ''}"
-        return self.api.search.by_key_prefix(key_prefix, offset, pages)
+        return self.api.search.by_key_prefix(f"#{label.lower()}#{prefix_filter or ''}", offset, pages)
 
-    def add(self, label, entries):
+    def add(self, entries):
         """
-        Add entities with the given label and JSON entries.
+        Add a new object with the given JSON entries.
+        Currently only supports Assetlike objects.
 
-        :param label: The type/label of entities to add
-        :type label: str
         :param entries: Dictionary or list of dictionaries containing entity data
         :type entries: dict or list
         :return: The entities that were added
         :rtype: list
         """
-        if isinstance(entries, dict):
-            entries = [entries]
-        
-        results = []
-        for entry in entries:
-            # Add the type/label to the entry
-            entry_with_type = entry.copy()
-            entry_with_type['type'] = label
-            
-            # Use the /model endpoint for adding entities
-            result = self.api.upsert('model', entry_with_type)
-            if isinstance(result, list):
-                results.extend(result)
-            else:
-                results.append(result)
-        
-        return results
+        return self.api.upsert('model', entries)
 
     def get_schema(self, entity_type: str = None) -> dict:
         """Get schema information for entity types
@@ -95,12 +59,3 @@ class Generic:
                 return {}
             return {entity_type: result[entity_type]}
         return result
-    
-    def get_available_entity_types(self) -> list:
-        """Get list of all available entity types
-        
-        Returns:
-            list: Available entity type names
-        """
-        schema_data = self.get_schema()
-        return list(schema_data.keys()) if isinstance(schema_data, dict) else []

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -98,7 +98,7 @@ class Node:
         SEED = 'Seed'
         TTL = 'TTL'
 
-    def __init__(self, labels: list[Label] = None, filters: list[Filter] = None,
+    def __init__(self, labels: list[str] = None, filters: list[Filter] = None,
                  relationships: list[Relationship] = None):
         self.labels = labels
         self.filters = filters
@@ -107,7 +107,7 @@ class Node:
     def to_dict(self):
         ret = dict()
         if self.labels:
-            ret |= dict(labels=[x.value for x in self.labels])
+            ret |= dict(labels=self.labels)
         if self.filters:
             ret |= dict(filters=[x.to_dict() for x in self.filters])
         if self.relationships:
@@ -165,11 +165,11 @@ def key_equals(key: str):
 
 
 def risk_of_key(key: str):
-    return Node(RISK_NODE, filters=key_equals(key))
+    return Node([label.value for label in RISK_NODE], filters=key_equals(key))
 
 
 def asset_of_key(key: str):
-    return Node(ASSET_NODE, filters=key_equals(key))
+    return Node([label.value for label in ASSET_NODE], filters=key_equals(key))
 
 
 def get_graph_kind(key: str):
@@ -213,7 +213,7 @@ def my_params_to_query(params: dict):
     if not label:
         return None
 
-    node = Node(labels=[label], filters=[filter])
+    node = Node(labels=[label.value], filters=[filter])
 
     page = int(params.get('offset', 0))
     global_ = bool(params.get('global', False))

--- a/praetorian_cli/sdk/model/utils.py
+++ b/praetorian_cli/sdk/model/utils.py
@@ -1,5 +1,8 @@
 # This file largely mirror the model definitions in the model package in chariot-client.
 
+import click    
+
+
 def asset_key(dns, name):
     return f'#asset#{dns}#{name}'
 
@@ -35,3 +38,27 @@ def configuration_key(name):
 
 def seed_status(type, status_code):
     return f'{type}#{status_code}'
+
+
+def get_dict_from_entries(entry):
+    config_dict = {}
+    for item in entry:
+        if '=' not in item:
+            click.echo(f"Error: Entry '{item}' is not in the format key=value")
+            return
+
+        if item.count('=') > 1:
+            click.echo(f"Error: Entry '{item}' contains multiple '=' characters. Format should be key=value")
+            return
+
+        key, value = item.split('=', 1)
+
+        if not key:
+            click.echo("Error: Key cannot be empty")
+            return
+
+        if not value:
+            click.echo("Error: Value cannot be empty")
+            return
+
+        config_dict[key] = value

--- a/praetorian_cli/sdk/model/utils.py
+++ b/praetorian_cli/sdk/model/utils.py
@@ -1,7 +1,5 @@
 # This file largely mirror the model definitions in the model package in chariot-client.
 
-import click    
-
 
 def asset_key(dns, name):
     return f'#asset#{dns}#{name}'
@@ -38,27 +36,3 @@ def configuration_key(name):
 
 def seed_status(type, status_code):
     return f'{type}#{status_code}'
-
-
-def get_dict_from_entries(entry):
-    config_dict = {}
-    for item in entry:
-        if '=' not in item:
-            click.echo(f"Error: Entry '{item}' is not in the format key=value")
-            return
-
-        if item.count('=') > 1:
-            click.echo(f"Error: Entry '{item}' contains multiple '=' characters. Format should be key=value")
-            return
-
-        key, value = item.split('=', 1)
-
-        if not key:
-            click.echo("Error: Key cannot be empty")
-            return
-
-        if not value:
-            click.echo("Error: Value cannot be empty")
-            return
-
-        config_dict[key] = value


### PR DESCRIPTION
## Summary (required)

Adds fallback commands to allow for new types to be listed and 'get'ed without CLI changes. WIP

Also allow the schema to be queried / displayed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic CLI subcommands for add/get/list allowing runtime entity names (add supports repeated --field name:value pairs; get prints JSON for a key; list supports --filter and --details with pagination).
  * New schema command to list entity types or show full JSON schema with --details (optional --type to filter).
* **Enhancements**
  * Improved field parsing for commands using --field (better validation/error feedback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->