### PR TITLE
Assets API Tweak

### DIFF
--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -26,7 +26,7 @@ class Assets:
         :return: The asset that was added
         :rtype: dict
         """
-        return self.api.upsert('asset', dict(group=group, identifier=identifier, status=status, surface=[surface], type=type))[0]
+        return self.api.upsert('asset', dict(group=group, identifier=identifier, status=status, attackSurface=[surface], type=type))[0]
 
     def get(self, key, details=False):
         """
@@ -58,9 +58,7 @@ class Assets:
         :rtype: None
         """
         if status:
-            self.api.upsert('asset', dict(key=key, status=status))
-        if surface:
-            self.api.attributes.add(key, 'surface', surface)
+            self.api.upsert('asset', dict(key=key, status=status, attackSurface=[surface]))
 
     def delete(self, key):
         """

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -57,8 +57,13 @@ class Assets:
         :return: None
         :rtype: None
         """
+        params = dict(key=key)
         if status:
-            self.api.upsert('asset', dict(key=key, status=status, attackSurface=[surface]))
+            params = params | dict(status=status)
+        if surface:
+            params = params | dict(attackSurface=[surface])
+            
+        return self.api.upsert('asset', params)
 
     def delete(self, key):
         """

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -42,7 +42,7 @@ class TestAsset:
         assert any([a['group'] == self.asset_dns for a in deleted_assets])
     
     def test_add_ad_domain(self):
-        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_domain_sid, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
+        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_domain_name, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
         assert asset['key'] == self.ad_domain_key
         assert len(asset['attackSurface']) == 1
         assert 'test-surface' in asset['attackSurface']

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -14,8 +14,8 @@ class TestAsset:
     def test_add_asset(self):
         asset = self.sdk.assets.add(self.asset_dns, self.asset_name, status=Asset.ACTIVE.value, surface='test-surface')
         assert asset['key'] == self.asset_key
-        assert len(asset['surface']) == 1
-        assert asset['surface'][0] == 'test-surface'
+        assert len(asset['attackSurface']) == 1
+        assert 'test-surface' in asset['attackSurface']
         assert asset['status'] == Asset.ACTIVE.value
 
     def test_get_asset(self):
@@ -30,11 +30,10 @@ class TestAsset:
         assert any([a['group'] == self.asset_dns for a in results])
 
     def test_update_asset(self):
-        self.sdk.assets.update(self.asset_key, status=Asset.FROZEN.value)
-        assert self.get_asset()['status'] == Asset.FROZEN.value
-        self.sdk.assets.update(self.asset_key, surface='abc')
-        attributes = self.sdk.assets.attributes(self.asset_key)
-        assert any([a['name'] == 'surface' and a['value'] == 'abc' for a in attributes])
+        self.sdk.assets.update(self.asset_key, status=Asset.FROZEN.value, surface='abc')
+        asset = self.get_asset()
+        assert asset['status'] == Asset.FROZEN.value
+        assert 'abc' in asset['attackSurface']
 
     def test_delete_asset(self):
         self.sdk.assets.delete(self.asset_key)
@@ -43,10 +42,10 @@ class TestAsset:
         assert any([a['group'] == self.asset_dns for a in deleted_assets])
     
     def test_add_ad_domain(self):
-        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_domain_name, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
+        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_domain_sid, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
         assert asset['key'] == self.ad_domain_key
-        assert len(asset['surface']) == 1
-        assert asset['surface'][0] == 'test-surface'
+        assert len(asset['attackSurface']) == 1
+        assert 'test-surface' in asset['attackSurface']
         assert asset['status'] == Asset.ACTIVE.value
     
     def test_get_ad_domain(self):
@@ -61,11 +60,10 @@ class TestAsset:
         assert any([a['group'] == self.ad_domain_name for a in results])
     
     def test_update_ad_domain(self):
-        self.sdk.assets.update(self.ad_domain_key, status=Asset.FROZEN.value)
-        assert self.get_ad_domain()['status'] == Asset.FROZEN.value
-        self.sdk.assets.update(self.ad_domain_key, surface='abc')
-        attributes = self.sdk.assets.attributes(self.ad_domain_key)
-        assert any([a['name'] == 'surface' and a['value'] == 'abc' for a in attributes])
+        self.sdk.assets.update(self.ad_domain_key, status=Asset.FROZEN.value, surface='abc')
+        ad_domain = self.get_ad_domain()
+        assert ad_domain['status'] == Asset.FROZEN.value
+        assert 'abc' in ad_domain['attackSurface']
     
     def test_delete_ad_domain(self):
         self.sdk.assets.delete(self.ad_domain_key)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -33,7 +33,7 @@ class TestZCli:
 
         self.verify(f'update asset -s F "{o.asset_key}" -f internal')
         self.verify(f'get asset "{o.asset_key}" -d', [o.asset_key,
-                    f'"status": "{Asset.FROZEN.value}"', f'#surface#internal'])
+                    f'"status": "{Asset.FROZEN.value}"', '"internal"'])
 
         self.verify(f'delete asset "{o.asset_key}"')
         self.verify(f'get asset "{o.asset_key}"', [o.asset_key, f'"status": "{Asset.DELETED.value}"'])

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -27,16 +27,12 @@ def random_dns():
 def random_ad_domain():
     return f'test-{epoch_micro()}.local'
 
-def random_ad_sid():
-    return f'S-{epoch_micro()}'
-
 def make_test_values(o):
     o.asset_dns = random_dns()
     o.asset_name = random_ip()
     o.asset_key = asset_key(o.asset_dns, o.asset_name)
     o.ad_domain_name = random_ad_domain()
-    o.ad_domain_sid = random_ad_sid()
-    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_sid)
+    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_name)
     o.seed_dns = random_dns()
     o.seed_key = seed_key('domain', o.seed_dns)
     o.risk_name = f'test-risk-name-{epoch_micro()}'

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -27,12 +27,16 @@ def random_dns():
 def random_ad_domain():
     return f'test-{epoch_micro()}.local'
 
+def random_ad_sid():
+    return f'S-{epoch_micro()}'
+
 def make_test_values(o):
     o.asset_dns = random_dns()
     o.asset_name = random_ip()
     o.asset_key = asset_key(o.asset_dns, o.asset_name)
     o.ad_domain_name = random_ad_domain()
-    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_name)
+    o.ad_domain_sid = random_ad_sid()
+    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_sid)
     o.seed_dns = random_dns()
     o.seed_key = seed_key('domain', o.seed_dns)
     o.risk_name = f'test-risk-name-{epoch_micro()}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update an asset’s status and attack surface in a single command/call.
  * Asset details now use attackSurface (list) instead of surface.
* **Style**
  * CLI “get asset” details output updated: surface value now appears as a quoted string (e.g., "internal").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->