### PR TITLE
feat: Add support for PRAETORIAN_CLI_API and PRAETORIAN_CLI_CLIENT_ID environment variables

### DIFF
--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -65,13 +65,16 @@ class Keychain:
             error(f'Could not find the "{self.profile}" profile in {self.filepath}. Run "praetorian configure" to fix.')
 
         profile = self.config[self.profile]
-        if 'api' not in profile or 'client_id' not in profile:
-            error(f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
-
+        
         self.load_env('username', 'PRAETORIAN_CLI_USERNAME', required=False)
         self.load_env('password', 'PRAETORIAN_CLI_PASSWORD', required=False)
         self.load_env(API_KEY_ID, 'PRAETORIAN_CLI_API_KEY_ID', required=False)
         self.load_env(API_KEY_SECRET, 'PRAETORIAN_CLI_API_KEY_SECRET', required=False)
+        self.load_env('api', 'PRAETORIAN_CLI_API', required=False)
+        self.load_env('client_id', 'PRAETORIAN_CLI_CLIENT_ID', required=False)
+        
+        if 'api' not in profile or 'client_id' not in profile:
+            error(f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
 
         if self.account is None:
             self.account = self.config.get(self.profile, 'account', fallback=None)


### PR DESCRIPTION
- Add load_env calls for 'api' and 'client_id' configuration
- Move environment variable loading before profile validation
- Environment variables now take precedence over keychain file for all config
- Enables fully environment-driven configuration for agent workflows

## Summary (required)

Briefly describe the changes and the issue it addresses. It helps the reviewers understand the context.

## JIRA (required)

- Add reference to the JIRA ticket. It helps connect JIRA with this PR.
