### PR TITLE
ARN fix for add-finding script

### DIFF
--- a/praetorian_cli/scripts/commands/add-finding.py
+++ b/praetorian_cli/scripts/commands/add-finding.py
@@ -262,7 +262,7 @@ class ManualAssetParser:
             return None
         
         # Last colon field becomes the asset name
-        asset_name = arn_parts[-1]
+        asset_name = ':'.join(arn_parts[5:])
         if not asset_name:
             click.echo("❌ Could not extract asset name from ARN (last colon field is empty)")
             return None


### PR DESCRIPTION
Fix asset naming so it doesn't use the revision number for ECS tasks.

<img width="656" height="205" alt="image" src="https://github.com/user-attachments/assets/e18e9645-a634-4f8b-8933-3cc634a538b6" />
