### PR TITLE
Generic Seeds (redo)

### DIFF
--- a/praetorian_cli/handlers/delete.py
+++ b/praetorian_cli/handlers/delete.py
@@ -88,11 +88,12 @@ def seed(chariot, key):
 
     \b
     Arguments:
-        - KEY: the key of an existing seed
+        - KEY: the key of an existing seed (now uses asset key format)
 
     \b
     Example usage:
-        - praetorian chariot delete seed "#seed#domain#example.com"
+        - praetorian chariot delete seed "#asset#domain#example.com"
+        - praetorian chariot delete seed "#addomain#corp.local"
     """
     chariot.seeds.delete(key)
 

--- a/praetorian_cli/handlers/delete.py
+++ b/praetorian_cli/handlers/delete.py
@@ -92,8 +92,8 @@ def seed(chariot, key):
 
     \b
     Example usage:
-        - praetorian chariot delete seed "#asset#domain#example.com"
-        - praetorian chariot delete seed "#addomain#corp.local"
+        - praetorian chariot delete seed "#asset#example.com#example.com"
+        - praetorian chariot delete seed "#addomain#corp.local#corp.local"
     """
     chariot.seeds.delete(key)
 

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -186,11 +186,12 @@ def seed(chariot, key):
 
     \b
     Argument:
-        - KEY: the key of an existing pre-seed
+        - KEY: the key of an existing seed (now uses asset key format)
 
     \b
     Example usages:
-        - praetorian chariot get preseed "#preseed#domain#example.com"
+        - praetorian chariot get seed "#asset#domain#example.com"
+        - praetorian chariot get seed "#addomain#corp.local"
     """
     print_json(chariot.seeds.get(key))
 

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -190,8 +190,8 @@ def seed(chariot, key):
 
     \b
     Example usages:
-        - praetorian chariot get seed "#asset#domain#example.com"
-        - praetorian chariot get seed "#addomain#corp.local"
+        - praetorian chariot get seed "#asset#example.com#example.com"
+        - praetorian chariot get seed "#addomain#corp.local#corp.local"
     """
     print_json(chariot.seeds.get(key))
 

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -162,7 +162,7 @@ def attributes(chariot, filter, key, details, offset, page):
 
 @list.command()
 @list_params('DNS')
-@click.option('-t', '--type', help='Filter by asset type (e.g., asset, addomain)')
+@click.option('-t', '--type', help='Filter by seed type (e.g., asset, addomain)')
 def seeds(chariot, type, filter, details, offset, page):
     """ List seeds
 

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -162,24 +162,23 @@ def attributes(chariot, filter, key, details, offset, page):
 
 @list.command()
 @list_params('DNS')
-@click.option('-t', '--type', type=click.Choice(['ip', 'domain']), help=f'Filter by type of the seeds')
+@click.option('-t', '--type', help='Filter by asset type (e.g., asset, addomain)')
 def seeds(chariot, type, filter, details, offset, page):
     """ List seeds
 
-   	Retrieve and display a list of seeds.
+   	Retrieve and display a list of seeds. Seeds are now assets with the 'Seed' label.
 
     \b
     Example usages:
         - praetorian chariot list seeds
-        - praetorian chariot list seeds --type ip
-        - praetorian chariot list seeds --type domain --filter example.com
+        - praetorian chariot list seeds --type asset
+        - praetorian chariot list seeds --type addomain
+        - praetorian chariot list seeds --type asset --filter example.com
         - praetorian chariot list seeds --details
         - praetorian chariot list seeds --page all
     """
-    if filter and not type:
-        error('When the DNS filter is specified, you also need to specify the type of the filter: ip or domain.')
-
-    render_list_results(chariot.seeds.list(type, filter, offset, pagination_size(page)), details)
+    # Note: filter restriction removed since we're using different key format now
+    render_list_results(chariot.seeds.list(type, filter, pagination_size(page)), details)
 
 
 @list.command()

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -71,7 +71,6 @@ def seed(chariot, key, status):
     
     chariot.seeds.update(key, status)
 
-
 @update.command()
 @cli_handler
 @click.argument('key', required=True)

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -67,6 +67,7 @@ def seed(chariot, key, status):
     Example usages:
         - praetorian chariot update seed "#asset#example.com#example.com" -s A
         - praetorian chariot update seed "#asset#1.1.1.0/24#1.1.1.0/24" -s F
+    """
     
     chariot.seeds.update(key, status)
 

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -65,9 +65,10 @@ def seed(chariot, key, status):
 
     \b
     Example usages:
