### PR TITLE
list assets tweak

### DIFF
--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -26,7 +26,7 @@ def assets(chariot, filter, model_type, details, offset, page):
         - praetorian chariot list assets --page all
         - praetorian chariot list assets --type repository
     """
-    render_list_results(chariot.assets.list(filter, model_type, offset, pagination_size(page)), details)
+    render_list_results(chariot.assets.list(filter, model_type, pagination_size(page)), details)
 
 
 @list.command()

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -98,8 +98,7 @@ class Assets:
         elif not asset_type:
             asset_type = Node.Label.ASSET
         else:
-            error(f'Invalid asset type: {asset_type}')
-            return ([], None)
+            raise ValueError(f'Invalid asset type: {asset_type}')
 
         node = Node(
             labels=[asset_type],

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -135,8 +135,7 @@ class Seeds:
         elif not seed_type:
             seed_type = Node.Label.SEED
         else:
-            error(f'Invalid seed type: {seed_type}')
-            return ([], None)
+            raise ValueError(f'Invalid seed type: {seed_type}')
 
         node = Node(
             labels=[seed_type],

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -91,7 +91,7 @@ class Node:
         ASSET = 'Asset'
         REPOSITORY = 'Repository'
         INTEGRATION = 'Integration'
-        ADDOMAIN = 'Addomain'
+        ADDOMAIN = 'ADDomain'
         ATTRIBUTE = 'Attribute'
         RISK = 'Risk'
         PRESEED = 'Preseed'

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -42,7 +42,7 @@ class TestAsset:
         assert any([a['group'] == self.asset_dns for a in deleted_assets])
     
     def test_add_ad_domain(self):
-        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_domain_name, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
+        asset = self.sdk.assets.add(self.ad_domain_name, self.ad_object_id, status=Asset.ACTIVE.value, surface='test-surface', type=Kind.ADDOMAIN.value)
         assert asset['key'] == self.ad_domain_key
         assert len(asset['attackSurface']) == 1
         assert 'test-surface' in asset['attackSurface']
@@ -51,7 +51,7 @@ class TestAsset:
     def test_get_ad_domain(self):
         asset = self.sdk.assets.get(self.ad_domain_key)
         assert asset['key'] == self.ad_domain_key
-        assert asset['name'] == self.ad_domain_name
+        assert asset['domain'] == self.ad_domain_name
         assert asset['status'] == Asset.ACTIVE.value
     
     def test_list_ad_domain(self):

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -20,11 +20,12 @@ class TestZCli:
         self.verify(f'add asset -n {o.asset_name} -d {o.asset_dns}')
 
         self.verify('list assets -p all', [o.asset_key])
-        self.verify(f'list assets -f "{o.asset_dns}"', [o.asset_key])
-        self.verify(f'list assets -f "{o.asset_dns}" -p first', [o.asset_key])
-        self.verify(f'list assets -f "{o.asset_dns}" -p all', [o.asset_key])
-        self.verify(f'list assets -f "{o.asset_dns}" -d', [o.asset_key, '"key"', '"data"'])
+        self.verify(f'list assets -f "#asset#{o.asset_dns}"', [o.asset_key])
+        self.verify(f'list assets -f "#asset#{o.asset_dns}" -p first', [o.asset_key])
+        self.verify(f'list assets -f "#asset#{o.asset_dns}" -p all', [o.asset_key])
+        self.verify(f'list assets -f "#asset#{o.asset_dns}" -d', [o.asset_key, '"key"', '"data"'])
 
+        self.verify(f'list assets -f "#asset#{epoch_micro()}"')
         self.verify(f'list assets -f {epoch_micro()}')
 
         self.verify(f'get asset "{o.asset_key}"', [o.asset_key, f'"status": "{Asset.ACTIVE.value}"'])

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -27,12 +27,24 @@ def random_dns():
 def random_ad_domain():
     return f'test-{epoch_micro()}.local'
 
+def random_object_id():
+    domain_id_1 = randint(1000000000, 4294967295)  # Start from 1 billion for realism
+    domain_id_2 = randint(1000000000, 4294967295)
+    domain_id_3 = randint(1000000000, 4294967295)
+
+    # Generate a random relative identifier (RID)
+    # Common ranges: 500-999 for built-in accounts, 1000+ for user accounts
+    relative_id = randint(1000, 999999)
+    return f"S-1-5-21-{domain_id_1}-{domain_id_2}-{domain_id_3}-{relative_id}"
+
+
 def make_test_values(o):
     o.asset_dns = random_dns()
     o.asset_name = random_ip()
     o.asset_key = asset_key(o.asset_dns, o.asset_name)
     o.ad_domain_name = random_ad_domain()
-    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_domain_name)
+    o.ad_object_id = random_object_id()
+    o.ad_domain_key = ad_domain_key(o.ad_domain_name, o.ad_object_id)
     o.seed_asset_dns = random_dns()
     o.seed_asset_key = seed_asset_key(o.seed_asset_dns)
     o.risk_name = f'test-risk-name-{epoch_micro()}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Asset filtering accepts “#asset#” hashed prefix and key-prefix queries for more precise listings.

- Refactor
  - Listing now pages by key-prefix-based queries (offset removed).
  - AD domain assets expose a domain field and adding now requires domain_name + object_id.
  - AD domain label normalized to “ADDomain”.

- Chores
  - CLI tests and flows updated to use “-f #asset#<value>”; unhashed filters still supported.

- Bug Fixes
  - Invalid seed types now produce a clear error instead of silent failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->