### PR TITLE
facilitate retrieval of global definition files

### DIFF
--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -147,7 +147,8 @@ def file(chariot, name, path):
 @cli_handler
 @click.argument('name')
 @click.option('-path', '--path', default=os.getcwd(), help='Download path. Default: save to current directory')
-def definition(chariot, name, path):
+@click.option('--global', 'global_', is_flag=True, help='Fetch from global definitions instead of user-specific')
+def definition(chariot, name, path, global_):
     """ Download a definition using the risk name
 
     \b
@@ -158,8 +159,9 @@ def definition(chariot, name, path):
     Example usage:
         - praetorian chariot get definition jira-unauthenticated-user-picker
         - praetorian chariot get definition CVE-2024-23049
+        - praetorian chariot get definition CVE-2024-23049 --global
      """
-    downloaded_path = chariot.definitions.get(name, path)
+    downloaded_path = chariot.definitions.get(name, path, global_=global_)
     click.echo(f'Saved definition at {downloaded_path}')
 
 

--- a/praetorian_cli/sdk/entities/definitions.py
+++ b/praetorian_cli/sdk/entities/definitions.py
@@ -54,6 +54,26 @@ class Definitions:
             file.write(content)
         return download_path
 
+    def get_content(self, definition_name, global_=False) -> str:
+        """
+        Download a risk definition file content into memory as UTF-8 string.
+
+        :param definition_name: The name of the definition file to download
+        :type definition_name: str
+        :param global_: If True, fetch from global definitions instead of user-specific
+        :type global_: bool
+        :return: The definition content as UTF-8 string
+        :rtype: str
+        :raises Exception: If the definition does not exist
+        """
+        if global_:
+            try:
+                return self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
+            except Exception as e:
+                raise Exception(f'Global definition {definition_name} not found or inaccessible.')
+        else:
+            return self.api.files.get_utf8(f'definitions/{definition_name}')
+
     def list(self, name_filter='', offset=None, pages=100000) -> tuple:
         """
         List the definition names, optionally prefix-filtered by a definition name.

--- a/praetorian_cli/sdk/entities/definitions.py
+++ b/praetorian_cli/sdk/entities/definitions.py
@@ -42,37 +42,18 @@ class Definitions:
         :return: The local file path where the definition was saved
         :rtype: str
         """
-        if global_:
-            try:
-                content = self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
-            except Exception as e:
+        try:
+            content = self.api.files.get_utf8(f'definitions/{definition_name}', _global=global_)
+        except Exception as e:
+            if global_:
                 raise Exception(f'Global definition {definition_name} not found or inaccessible.')
-        else:
-            content = self.api.files.get_utf8(f'definitions/{definition_name}')
+            else:
+                raise
         download_path = os.path.join(download_directory, definition_name)
         with open(download_path, 'w') as file:
             file.write(content)
         return download_path
 
-    def get_content(self, definition_name, global_=False) -> str:
-        """
-        Download a risk definition file content into memory as UTF-8 string.
-
-        :param definition_name: The name of the definition file to download
-        :type definition_name: str
-        :param global_: If True, fetch from global definitions instead of user-specific
-        :type global_: bool
-        :return: The definition content as UTF-8 string
-        :rtype: str
-        :raises Exception: If the definition does not exist
-        """
-        if global_:
-            try:
-                return self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
-            except Exception as e:
-                raise Exception(f'Global definition {definition_name} not found or inaccessible.')
-        else:
-            return self.api.files.get_utf8(f'definitions/{definition_name}')
 
     def list(self, name_filter='', offset=None, pages=100000) -> tuple:
         """

--- a/praetorian_cli/sdk/entities/definitions.py
+++ b/praetorian_cli/sdk/entities/definitions.py
@@ -43,7 +43,10 @@ class Definitions:
         :rtype: str
         """
         if global_:
-            content = self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
+            try:
+                content = self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
+            except Exception as e:
+                raise Exception(f'Global definition {definition_name} not found or inaccessible.')
         else:
             content = self.api.files.get_utf8(f'definitions/{definition_name}')
         download_path = os.path.join(download_directory, definition_name)

--- a/praetorian_cli/sdk/entities/definitions.py
+++ b/praetorian_cli/sdk/entities/definitions.py
@@ -29,7 +29,7 @@ class Definitions:
             definition_name = os.path.basename(local_filepath)
         return self.api.files.add(local_filepath, f'definitions/{definition_name}')
 
-    def get(self, definition_name, download_directory=os.getcwd()):
+    def get(self, definition_name, download_directory=os.getcwd(), global_=False):
         """
         Download a risk definition file from the definitions folder.
 
@@ -37,10 +37,15 @@ class Definitions:
         :type definition_name: str
         :param download_directory: The directory to save the downloaded file (defaults to current working directory)
         :type download_directory: str
+        :param global_: If True, fetch from global definitions instead of user-specific
+        :type global_: bool
         :return: The local file path where the definition was saved
         :rtype: str
         """
-        content = self.api.files.get_utf8(f'definitions/{definition_name}')
+        if global_:
+            content = self.api.download(f'definitions/{definition_name}', global_=True).decode('utf-8')
+        else:
+            content = self.api.files.get_utf8(f'definitions/{definition_name}')
         download_path = os.path.join(download_directory, definition_name)
         with open(download_path, 'w') as file:
             file.write(content)

--- a/praetorian_cli/sdk/entities/files.py
+++ b/praetorian_cli/sdk/entities/files.py
@@ -46,30 +46,35 @@ class Files:
 
         return download_path
 
-    def get(self, chariot_filepath) -> bytes:
+    def get(self, chariot_filepath, _global=False) -> bytes:
         """
         Download a file from Chariot storage into memory as bytes.
 
         :param chariot_filepath: Path of the file in Chariot storage to download
         :type chariot_filepath: str
+        :param _global: If True, fetch from global storage instead of user-specific
+        :type _global: bool
         :return: The file content as bytes
         :rtype: bytes
         :raises Exception: If the file does not exist in Chariot storage
         """
-        self.raise_if_missing(chariot_filepath)
-        return self.api.download(chariot_filepath)
+        if not _global:
+            self.raise_if_missing(chariot_filepath)
+        return self.api.download(chariot_filepath, global_=_global)
 
-    def get_utf8(self, chariot_filepath) -> str:
+    def get_utf8(self, chariot_filepath, _global=False) -> str:
         """
         Download a file from Chariot storage into memory as a UTF-8 string.
 
         :param chariot_filepath: Path of the file in Chariot storage to download
         :type chariot_filepath: str
+        :param _global: If True, fetch from global storage instead of user-specific
+        :type _global: bool
         :return: The file content as a UTF-8 decoded string
         :rtype: str
         :raises Exception: If the file does not exist in Chariot storage
         """
-        return self.get(chariot_filepath).decode('utf-8')
+        return self.get(chariot_filepath, _global=_global).decode('utf-8')
 
     def list(self, prefix_filter='', offset=None, pages=100000) -> tuple:
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --global flag to the get definition command to fetch global definitions.
  * Added a new API method to retrieve definition content directly into memory.

* **Documentation**
  * Updated command examples and docstrings to document --global usage and the new content-retrieval method.

* **Improvements**
  * Added explicit error handling for global fetches and ensured UTF-8 decoding of retrieved content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->