-        - praetorian chariot update seed "#seed#domain#example.com" -s A
-        - praetorian chariot update seed "#seed#ip#1.1.1.0/24" -s F
+        - praetorian chariot update seed "#asset#example.com#1.2.3.4" -s A
+        - praetorian chariot update seed "#asset#1.1.1.0/24#1.1.1.0/24" -s F
     """
+    
     chariot.seeds.update(key, status)
 
 

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -65,9 +65,8 @@ def seed(chariot, key, status):
 
     \b
     Example usages:
-        - praetorian chariot update seed "#asset#example.com#1.2.3.4" -s A
+        - praetorian chariot update seed "#asset#example.com#example.com" -s A
         - praetorian chariot update seed "#asset#1.1.1.0/24#1.1.1.0/24" -s F
-    """
     
     chariot.seeds.update(key, status)
 

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -1,6 +1,6 @@
 from praetorian_cli.handlers.utils import error
 from praetorian_cli.sdk.model.globals import Seed, Kind
-from praetorian_cli.sdk.model.query import Query, Node, Filter
+from praetorian_cli.sdk.model.query import Query, Node, Filter, KIND_TO_LABEL
 
 
 class Seeds:
@@ -114,27 +114,31 @@ class Seeds:
         else:
             error(f'Seed {key} not found.')
 
-    def list(self, type=Kind.SEED.value, key_prefix='', pages=100000) -> tuple:
+    def list(self, seed_type=Kind.SEED.value, key_prefix='', pages=100000) -> tuple:
         """
         List seeds by querying assets with 'Seed' label.
         
-        :param type: Optional asset type filter (e.g., 'asset', 'addomain')
-        :type type: str or None
+        :param seed_type: Optional asset seed_type filter (e.g., 'asset', 'addomain')
+        :seed_type seed_type: str or None
         :param key_prefix: Filter by key prefix
-        :type key_prefix: str
+        :seed_type key_prefix: str
         :param offset: The offset of the page you want to retrieve results. If this is not supplied, this function retrieves from the first page
-        :type offset: str or None
+        :seed_type offset: str or None
         :param pages: The number of pages of results to retrieve. <mcp>Start with one page of results unless specifically requested.</mcp>
-        :type pages: int
+        :seed_type pages: int
         :return: A tuple containing (list of seeds, next page offset)
-        :rtype: tuple
+        :rseed_type: tuple
         """
-        if not type:
-            type = Kind.SEED.value
 
-        # Create a Node with Seed label and key filter
+        if seed_type in KIND_TO_LABEL:
+            seed_type = KIND_TO_LABEL[seed_type]
+        elif not seed_type:
+            seed_type = Node.Label.SEED
+        else:
+            seed_type = Node.Label.NOSUCHTYPE
+                    
         node = Node(
-            labels=[type],
+            labels=[seed_type],
             filters=[]
         )
 

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -135,7 +135,7 @@ class Seeds:
         elif not seed_type:
             seed_type = Node.Label.SEED
         else:
