### PR TITLE
Add Seed Tweaks

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -212,7 +212,7 @@ def seed(sdk, seed_type, status, field_list):
         - praetorian chariot add seed --type asset --field dns:example.com
         - praetorian chariot add seed --type asset --field dns:example.com --status A
         - praetorian chariot add seed --type asset --field dns:example.com --field name:1.2.3.4
-        - praetorian chariot add seed --type addomain --field name:corp.local --field netbios_name:CORP
+        - praetorian chariot add seed --type addomain --field domain:corp.local --field objectid:S-1-5-21-2701466056-1043032755-2418290285
     """
     # Collect dynamic fields from the --fields option
     dynamic_fields = {}

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -70,25 +70,15 @@ class Chariot:
             kwargs['proxies'] = {'http': self.proxy, 'https': self.proxy}
             kwargs['verify'] = False
         
-        self._add_beta_filter(method, kwargs)
+        self.add_beta_url_param(kwargs)
 
         return requests.request(method, url, headers=self.keychain.headers(), **kwargs)
 
-    def _add_beta_filter(self, method: str, kwargs: dict):
-        if method == 'GET' or method == 'DELETE':
-            self._add_beta_url_param(kwargs)
-        else:
-            self._add_beta_json_param(kwargs)
-
-    def _add_beta_url_param(self, kwargs: dict):
+    def add_beta_url_param(self, kwargs: dict):
         if 'params' in kwargs:
             kwargs['params']['beta'] = 'true'
         else:
             kwargs['params'] = {'beta': 'true'}
-
-    def _add_beta_json_param(self, kwargs: dict):
-        if 'json' in kwargs:
-            kwargs['json']['beta'] = True
 
     def my(self, params: dict, pages=1) -> dict:
         final_resp = dict()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent beta handling across all API requests via URL parameter, improving reliability and compatibility with endpoints.

- Documentation
  - Updated CLI example for “praetorian chariot add seed” (type: addomain) to use the new dynamic fields: domain and objectid (e.g., domain:corp.local, objectid:S-1-5-21-...).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->