-            seed_type = Node.Label.NOSUCHTYPE
+            error(f'Invalid seed type: {seed_type}')
                     
         node = Node(
             labels=[seed_type],

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -37,7 +37,7 @@ class Seeds:
         """
         Get details of a seed by key.
 
-        :param key: Entity key (e.g., '#asset#example.com#1.2.3.4')
+        :param key: Entity key (e.g., '#asset#example.com#example.com')
         :type key: str
         :return: The seed matching the specified key, or None if not found
         :rtype: dict or None

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -136,7 +136,7 @@ class Seeds:
             seed_type = Node.Label.SEED
         else:
             error(f'Invalid seed type: {seed_type}')
-                    
+            return ([], None)
         node = Node(
             labels=[seed_type],
             filters=[]

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -69,7 +69,7 @@ class Seeds:
             return None
         return results[0]
 
-    def update(self, key, status=None, **kwargs):
+    def update(self, key, status=None):
         """
         Update seed fields dynamically.
         
@@ -137,6 +137,7 @@ class Seeds:
         else:
             error(f'Invalid seed type: {seed_type}')
             return ([], None)
+
         node = Node(
             labels=[seed_type],
             filters=[]

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -60,12 +60,14 @@ class Seeds:
         query = Query(node=node)
         
         # Call by_query with the constructed Query object
-        results = self.api.search.by_query(query)
+        results_tuple = self.api.search.by_query(query)
+        if not results_tuple:
+            return None
         
-        # Return the first result if found, otherwise None
-        if results and len(results) > 0:
-            return results[0]
-        return None
+        results, _ = results_tuple
+        if len(results) == 0:
+            return None
+        return results[0]
 
     def update(self, key, status=None, **kwargs):
         """
@@ -112,7 +114,7 @@ class Seeds:
         else:
             error(f'Seed {key} not found.')
 
-    def list(self, type=None, key_prefix='', pages=100000) -> tuple:
+    def list(self, type=Kind.SEED.value, key_prefix='', pages=100000) -> tuple:
         """
         List seeds by querying assets with 'Seed' label.
         
@@ -127,9 +129,13 @@ class Seeds:
         :return: A tuple containing (list of seeds, next page offset)
         :rtype: tuple
         """
+        if not type:
+            type = Kind.SEED.value
+
         # Create a Node with Seed label and key filter
         node = Node(
-            labels=[Node.Label.SEED]
+            labels=[type],
+            filters=[]
         )
 
         key_filter = Filter(

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -97,7 +97,6 @@ class Node:
         PRESEED = 'Preseed'
         SEED = 'Seed'
         TTL = 'TTL'
-        NOSUCHTYPE = 'Nosuchtype'
 
     def __init__(self, labels: list[Label] = None, filters: list[Filter] = None,
                  relationships: list[Relationship] = None):

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -97,6 +97,7 @@ class Node:
         PRESEED = 'Preseed'
         SEED = 'Seed'
         TTL = 'TTL'
+        NOSUCHTYPE = 'Nosuchtype'
 
     def __init__(self, labels: list[Label] = None, filters: list[Filter] = None,
                  relationships: list[Relationship] = None):

--- a/praetorian_cli/sdk/model/utils.py
+++ b/praetorian_cli/sdk/model/utils.py
@@ -15,14 +15,11 @@ def integration_key(dns, name):
 def risk_key(dns, name):
     return f'#risk#{dns}#{name}'
 
-
 def attribute_key(name, value, source_key):
     return f'#attribute#{name}#{value}{source_key}'
 
-
-def seed_key(type, dns):
-    return f'#seed#{type}#{dns}'
-
+def seed_asset_key(dns):
+    return f'#asset#{dns}#{dns}'
 
 def preseed_key(type, title, value):
     return f'#preseed#{type}#{title}#{value}'
@@ -32,6 +29,3 @@ def setting_key(name):
 
 def configuration_key(name):
     return f'#configuration#{name}'
-
-def seed_status(type, status_code):
-    return f'{type}#{status_code}'

--- a/praetorian_cli/sdk/test/test_seed.py
+++ b/praetorian_cli/sdk/test/test_seed.py
@@ -1,7 +1,6 @@
 import pytest
 
-from praetorian_cli.sdk.model.globals import Seed
-from praetorian_cli.sdk.model.utils import seed_status
+from praetorian_cli.sdk.model.globals import Seed, Kind
 from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
 
 
@@ -12,30 +11,30 @@ class TestSeed:
         self.sdk = setup_chariot()
         make_test_values(self)
 
-    def test_add_seed(self):
-        seed = self.sdk.seeds.add(self.seed_dns)
-        assert seed['key'] == self.seed_key
+    def test_add_asset_seed(self):
+        seed = self.sdk.seeds.add(dns=self.seed_asset_dns)
+        assert seed['key'] == self.seed_asset_key
 
     def test_get_seed(self):
         a = self.get_seed()
-        assert a['dns'] == self.seed_dns
-        assert a['status'] == seed_status('domain', Seed.PENDING.value)
+        assert a['dns'] == self.seed_asset_dns
+        assert a['status'] == Seed.PENDING.value
 
     def test_list_seed(self):
-        results, _ = self.sdk.seeds.list('domain', self.seed_dns)
+        results, _ = self.sdk.seeds.list(Kind.ASSET.value, f"#asset#{self.seed_asset_dns}")
         assert len(results) == 1
-        assert results[0]['dns'] == self.seed_dns
+        assert results[0]['dns'] == self.seed_asset_dns
 
     def test_update_seed(self):
-        self.sdk.seeds.update(self.seed_key, Seed.ACTIVE.value)
-        assert self.get_seed()['status'] == seed_status('domain', Seed.ACTIVE.value)
+        self.sdk.seeds.update(self.seed_asset_key, Seed.ACTIVE.value)
+        assert self.get_seed()['status'] == Seed.ACTIVE.value
 
     def test_delete_seed(self):
-        self.sdk.seeds.delete(self.seed_key)
-        assert self.sdk.seeds.get(self.seed_key)['status'] == seed_status('domain', Seed.DELETED.value)
+        self.sdk.seeds.delete(self.seed_asset_key)
+        assert self.sdk.seeds.get(self.seed_asset_key)['status'] == Seed.DELETED.value
 
     def get_seed(self):
-        return self.sdk.seeds.get(self.seed_key)
+        return self.sdk.seeds.get(self.seed_asset_key)
 
     def teardown_class(self):
         clean_test_entities(self.sdk, self)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -50,7 +50,7 @@ class TestZCli:
         self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -p first', [o.seed_asset_key])
         self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -p all', [o.seed_asset_key])
         self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -d', [o.seed_asset_dns, '"key"', '"data"'])
-        self.verify(f'list seeds -t notatype -f "#asset#{o.seed_asset_dns}"')
+        self.verify(f'list seeds -t notatype -f "#asset#{o.seed_asset_dns}"', [], ['Invalid seed type: notatype'])
         self.verify(f'list seeds -f "#asset#{o.seed_asset_dns}"', [o.seed_asset_key])
 
         self.verify(f'list seeds -t asset -f {epoch_micro()}')

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -5,7 +5,6 @@ from subprocess import run
 import pytest
 
 from praetorian_cli.sdk.model.globals import AddRisk, Asset, Risk, Seed, Preseed
-from praetorian_cli.sdk.model.utils import seed_status
 from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, make_test_values, clean_test_entities, setup_chariot
 
 
@@ -43,30 +42,29 @@ class TestZCli:
     def test_seed_cli(self):
         o = make_test_values(lambda: None)
 
-        self.verify(f'add seed -d {o.seed_dns}')
+        self.verify(f'add seed --field dns:{o.seed_asset_dns}')
 
-        self.verify('list seeds -p all', [o.seed_key])
-        self.verify('list seeds -t domain -p all', [o.seed_key])
-        self.verify(f'list seeds -t domain -f "{o.seed_dns}"', [o.seed_key])
-        self.verify(f'list seeds -t domain -f "{o.seed_dns}" -p first', [o.seed_key])
-        self.verify(f'list seeds -t domain -f "{o.seed_dns}" -p all', [o.seed_key])
-        self.verify(f'list seeds -t domain -f "{o.seed_dns}" -p first', [o.seed_key])
-        self.verify(f'list seeds -t domain -f "{o.seed_dns}" -d', [o.seed_dns, '"key"', '"data"'])
-        self.verify(f'list seeds -t ip -f "{o.seed_dns}"')
-        self.verify(f'list seeds -f "{o.seed_dns}"', [],
+        self.verify('list seeds -p all', [o.seed_asset_key])
+        self.verify('list seeds -t asset -p all', [o.seed_asset_key])
+        self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}"', [o.seed_asset_key])
+        self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -p first', [o.seed_asset_key])
+        self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -p all', [o.seed_asset_key])
+        self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -d', [o.seed_asset_dns, '"key"', '"data"'])
+        self.verify(f'list seeds -t notatype -f "#asset#{o.seed_asset_dns}"')
+        self.verify(f'list seeds -f "#asset#{o.seed_asset_dns}"', [],
                     ["When the DNS filter is specified, you also need to specify the type of the filter"])
 
-        self.verify(f'list seeds -t domain -f {epoch_micro()}')
+        self.verify(f'list seeds -t asset -f {epoch_micro()}')
 
-        self.verify(f'get seed "{o.seed_key}"',
-                    [o.seed_key, f'"status": "{seed_status("domain", Seed.PENDING.value)}"'])
+        self.verify(f'get seed "{o.seed_asset_key}"',
+                    [o.seed_asset_key, f'"status": "{Seed.PENDING.value}"'])
 
-        self.verify(f'update seed -s {Seed.ACTIVE.value} "{o.seed_key}"')
-        self.verify(f'get seed "{o.seed_key}"',
-                    [o.seed_key, f'"status": "{seed_status("domain", Seed.ACTIVE.value)}"'])
+        self.verify(f'update seed -s {Seed.ACTIVE.value} "{o.seed_asset_key}"')
+        self.verify(f'get seed "{o.seed_asset_key}"',
+                    [o.seed_asset_key, f'"status": "{Seed.ACTIVE.value}"'])
 
-        self.verify(f'delete seed "{o.seed_key}"')
-        self.verify(f'get seed "{o.seed_key}"', [f'"status": "{seed_status("domain", Seed.DELETED.value)}"'])
+        self.verify(f'delete seed "{o.seed_asset_key}"')
+        self.verify(f'get seed "{o.seed_asset_key}"', [f'"status": "{Seed.DELETED.value}"'])
 
         clean_test_entities(self.sdk, o)
 
@@ -75,12 +73,12 @@ class TestZCli:
 
         self.verify(f'add preseed -t {o.preseed_type} -l {o.preseed_title} -v {o.preseed_value} -s {o.preseed_status}')
 
-        self.verify(f'list preseeds -p all', [o.preseed_key])
+        self.verify(f'list preseeds -p all', [o.preseed_asset_key])
 
-        self.verify(f'update preseed -s {Preseed.FROZEN.value} "{o.preseed_key}"')
-        self.verify(f'get preseed "{o.preseed_key}"', [o.preseed_key, f'"status": "{Preseed.FROZEN.value}"'])
+        self.verify(f'update preseed -s {Preseed.FROZEN.value} "{o.preseed_asset_key}"')
+        self.verify(f'get preseed "{o.preseed_asset_key}"', [o.preseed_asset_key, f'"status": "{Preseed.FROZEN.value}"'])
 
-        self.verify(f'get preseed "{o.preseed_key}" --details', [o.preseed_key, f'"status": "{Preseed.FROZEN.value}"'])
+        self.verify(f'get preseed "{o.preseed_asset_key}" --details', [o.preseed_asset_key, f'"status": "{Preseed.FROZEN.value}"'])
 
         clean_test_entities(self.sdk, o)
 

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -51,8 +51,7 @@ class TestZCli:
         self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -p all', [o.seed_asset_key])
         self.verify(f'list seeds -t asset -f "#asset#{o.seed_asset_dns}" -d', [o.seed_asset_dns, '"key"', '"data"'])
         self.verify(f'list seeds -t notatype -f "#asset#{o.seed_asset_dns}"')
-        self.verify(f'list seeds -f "#asset#{o.seed_asset_dns}"', [],
-                    ["When the DNS filter is specified, you also need to specify the type of the filter"])
+        self.verify(f'list seeds -f "#asset#{o.seed_asset_dns}"', [o.seed_asset_key])
 
         self.verify(f'list seeds -t asset -f {epoch_micro()}')
 
@@ -73,12 +72,12 @@ class TestZCli:
 
         self.verify(f'add preseed -t {o.preseed_type} -l {o.preseed_title} -v {o.preseed_value} -s {o.preseed_status}')
 
-        self.verify(f'list preseeds -p all', [o.preseed_asset_key])
+        self.verify(f'list preseeds -p all', [o.preseed_key])
 
-        self.verify(f'update preseed -s {Preseed.FROZEN.value} "{o.preseed_asset_key}"')
-        self.verify(f'get preseed "{o.preseed_asset_key}"', [o.preseed_asset_key, f'"status": "{Preseed.FROZEN.value}"'])
+        self.verify(f'update preseed -s {Preseed.FROZEN.value} "{o.preseed_key}"')
+        self.verify(f'get preseed "{o.preseed_key}"', [o.preseed_key, f'"status": "{Preseed.FROZEN.value}"'])
 
-        self.verify(f'get preseed "{o.preseed_asset_key}" --details', [o.preseed_asset_key, f'"status": "{Preseed.FROZEN.value}"'])
+        self.verify(f'get preseed "{o.preseed_key}" --details', [o.preseed_key, f'"status": "{Preseed.FROZEN.value}"'])
 
         clean_test_entities(self.sdk, o)
 

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -5,7 +5,7 @@ from random import randint
 from praetorian_cli.sdk.chariot import Chariot
 from praetorian_cli.sdk.keychain import Keychain
 from praetorian_cli.sdk.model.globals import Risk, Preseed
-from praetorian_cli.sdk.model.utils import risk_key, asset_key, ad_domain_key, attribute_key, seed_key, preseed_key, setting_key, configuration_key
+from praetorian_cli.sdk.model.utils import risk_key, asset_key, ad_domain_key, attribute_key, seed_asset_key, preseed_key, setting_key, configuration_key
 
 
 def epoch_micro():
@@ -33,8 +33,8 @@ def make_test_values(o):
     o.asset_key = asset_key(o.asset_dns, o.asset_name)
     o.ad_domain_name = random_ad_domain()
     o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_name)
-    o.seed_dns = random_dns()
-    o.seed_key = seed_key('domain', o.seed_dns)
+    o.seed_asset_dns = random_dns()
+    o.seed_asset_key = seed_asset_key(o.seed_asset_dns)
     o.risk_name = f'test-risk-name-{epoch_micro()}'
     o.risk_key = risk_key(o.asset_dns, o.risk_name)
     o.comment = f'Test comment {epoch_micro()}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Seed command supports typed asset seeds with --type (default: asset) and repeatable --field name:value pairs for dynamic attributes.

- **Refactor**
  - Seeds are redefined as assets with asset-key format; listing/filtering adapted to asset-style keys and no longer enforces previous type/offset guards.

- **Documentation**
  - CLI help, examples and docstrings updated to show new --type/--field syntax and asset-key usage.

- **Tests**
  - Test suite updated to an asset-centric workflow and adjusted expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->