### PR TITLE
feat(aegis): add scheduled jobs, credential UUID passthrough, and UX improvements

### DIFF
--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -16,6 +16,7 @@ from praetorian_cli.sdk.entities.keys import Keys
 from praetorian_cli.sdk.entities.preseeds import Preseeds
 from praetorian_cli.sdk.entities.risks import Risks
 from praetorian_cli.sdk.entities.scanners import Scanners
+from praetorian_cli.sdk.entities.schedules import Schedules
 from praetorian_cli.sdk.entities.schema import Schema
 from praetorian_cli.sdk.entities.search import Search
 from praetorian_cli.sdk.entities.seeds import Seeds
@@ -55,6 +56,7 @@ class Chariot:
         self.credentials = Credentials(self)
         self.webpage = Webpage(self)
         self.schema = Schema(self)
+        self.schedules = Schedules(self)
         self.proxy = proxy
 
         if self.proxy == '' and os.environ.get('CHARIOT_PROXY'):
@@ -156,6 +158,11 @@ class Chariot:
 
     def delete(self, type: str, body: dict, params: dict) -> dict:
         resp = self.chariot_request('DELETE', self.url(f'/{type}'), json=body, params=params)
+        process_failure(resp)
+        return resp.json()
+
+    def patch(self, type: str, body: dict = None, params: dict = None) -> dict:
+        resp = self.chariot_request('PATCH', self.url(f'/{type}'), json=body or {}, params=params or {})
         process_failure(resp)
         return resp.json()
 

--- a/praetorian_cli/sdk/entities/jobs.py
+++ b/praetorian_cli/sdk/entities/jobs.py
@@ -8,7 +8,7 @@ class Jobs:
     def __init__(self, api):
         self.api = api
 
-    def add(self, target_key, capabilities=[], config=None, credentials=[]):
+    def add(self, target_key, capabilities=None, config=None, credentials=None):
         """
         Add a job to execute capabilities against an asset or attribute.
 

--- a/praetorian_cli/sdk/entities/schedules.py
+++ b/praetorian_cli/sdk/entities/schedules.py
@@ -1,0 +1,233 @@
+"""SDK entity for capability schedules."""
+
+import re
+from typing import Optional
+
+_SCHEDULE_ID_RE = re.compile(r'^[a-f0-9\-]+$', re.IGNORECASE)
+
+
+def _validate_schedule_id(schedule_id: str) -> str:
+    if not schedule_id or not _SCHEDULE_ID_RE.match(schedule_id):
+        raise ValueError(f"Invalid schedule_id format: {schedule_id!r}")
+    return schedule_id
+
+
+class Schedules:
+    """The methods in this class are to be accessed from sdk.schedules, where sdk
+    is an instance of Chariot."""
+
+    def __init__(self, api):
+        self.api = api
+
+    def list(self, pages=1) -> tuple:
+        """
+        List all capability schedules for the current user.
+
+        Retrieves all scheduled capability executions, returning them with
+        detailed information including schedule configuration, next execution
+        time, and status.
+
+        :param pages: Maximum number of pages to retrieve (default: 1)
+        :type pages: int
+        :return: A tuple containing (list of schedule objects, next page offset)
+        :rtype: tuple
+
+        **Example Usage:**
+            >>> # List all schedules
+            >>> schedules, _ = sdk.schedules.list()
+
+            >>> # Check schedule properties
+            >>> for schedule in schedules:
+            >>>     print(f"Schedule: {schedule['scheduleId']}")
+            >>>     print(f"Capability: {schedule['capabilityName']}")
+            >>>     print(f"Status: {schedule['status']}")
+            >>>     print(f"Next: {schedule.get('nextExecution', 'N/A')}")
+
+        **Schedule Object Properties:**
+            - scheduleId: Unique identifier for the schedule
+            - capabilityName: Name of the capability to execute
+            - targetKey: Target asset key
+            - status: Schedule status (active, paused, expired)
+            - weeklySchedule: Weekly execution configuration
+            - nextExecution: Next calculated execution time
+            - lastExecution: Last execution timestamp
+        """
+        params = {'key': '#capability_schedule#'}
+        resp = self.api.my(params, pages=pages)
+        schedules = resp.get('capabilityschedules', [])
+        offset = resp.get('offset')
+        return schedules, offset
+
+    def get(self, schedule_id: str) -> Optional[dict]:
+        """
+        Get a specific schedule by its ID.
+
+        :param schedule_id: The unique schedule identifier
+        :type schedule_id: str
+        :return: Schedule object if found, None if not found
+        :rtype: dict or None
+
+        **Example Usage:**
+            >>> # Get specific schedule
+            >>> schedule = sdk.schedules.get("abc123-def456")
+            >>> if schedule:
+            >>>     print(f"Found schedule: {schedule['capabilityName']}")
+        """
+        key = f'#capability_schedule#{schedule_id}'
+        return self.api.search.by_exact_key(key)
+
+    def create(self, capability_name: str, target_key: str, weekly_schedule: dict,
+               start_date: str, end_date: str = None, config: dict = None,
+               client_id: str = None) -> dict:
+        """
+        Create a new capability schedule.
+
+        Creates a scheduled execution for a capability that will run on specified
+        days and times.
+
+        :param capability_name: Name of the capability to execute
+        :type capability_name: str
+        :param target_key: Target asset key (e.g., '#asset#hostname#hostname')
+        :type target_key: str
+        :param weekly_schedule: Weekly schedule configuration with day schedules
+        :type weekly_schedule: dict
+        :param start_date: Start date in RFC3339 format (e.g., '2024-01-15T00:00:00Z')
+        :type start_date: str
+        :param end_date: Optional end date in RFC3339 format
+        :type end_date: str or None
+        :param config: Optional capability configuration parameters
+        :type config: dict or None
+        :param client_id: Optional Aegis client ID for Aegis capabilities
+        :type client_id: str or None
+        :return: Created schedule object
+        :rtype: dict
+
+        **Example Usage:**
+            >>> # Create a schedule that runs Monday and Friday at 10:00 UTC
+            >>> weekly = {
+            >>>     'monday': {'enabled': True, 'time': '10:00'},
+            >>>     'tuesday': {'enabled': False, 'time': ''},
+            >>>     'wednesday': {'enabled': False, 'time': ''},
+            >>>     'thursday': {'enabled': False, 'time': ''},
+            >>>     'friday': {'enabled': True, 'time': '10:00'},
+            >>>     'saturday': {'enabled': False, 'time': ''},
+            >>>     'sunday': {'enabled': False, 'time': ''}
+            >>> }
+            >>> schedule = sdk.schedules.create(
+            >>>     capability_name='windows-smb-snaffler',
+            >>>     target_key='#asset#server01#server01',
+            >>>     weekly_schedule=weekly,
+            >>>     start_date='2024-01-15T00:00:00Z'
+            >>> )
+        """
+        body = {
+            'capabilityName': capability_name,
+            'targetKey': target_key,
+            'weeklySchedule': weekly_schedule,
+            'startDate': start_date,
+        }
+        if end_date:
+            body['endDate'] = end_date
+        if config:
+            body['config'] = config
+        if client_id:
+            body['clientId'] = client_id
+
+        return self.api.post('capability/schedule', body)
+
+    def update(self, schedule_id: str, weekly_schedule: dict = None,
+               start_date: str = None, end_date: str = None,
+               config: dict = None) -> dict:
+        """
+        Update an existing schedule.
+
+        :param schedule_id: The schedule ID to update
+        :type schedule_id: str
+        :param weekly_schedule: New weekly schedule configuration
+        :type weekly_schedule: dict or None
+        :param start_date: New start date in RFC3339 format
+        :type start_date: str or None
+        :param end_date: New end date in RFC3339 format (empty string to clear)
+        :type end_date: str or None
+        :param config: New capability configuration
+        :type config: dict or None
+        :return: Updated schedule object
+        :rtype: dict
+
+        **Example Usage:**
+            >>> # Update schedule to run daily at 14:00
+            >>> weekly = {
+            >>>     'monday': {'enabled': True, 'time': '14:00'},
+            >>>     'tuesday': {'enabled': True, 'time': '14:00'},
+            >>>     # ... other days
+            >>> }
+            >>> schedule = sdk.schedules.update(
+            >>>     schedule_id='abc123',
+            >>>     weekly_schedule=weekly
+            >>> )
+        """
+        schedule_id = _validate_schedule_id(schedule_id)
+        body = {}
+        if weekly_schedule is not None:
+            body['weeklySchedule'] = weekly_schedule
+        if start_date is not None:
+            body['startDate'] = start_date
+        if end_date is not None:
+            body['endDate'] = end_date
+        if config is not None:
+            body['config'] = config
+
+        return self.api.put(f'capability/schedule/{schedule_id}', body)
+
+    def delete(self, schedule_id: str) -> None:
+        """
+        Delete a schedule.
+
+        :param schedule_id: The schedule ID to delete
+        :type schedule_id: str
+
+        **Example Usage:**
+            >>> # Delete a schedule
+            >>> sdk.schedules.delete('abc123-def456')
+        """
+        schedule_id = _validate_schedule_id(schedule_id)
+        self.api.delete(f'capability/schedule/{schedule_id}', {}, {})
+
+    def pause(self, schedule_id: str) -> dict:
+        """
+        Pause a schedule.
+
+        Temporarily stops a schedule from executing. The schedule can be resumed
+        later with the resume() method.
+
+        :param schedule_id: The schedule ID to pause
+        :type schedule_id: str
+        :return: Updated schedule object with paused status
+        :rtype: dict
+
+        **Example Usage:**
+            >>> # Pause a schedule
+            >>> schedule = sdk.schedules.pause('abc123-def456')
+            >>> print(f"Status: {schedule['status']}")  # 'paused'
+        """
+        schedule_id = _validate_schedule_id(schedule_id)
+        return self.api.patch(f'capability/schedule/{schedule_id}/pause')
+
+    def resume(self, schedule_id: str) -> dict:
+        """
+        Resume a paused schedule.
+
+        Reactivates a paused schedule so it will execute at the next scheduled time.
+
+        :param schedule_id: The schedule ID to resume
+        :type schedule_id: str
+        :return: Updated schedule object with active status
+        :rtype: dict
+
+        **Example Usage:**
+            >>> # Resume a paused schedule
+            >>> schedule = sdk.schedules.resume('abc123-def456')
+            >>> print(f"Status: {schedule['status']}")  # 'active'
+        """
+        schedule_id = _validate_schedule_id(schedule_id)
+        return self.api.patch(f'capability/schedule/{schedule_id}/resume')

--- a/praetorian_cli/sdk/test/ui/test_aegis_job.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_job.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from praetorian_cli.ui.aegis.commands.job import handle_job
 from rich.prompt import Confirm
@@ -52,3 +54,330 @@ def test_job_run_success(monkeypatch):
     assert len(job_calls) == 1
     assert job_calls[0]['capabilities'] == ['windows-smb']
     assert job_calls[0]['target_key'].startswith('#asset#')
+
+
+def test_job_run_with_credential_attachment(monkeypatch):
+    """Test that only active-directory credentials can be selected and attached to jobs.
+
+    The mock data includes 6 credentials (aws, active-directory, ssh_key, active-directory, gcp, static).
+    Only the 2 active-directory credentials should be available for selection.
+    When user selects "1", they should get the first AD credential (cred1), not the first overall credential (aws1).
+
+    UPDATED: After fix, credentials are passed by UUID (like CLI), not fetched and embedded.
+    """
+    responses = {
+        'capabilities': {
+            'ad-enum': {'name': 'ad-enum', 'description': 'AD enumeration', 'target': 'addomain', 'parameters': [
+                {'name': 'Username', 'default': ''}, {'name': 'Password', 'default': ''}, {'name': 'Domain', 'default': ''}
+            ]}
+        },
+        'credentials': [
+            {
+                'key': '#credential#cloud#aws#aws1',
+                'name': 'AWS Credential',
+                'type': 'aws',
+            },
+            {
+                'key': '#credential#env-integration#active-directory#cred1',
+                'name': 'Test AD Credential',
+                'type': 'active-directory',
+                'username': 'testuser',
+            },
+            {
+                'key': '#credential#cloud#ssh_key#ssh1',
+                'name': 'SSH Key',
+                'type': 'ssh_key',
+                'username': 'root',
+            },
+            {
+                'key': '#credential#env-integration#active-directory#cred2',
+                'name': 'Another AD Credential',
+                'type': 'active-directory',
+                'username': 'admin',
+            },
+            {
+                'key': '#credential#cloud#gcp#gcp1',
+                'name': 'GCP Credential',
+                'type': 'gcp',
+            },
+            {
+                'key': '#credential#integration#static#static1',
+                'name': 'Static Credential',
+                'type': 'static',
+                'username': 'user',
+            }
+        ],
+        'domains': ['example.local'],
+        'assets': [
+            {
+                'key': '#addomain#example.local#S-1-5-21-fake-sid',
+                'dns': 'example.local',
+                'name': 'S-1-5-21-fake-sid',
+                'type': 'addomain',
+                'status': 'A'
+            }
+        ],
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Mock user interactions:
+    # 1. Confirm using the suggested capability
+    # 2. Confirm wanting to attach credentials
+    # 3. Confirm large artifact storage
+    # 4. Confirm running the job
+    confirm_responses = [True, True, True, True]  # Use suggested cap, attach credentials, large artifact, run job
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+    # Mock the fuzzy-picker functions directly
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_domain', lambda m: 'example.local')
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_credentials',
+                        lambda m: ('#credential#env-integration#active-directory#cred1', 'Test Credential (admin)'))
+
+    handle_job(menu, ['run', 'ad-enum'])
+
+    # CRITICAL: credentials.get() should NOT be called after fix!
+    # Credentials are passed by UUID, not fetched
+    cred_calls = menu.sdk.credentials.calls
+    get_calls = [call for call in cred_calls if call.get('method') == 'get']
+    assert len(get_calls) == 0, "credentials.get() should NOT be called - UUID is passed directly!"
+
+    # Verify job was created with credential UUID passed (not embedded in config)
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    assert job_calls[0]['capabilities'] == ['ad-enum']
+
+    # Credentials should be passed as UUIDs in the credentials parameter
+    credentials_param = job_calls[0].get('credentials', [])
+    assert credentials_param == ['cred1'], \
+        f"Expected credentials=['cred1'], got {credentials_param}. UUID should be passed directly!"
+
+
+def test_job_run_with_parameter_configuration(monkeypatch):
+    """Test that capabilities with parameters prompt for configuration."""
+    responses = {
+        'capabilities': {
+            'linux-scan': {
+                'name': 'linux-scan',
+                'description': 'Scan Linux systems',
+                'target': 'asset',
+                'parameters': {
+                    'timeout': '300',
+                    'threads': '10',
+                    'verbose': 'false'
+                }
+            }
+        },
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Track Prompt.ask calls to verify parameter prompts
+    prompt_calls = []
+
+    def mock_prompt_ask(prompt, **kwargs):
+        prompt_calls.append({'prompt': prompt, 'default': kwargs.get('default')})
+        # Return custom values for parameters
+        if 'timeout' in prompt.lower():
+            return '600'
+        elif 'threads' in prompt.lower():
+            return '20'
+        elif 'verbose' in prompt.lower():
+            return 'true'
+        return kwargs.get('default', '')
+
+    # Auto-confirm prompts
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', lambda *a, **k: True)
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Prompt.ask', mock_prompt_ask)
+
+    handle_job(menu, ['run', 'linux-scan'])
+
+    # Verify parameters were prompted for
+    assert len(prompt_calls) >= 3  # At least 3 parameter prompts
+    param_prompts = [call for call in prompt_calls if any(
+        param in call['prompt'].lower() for param in ['timeout', 'threads', 'verbose']
+    )]
+    assert len(param_prompts) == 3
+
+    # Verify job was created with custom parameters in config
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    config = job_calls[0].get('config', {})
+    # Config should contain the custom parameter values
+    assert 'timeout' in config or 'Timeout' in config
+    assert 'threads' in config or 'Threads' in config
+    assert 'verbose' in config or 'Verbose' in config
+
+
+def test_job_run_with_list_based_parameters(monkeypatch):
+    """Test that capabilities with list-based parameters (actual API format) work correctly."""
+    responses = {
+        'capabilities': {
+            'network-scan': {
+                'name': 'network-scan',
+                'description': 'Network scanning tool',
+                'target': 'asset',
+                'parameters': [
+                    {'name': 'timeout', 'default': 300},
+                    {'name': 'ports', 'default': '80,443,8080'},
+                    {'name': 'aggressive', 'default': False}
+                ]
+            }
+        },
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Track Prompt.ask calls
+    prompt_calls = []
+
+    def mock_prompt_ask(prompt, **kwargs):
+        prompt_calls.append({'prompt': prompt, 'default': kwargs.get('default')})
+        # Return custom values
+        if 'timeout' in prompt.lower():
+            return '600'
+        elif 'ports' in prompt.lower():
+            return '22,80,443'
+        elif 'aggressive' in prompt.lower():
+            return 'True'
+        return kwargs.get('default', '')
+
+    # Auto-confirm prompts
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', lambda *a, **k: True)
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Prompt.ask', mock_prompt_ask)
+
+    handle_job(menu, ['run', 'network-scan'])
+
+    # Verify parameters were prompted (list format should work)
+    assert len(prompt_calls) >= 3
+    param_prompts = [call for call in prompt_calls if any(
+        param in call['prompt'].lower() for param in ['timeout', 'ports', 'aggressive']
+    )]
+    assert len(param_prompts) == 3, "All 3 parameters should be prompted"
+
+    # Verify job was created
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    config = job_calls[0].get('config', {})
+    # Config should contain parameters
+    assert config  # Not empty
+
+
+def test_job_run_with_large_artifact(monkeypatch):
+    """Test that capabilities with largeArtifact: true prompt for S3 upload."""
+    responses = {
+        'capabilities': {
+            'windows-network-nmap': {
+                'name': 'windows-network-nmap',
+                'description': 'Network mapper with large output',
+                'target': 'asset',  # Use asset target to simplify test
+                'largeArtifact': True,  # This capability generates large artifacts
+                'parameters': []
+            }
+        },
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Track Confirm.ask calls to verify large artifact prompt appears
+    confirm_calls = []
+    # Prompts: Use suggested cap, enable large artifact, run job
+    confirm_responses = [True, True, True]
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        confirm_calls.append({'prompt': prompt, 'default': kwargs.get('default')})
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+
+    handle_job(menu, ['run', 'windows-network-nmap'])
+
+    # Verify large artifact prompt appeared
+    large_artifact_prompts = [call for call in confirm_calls if 'large artifact' in call['prompt'].lower()]
+    assert len(large_artifact_prompts) == 1, f"Should prompt once for large artifact storage. Got {len(large_artifact_prompts)} prompts: {large_artifact_prompts}"
+
+    # Verify the default was True for largeArtifact capability
+    assert large_artifact_prompts[0]['default'] is True, "Default should be True for capability with largeArtifact=True"
+
+    # Verify job was created with largeArtifact config
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    config = job_calls[0].get('config', '{}')
+    if isinstance(config, str):
+        config = json.loads(config)
+    assert config.get('largeArtifact') == 'true', "Config should have largeArtifact='true' when enabled"
+
+
+def test_job_run_without_large_artifact_default_false(monkeypatch):
+    """Test that capabilities without largeArtifact have default=False for the S3 prompt."""
+    responses = {
+        'capabilities': {
+            'linux-enum': {
+                'name': 'linux-enum',
+                'description': 'Basic Linux enumeration',
+                'target': 'asset',
+                'largeArtifact': False,  # This capability does NOT generate large artifacts
+                'parameters': []
+            }
+        },
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Track Confirm.ask calls
+    confirm_calls = []
+    # Prompts: Use suggested cap, large artifact (decline), run job
+    confirm_responses = [True, False, True]
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        confirm_calls.append({'prompt': prompt, 'default': kwargs.get('default')})
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+
+    handle_job(menu, ['run', 'linux-enum'])
+
+    # Verify large artifact prompt appeared but with default=False
+    large_artifact_prompts = [call for call in confirm_calls if 'large artifact' in call['prompt'].lower()]
+    assert len(large_artifact_prompts) == 1, "Large artifact prompt should always appear"
+    assert large_artifact_prompts[0]['default'] is False, "Default should be False for capability without largeArtifact"
+
+    # Verify job was created without largeArtifact config (user declined)
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    config = job_calls[0].get('config', '{}')
+    if isinstance(config, str):
+        config = json.loads(config)
+    assert 'largeArtifact' not in config, "Config should not have largeArtifact when user declines"

--- a/praetorian_cli/sdk/test/ui/test_aegis_job_addomain_target_key.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_job_addomain_target_key.py
@@ -1,0 +1,155 @@
+import pytest
+from praetorian_cli.ui.aegis.commands.job import handle_job
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
+
+pytestmark = pytest.mark.tui
+
+
+class Menu(MockMenuBase):
+    def __init__(self, responses=None):
+        super().__init__()
+        self.sdk = MockSDK(responses=responses)
+        self.selected_agent = MockAgent()
+
+
+def test_job_run_addomain_uses_asset_key_from_database(monkeypatch):
+    """Test that addomain jobs use the actual asset key from the database, not constructed keys.
+
+    When running a job against an AD domain, the target_key should be the actual asset key
+    from the database (which includes the SID), not a constructed key like #addomain#{domain}#{domain}.
+
+    Expected format: #addomain#<domain>#<SID>
+    Example: #addomain#corp.local#S-1-5-21-123456789-123456789-123456789-1001
+    NOT: #addomain#corp.local#corp.local
+    """
+    # Mock response with actual AD domain asset (with SID in key)
+    domain_asset_key = '#addomain#corp.local#S-1-5-21-123456789-123456789-123456789-1001'
+
+    responses = {
+        'capabilities': {
+            'ad-enum': {
+                'name': 'ad-enum',
+                'description': 'AD enumeration',
+                'target': 'addomain',
+                'parameters': [
+                    {'name': 'Username', 'default': ''}, {'name': 'Password', 'default': ''}, {'name': 'Domain', 'default': ''}
+                ]
+            }
+        },
+        'domains': ['corp.local'],
+        'assets': [
+            {
+                'key': domain_asset_key,
+                'dns': 'corp.local',
+                'name': 'S-1-5-21-123456789-123456789-123456789-1001',
+                'type': 'addomain',
+                'status': 'A'
+            }
+        ],
+        'job': {
+            'key': '#job#corp.local#ad-enum#1234567890',
+            'status': 'JQ',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Mock user interactions: confirm suggested capability, decline credentials, large artifact, confirm running the job
+    confirm_index = [0]
+    confirm_responses = [True, False, True, True]  # Confirm suggested capability, Decline credentials, Large artifact, Run job
+
+    def mock_confirm_ask(prompt, **kwargs):
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+    # Mock Prompt.ask to return defaults for parameter configuration
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Prompt.ask', lambda prompt, **kw: kw.get('default', ''))
+    # Mock the fuzzy-picker domain selector directly
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_domain', lambda m: 'corp.local')
+
+    # Run the job
+    handle_job(menu, ['run', 'ad-enum'])
+
+    # Verify the job was created with the correct target_key from the database
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1, "Expected exactly one job call"
+    assert job_calls[0]['capabilities'] == ['ad-enum'], "Capability should be ad-enum"
+
+    # CRITICAL: The target_key MUST be the actual asset key from database (with SID)
+    actual_target_key = job_calls[0]['target_key']
+    assert actual_target_key == domain_asset_key, \
+        f"Expected target_key to be the actual asset key '{domain_asset_key}' (with SID), " \
+        f"but got '{actual_target_key}'"
+
+    # Verify it's NOT the incorrect constructed format
+    incorrect_format = '#addomain#corp.local#corp.local'
+    assert actual_target_key != incorrect_format, \
+        f"target_key should NOT be constructed as '{incorrect_format}', " \
+        f"it must use the actual asset key from the database with SID"
+
+
+def test_job_run_addomain_queries_assets_for_domain(monkeypatch):
+    """Test that when running an addomain job, we query assets to find the domain's asset key."""
+    domain_asset_key = '#addomain#example.local#S-1-5-21-999888777-666555444-333222111-500'
+
+    responses = {
+        'capabilities': {
+            'windows-ad-sharphound': {
+                'name': 'windows-ad-sharphound',
+                'description': 'Run Sharphound collector',
+                'target': 'addomain',
+                'parameters': [
+                    {'name': 'Username', 'default': ''}, {'name': 'Password', 'default': ''}, {'name': 'Domain', 'default': ''}
+                ]
+            }
+        },
+        'domains': ['example.local'],
+        'assets': [
+            {
+                'key': domain_asset_key,
+                'dns': 'example.local',
+                'name': 'S-1-5-21-999888777-666555444-333222111-500',
+                'type': 'addomain',
+                'status': 'A'
+            }
+        ],
+        'job': {
+            'key': '#job#example.local#windows-ad-sharphound#1234567890',
+            'status': 'JQ',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    confirm_responses = [True, False, True, True]  # Confirm suggested capability, Decline credentials, Large artifact, Run job
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+    # Mock Prompt.ask to return defaults for parameter configuration
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Prompt.ask', lambda prompt, **kw: kw.get('default', ''))
+    # Mock the fuzzy-picker domain selector directly
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_domain', lambda m: 'example.local')
+
+    handle_job(menu, ['run', 'windows-ad-sharphound'])
+
+    # Verify assets were queried to get the actual domain key
+    asset_calls = menu.sdk.assets.calls
+    assert len(asset_calls) >= 1, "Expected at least one call to assets.list to find domain asset"
+
+    # Verify the first asset call was to query for the domain
+    first_asset_call = asset_calls[0]
+    assert first_asset_call['method'] == 'list', "Should call assets.list to find domain"
+    assert '#addomain#example.local' in first_asset_call.get('key_prefix', ''), \
+        "Should query assets with #addomain#{domain} prefix"
+
+    # Verify job was created with the correct asset key
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    assert job_calls[0]['target_key'] == domain_asset_key

--- a/praetorian_cli/sdk/test/ui/test_aegis_job_credential_fix.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_job_credential_fix.py
@@ -1,0 +1,209 @@
+"""Test that TUI attaches credentials by UUID, not by fetching and embedding values.
+
+This test verifies the fix for the bug where the TUI was trying to fetch
+credential values (causing 403 errors) instead of just passing the credential
+UUID to the jobs API like the CLI does.
+
+Working CLI pattern:
+    praetorian chariot add job --key <target> --credential <uuid>
+    → jobs.add(key, capabilities, config, credentials=[uuid])
+    → API receives credential_ids=[uuid] and retrieves values server-side
+
+Broken TUI pattern (before fix):
+    → credentials.get(uuid) # 403 error!
+    → embed values in config
+    → jobs.add(key, capabilities, config, credentials=[])  # empty!
+
+Fixed TUI pattern (after fix):
+    → extract UUID from credential key
+    → jobs.add(key, capabilities, config, credentials=[uuid])  # UUID passed!
+"""
+
+import json
+
+import pytest
+from praetorian_cli.ui.aegis.commands.job import handle_job
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
+
+pytestmark = pytest.mark.tui
+
+
+class Menu(MockMenuBase):
+    def __init__(self, responses=None):
+        super().__init__()
+        self.sdk = MockSDK(responses=responses)
+        self.selected_agent = MockAgent()
+
+
+def test_credential_uuid_passed_not_fetched(monkeypatch):
+    """Test that credential UUID is passed to jobs.add(), not fetched and embedded.
+
+    This is the CORRECT behavior:
+    1. User selects credential from list
+    2. Extract UUID from credential key
+    3. Pass UUID to jobs.add(credentials=[uuid])
+    4. API retrieves values server-side (not the TUI!)
+
+    This test verifies:
+    - credentials.get() is NOT called (no fetching!)
+    - jobs.add() receives credentials=[uuid] parameter
+    - Config does NOT contain embedded Username/Password/Domain
+    """
+    responses = {
+        'capabilities': {
+            'ad-enum': {
+                'name': 'ad-enum',
+                'description': 'AD enumeration',
+                'target': 'addomain',
+                'parameters': [
+                    {'name': 'Username', 'default': ''}, {'name': 'Password', 'default': ''}, {'name': 'Domain', 'default': ''}
+                ]
+            }
+        },
+        'credentials': [
+            {
+                'key': '#credential#env-integration#active-directory#test-uuid-1234',
+                'name': 'Test AD Credential',
+                'type': 'active-directory',
+                'username': 'testuser',
+            },
+        ],
+        'domains': ['example.local'],
+        'assets': [
+            {
+                'key': '#addomain#example.local#S-1-5-21-fake-sid',
+                'dns': 'example.local',
+                'name': 'S-1-5-21-fake-sid',
+                'type': 'addomain',
+                'status': 'A'
+            }
+        ],
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # Mock user interactions:
+    confirm_responses = [True, True, True, True]  # Use suggested cap, attach credentials, large artifact, run job
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+    # Mock the fuzzy-picker functions directly
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_domain', lambda m: 'example.local')
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_credentials',
+                        lambda m: ('#credential#env-integration#active-directory#test-uuid-1234', 'Test Credential (admin)'))
+
+    handle_job(menu, ['run', 'ad-enum'])
+
+    # CRITICAL: credentials.get() should NOT be called
+    # The TUI should not fetch credential values - that causes 403!
+    cred_calls = menu.sdk.credentials.calls
+    get_calls = [call for call in cred_calls if call.get('method') == 'get']
+    assert len(get_calls) == 0, \
+        "credentials.get() should NOT be called - causes 403 error! UUID should be passed directly."
+
+    # CRITICAL: Credential UUID should be passed to jobs.add()
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1, "jobs.add() should be called once"
+
+    # The credentials parameter should contain the UUID
+    credentials_param = job_calls[0].get('credentials', [])
+    assert credentials_param == ['test-uuid-1234'], \
+        f"Expected credentials=['test-uuid-1234'], got {credentials_param}. " \
+        f"UUID should be passed directly to jobs.add(), not left empty!"
+
+    # Config should NOT contain embedded Username/Password/Domain
+    # (They should be retrieved server-side from the credential UUID)
+    config = job_calls[0].get('config', '{}')
+    if isinstance(config, str):
+        config = json.loads(config)
+
+    assert 'Username' not in config, \
+        "Username should NOT be embedded in config - credential is passed by UUID!"
+    assert 'Password' not in config, \
+        "Password should NOT be embedded in config - credential is passed by UUID!"
+    assert 'Domain' not in config, \
+        "Domain should NOT be embedded in config - credential is passed by UUID!"
+
+
+def test_multiple_credentials_passed_as_uuids(monkeypatch):
+    """Test that multiple credentials can be attached by UUID.
+
+    The CLI supports --credential multiple times:
+        praetorian chariot add job --credential uuid1 --credential uuid2
+
+    The TUI should support the same pattern.
+    """
+    responses = {
+        'capabilities': {
+            'ad-enum': {
+                'name': 'ad-enum',
+                'description': 'AD enumeration',
+                'target': 'addomain',
+                'parameters': [
+                    {'name': 'Username', 'default': ''}, {'name': 'Password', 'default': ''}, {'name': 'Domain', 'default': ''}
+                ]
+            }
+        },
+        'credentials': [
+            {
+                'key': '#credential#env#active-directory#uuid-1',
+                'name': 'First Credential',
+                'type': 'active-directory',
+            },
+            {
+                'key': '#credential#env#active-directory#uuid-2',
+                'name': 'Second Credential',
+                'type': 'active-directory',
+            },
+        ],
+        'domains': ['example.local'],
+        'assets': [
+            {
+                'key': '#addomain#example.local#S-1-5-21-fake-sid',
+                'dns': 'example.local',
+                'name': 'S-1-5-21-fake-sid',
+                'type': 'addomain',
+                'status': 'A'
+            }
+        ],
+        'job': {
+            'key': 'jobs#deadbeefcafebabe',
+            'status': 'queued',
+        },
+        'config': {},
+    }
+    menu = Menu(responses=responses)
+
+    # For this test, we'll only select one credential
+    # (Multiple credential selection requires UI flow changes not in scope)
+    confirm_responses = [True, True, True, True]  # Use suggested cap, attach credentials, large artifact, run job
+    confirm_index = [0]
+
+    def mock_confirm_ask(prompt, **kwargs):
+        result = confirm_responses[confirm_index[0]]
+        confirm_index[0] += 1
+        return result
+
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job.Confirm.ask', mock_confirm_ask)
+    # Mock the fuzzy-picker functions directly
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_domain', lambda m: 'example.local')
+    monkeypatch.setattr('praetorian_cli.ui.aegis.commands.job._select_credentials',
+                        lambda m: ('#credential#env#active-directory#uuid-1', 'Test Credential (admin)'))
+
+    handle_job(menu, ['run', 'ad-enum'])
+
+    # Verify credential UUID is passed
+    job_calls = menu.sdk.jobs.calls
+    assert len(job_calls) == 1
+    credentials_param = job_calls[0].get('credentials', [])
+    assert len(credentials_param) >= 1, "At least one credential should be attached"
+    assert credentials_param[0] == 'uuid-1', "First credential UUID should be passed"

--- a/praetorian_cli/sdk/test/ui/test_aegis_schedule.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_schedule.py
@@ -1,0 +1,552 @@
+"""Tests for schedule.py TUI command handlers."""
+
+import pytest
+from praetorian_cli.ui.aegis.commands.schedule import (
+    handle_schedule,
+    list_schedules,
+    view_schedule,
+    add_schedule,
+    edit_schedule,
+    delete_schedule,
+    pause_schedule,
+    resume_schedule,
+    show_schedule_help,
+    complete,
+)
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockAgent
+
+pytestmark = pytest.mark.tui
+
+
+# --- Mock SDK with schedules support ---
+
+class MockSchedulesAPI:
+    """Mock for sdk.schedules that records calls."""
+
+    def __init__(self, schedules=None, error=None):
+        self._schedules = schedules or []
+        self._error = error
+        self.calls = []
+
+    def list(self, pages=1):
+        self.calls.append({'method': 'list'})
+        if self._error:
+            raise self._error
+        return self._schedules, None
+
+    def create(self, **kwargs):
+        self.calls.append({'method': 'create', **kwargs})
+        return {'scheduleId': 'new-schedule-id', 'status': 'active', 'nextExecution': '2024-06-15T10:00:00Z'}
+
+    def update(self, **kwargs):
+        self.calls.append({'method': 'update', **kwargs})
+        return {'scheduleId': kwargs.get('schedule_id', ''), 'status': 'active', 'nextExecution': '2024-06-16T10:00:00Z'}
+
+    def delete(self, schedule_id):
+        self.calls.append({'method': 'delete', 'schedule_id': schedule_id})
+        if self._error:
+            raise self._error
+
+    def pause(self, schedule_id):
+        self.calls.append({'method': 'pause', 'schedule_id': schedule_id})
+        if self._error:
+            raise self._error
+        return {'scheduleId': schedule_id, 'status': 'paused'}
+
+    def resume(self, schedule_id):
+        self.calls.append({'method': 'resume', 'schedule_id': schedule_id})
+        if self._error:
+            raise self._error
+        return {'scheduleId': schedule_id, 'status': 'active', 'nextExecution': '2024-06-15T10:00:00Z'}
+
+
+class MockAegis:
+    def validate_capability(self, name):
+        return {'name': name, 'description': 'test', 'target': 'asset', 'parameters': []}
+
+
+class MockAssets:
+    def list(self, **kwargs):
+        return [], None
+
+
+class ScheduleMenu(MockMenuBase):
+    """Menu with schedule-specific SDK mocks."""
+
+    def __init__(self, schedules=None, error=None):
+        super().__init__()
+        self.sdk = type('SDK', (), {
+            'schedules': MockSchedulesAPI(schedules=schedules, error=error),
+            'aegis': MockAegis(),
+            'assets': MockAssets(),
+        })()
+        self.selected_agent = MockAgent()
+        self.agent_lookup = {}
+
+
+SAMPLE_SCHEDULES = [
+    {
+        'scheduleId': 'abc123-def456-ghi789',
+        'capabilityName': 'windows-smb-snaffler',
+        'status': 'active',
+        'targetKey': '#asset#server01#server01',
+        'clientId': 'C.1',
+        'weeklySchedule': {
+            'monday': {'enabled': True, 'time': '10:00'},
+            'tuesday': {'enabled': False, 'time': ''},
+            'wednesday': {'enabled': True, 'time': '14:00'},
+            'thursday': {'enabled': False, 'time': ''},
+            'friday': {'enabled': True, 'time': '10:00'},
+            'saturday': {'enabled': False, 'time': ''},
+            'sunday': {'enabled': False, 'time': ''},
+        },
+        'startDate': '2024-01-15T00:00:00Z',
+        'endDate': '',
+        'nextExecution': '2099-06-15T10:00:00Z',
+        'lastExecution': '2024-06-14T10:00:00Z',
+        'config': {'aegis': 'true', 'client_id': 'C.1'},
+    },
+    {
+        'scheduleId': 'xyz789-uvw012',
+        'capabilityName': 'linux-enum',
+        'status': 'paused',
+        'targetKey': '#asset#linux01#linux01',
+        'clientId': '',
+        'weeklySchedule': {},
+        'startDate': '2024-03-01T00:00:00Z',
+        'nextExecution': '',
+        'config': {},
+    },
+]
+
+
+# --- handle_schedule routing tests ---
+
+class TestHandleScheduleRouting:
+    def test_empty_args_shows_help(self):
+        menu = ScheduleMenu()
+        handle_schedule(menu, [])
+        output = '\n'.join(menu.console.lines)
+        assert 'Schedule Commands' in output
+
+    def test_unknown_subcommand_shows_help(self):
+        menu = ScheduleMenu()
+        handle_schedule(menu, ['foobar'])
+        output = '\n'.join(menu.console.lines)
+        assert 'Unknown schedule subcommand' in output
+        assert 'Schedule Commands' in output
+
+    def test_list_subcommand_routes(self):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+        handle_schedule(menu, ['list'])
+        # list_schedules was called - verify output
+        output = '\n'.join(menu.console.lines)
+        assert 'Scheduled Jobs' in output
+
+
+# --- list_schedules tests ---
+
+class TestListSchedules:
+    def test_list_with_schedules(self):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+        list_schedules(menu)
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Scheduled Jobs' in output
+        assert menu.paused is True
+
+    def test_list_empty_schedules(self):
+        menu = ScheduleMenu(schedules=[])
+        list_schedules(menu)
+
+        output = '\n'.join(menu.console.lines)
+        assert 'No scheduled jobs found' in output
+        assert 'schedule add' in output
+        assert menu.paused is True
+
+    def test_list_api_error(self):
+        menu = ScheduleMenu(error=Exception("API timeout"))
+        list_schedules(menu)
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Error listing schedules' in output
+        assert menu.paused is True
+
+    def test_list_with_agent_lookup(self):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+        menu.agent_lookup = {'C.1': 'server01-hostname'}
+        list_schedules(menu)
+
+        # The table should be rendered (we can't easily inspect Rich Table content,
+        # but the schedule list was created without error)
+        assert menu.paused is True
+        assert menu.sdk.schedules.calls[0]['method'] == 'list'
+
+
+# --- view_schedule tests ---
+
+class TestViewSchedule:
+    def test_view_with_valid_prefix(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        # Mock interactive_schedule_picker to return the first schedule
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+
+        view_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Schedule Details' in output
+        assert 'windows-smb-snaffler' in output
+        assert menu.paused is True
+
+    def test_view_not_found(self, monkeypatch):
+        menu = ScheduleMenu(schedules=[])
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (None, None)
+        )
+
+        view_schedule(menu, ['nonexistent'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'not found' in output
+        assert menu.paused is True
+
+    def test_view_shows_weekly_schedule(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+        menu.agent_lookup = {}
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+
+        view_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Schedule' in output
+        assert 'Mon' in output
+        assert menu.paused is True
+
+    def test_view_hides_password_in_config(self, monkeypatch):
+        schedule_with_secret = dict(SAMPLE_SCHEDULES[0])
+        schedule_with_secret['config'] = {'password': 'secret123', 'aegis': 'true'}
+
+        menu = ScheduleMenu()
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (schedule_with_secret, 'abc123')
+        )
+
+        view_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'secret123' not in output
+        assert '********' in output
+
+
+# --- delete_schedule tests ---
+
+class TestDeleteSchedule:
+    def test_delete_confirmed(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Confirm.ask',
+            lambda *a, **k: True
+        )
+
+        delete_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'deleted successfully' in output
+        assert any(c['method'] == 'delete' for c in menu.sdk.schedules.calls)
+
+    def test_delete_cancelled(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Confirm.ask',
+            lambda *a, **k: False
+        )
+
+        delete_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Cancelled' in output
+        assert not any(c['method'] == 'delete' for c in menu.sdk.schedules.calls)
+
+    def test_delete_not_found(self, monkeypatch):
+        menu = ScheduleMenu()
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (None, None)
+        )
+
+        delete_schedule(menu, ['nonexistent'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'not found' in output
+
+
+# --- pause_schedule tests ---
+
+class TestPauseSchedule:
+    def test_pause_success(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+
+        pause_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'paused' in output
+        assert any(c['method'] == 'pause' for c in menu.sdk.schedules.calls)
+
+    def test_pause_not_found(self, monkeypatch):
+        menu = ScheduleMenu()
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (None, None)
+        )
+
+        pause_schedule(menu, ['nonexistent'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'not found' in output
+
+
+# --- resume_schedule tests ---
+
+class TestResumeSchedule:
+    def test_resume_success(self, monkeypatch):
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[1], 'xyz789-uvw012')
+        )
+
+        resume_schedule(menu, ['xyz789'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'resumed' in output
+        assert any(c['method'] == 'resume' for c in menu.sdk.schedules.calls)
+
+    def test_resume_not_found(self, monkeypatch):
+        menu = ScheduleMenu()
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (None, None)
+        )
+
+        resume_schedule(menu, ['nonexistent'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'not found' in output
+
+    def test_resume_api_error(self, monkeypatch):
+        menu = ScheduleMenu()
+        menu.sdk.schedules._error = Exception("API unavailable")
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[1], 'xyz789-uvw012')
+        )
+
+        resume_schedule(menu, ['xyz789'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'Error resuming schedule' in output
+
+
+# --- edit_schedule tests ---
+
+class TestEditSchedule:
+    def test_edit_no_changes(self, monkeypatch):
+        """When user declines all edit prompts, no update is sent."""
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+        # Decline editing weekly, start date, end date
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Confirm.ask',
+            lambda *a, **k: False
+        )
+
+        from praetorian_cli.ui.aegis.commands.schedule import edit_schedule
+        edit_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'No changes made' in output
+        assert not any(c['method'] == 'update' for c in menu.sdk.schedules.calls)
+
+    def test_edit_not_found(self, monkeypatch):
+        menu = ScheduleMenu()
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (None, None)
+        )
+
+        edit_schedule(menu, ['nonexistent'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'not found' in output
+
+    def test_edit_with_weekly_schedule_change(self, monkeypatch):
+        """When user edits the weekly schedule, update() is called with new schedule."""
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.interactive_schedule_picker',
+            lambda m, suggested, prompt_prefix: (SAMPLE_SCHEDULES[0], 'abc123-def456-ghi789')
+        )
+
+        new_weekly = {
+            'monday': {'enabled': True, 'time': '08:00'},
+            'tuesday': {'enabled': False, 'time': ''},
+            'wednesday': {'enabled': False, 'time': ''},
+            'thursday': {'enabled': True, 'time': '12:00'},
+            'friday': {'enabled': False, 'time': ''},
+            'saturday': {'enabled': False, 'time': ''},
+            'sunday': {'enabled': False, 'time': ''},
+        }
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.configure_weekly_schedule',
+            lambda m: new_weekly
+        )
+
+        # Sequence: Yes to edit weekly, No to start date, No to end date, Yes to save
+        confirm_answers = iter([True, False, False, True])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Confirm.ask',
+            lambda *a, **k: next(confirm_answers)
+        )
+
+        edit_schedule(menu, ['abc123'])
+
+        output = '\n'.join(menu.console.lines)
+        assert 'updated successfully' in output
+        update_calls = [c for c in menu.sdk.schedules.calls if c['method'] == 'update']
+        assert len(update_calls) == 1
+        assert update_calls[0]['schedule_id'] == 'abc123-def456-ghi789'
+        assert update_calls[0]['weekly_schedule'] == new_weekly
+
+
+# --- add_schedule tests ---
+
+class TestAddSchedule:
+    def test_add_schedule_success(self, monkeypatch):
+        """Happy path: add_schedule creates a schedule with correct params."""
+        menu = ScheduleMenu(schedules=SAMPLE_SCHEDULES)
+
+        # Mock capability picker to return a capability name
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule._interactive_capability_picker',
+            lambda m: 'windows-smb-snaffler'
+        )
+
+        new_weekly = {
+            'monday': {'enabled': True, 'time': '09:00'},
+            'tuesday': {'enabled': False, 'time': ''},
+            'wednesday': {'enabled': True, 'time': '09:00'},
+            'thursday': {'enabled': False, 'time': ''},
+            'friday': {'enabled': True, 'time': '09:00'},
+            'saturday': {'enabled': False, 'time': ''},
+            'sunday': {'enabled': False, 'time': ''},
+        }
+
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.configure_weekly_schedule',
+            lambda m: new_weekly
+        )
+
+        # Prompt.ask for start_date and end_date
+        prompt_answers = iter(['2024-06-01T00:00:00Z', ''])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Prompt.ask',
+            lambda *a, **k: next(prompt_answers)
+        )
+
+        # Confirm.ask for "Create this schedule?"
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule.Confirm.ask',
+            lambda *a, **k: True
+        )
+
+        add_schedule(menu)
+
+        output = '\n'.join(menu.console.lines)
+        assert 'created successfully' in output
+
+        create_calls = [c for c in menu.sdk.schedules.calls if c['method'] == 'create']
+        assert len(create_calls) == 1
+        assert create_calls[0]['capability_name'] == 'windows-smb-snaffler'
+        assert create_calls[0]['weekly_schedule'] == new_weekly
+        assert create_calls[0]['client_id'] == 'C.1'
+
+
+# --- complete() autocomplete tests ---
+
+class TestComplete:
+    def test_complete_subcommands(self):
+        menu = ScheduleMenu()
+        results = complete(menu, 'li', ['schedule', 'li'])
+        assert 'list' in results
+
+    def test_complete_empty_returns_all_subcommands(self):
+        menu = ScheduleMenu()
+        results = complete(menu, '', ['schedule', ''])
+        assert 'list' in results
+        assert 'view' in results
+        assert 'add' in results
+        assert 'edit' in results
+        assert 'delete' in results
+        assert 'pause' in results
+        assert 'resume' in results
+
+    def test_complete_no_match(self):
+        menu = ScheduleMenu()
+        results = complete(menu, 'zzz', ['schedule', 'zzz'])
+        assert len(results) == 0
+
+
+# --- show_schedule_help tests ---
+
+class TestShowScheduleHelp:
+    def test_help_shows_all_subcommands(self):
+        menu = ScheduleMenu()
+        show_schedule_help(menu)
+
+        output = '\n'.join(menu.console.lines)
+        assert 'schedule list' in output
+        assert 'schedule view' in output
+        assert 'schedule add' in output
+        assert 'schedule edit' in output
+        assert 'schedule delete' in output
+        assert 'schedule pause' in output
+        assert 'schedule resume' in output
+        assert menu.paused is True

--- a/praetorian_cli/sdk/test/ui/test_aegis_schedule_helpers.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_schedule_helpers.py
@@ -1,0 +1,393 @@
+"""Tests for schedule_helpers.py formatting functions and interactive helpers."""
+
+import pytest
+from praetorian_cli.ui.aegis.commands.schedule_helpers import (
+    format_target,
+    format_days,
+    format_status,
+    format_next_execution,
+    format_date,
+    format_datetime,
+    configure_weekly_schedule,
+    find_schedule_by_prefix,
+    complete_schedule_ids,
+    ScheduleCompleter,
+    DAYS,
+    DAY_ABBREVS,
+)
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase
+
+pytestmark = pytest.mark.tui
+
+
+# --- format_target tests ---
+
+class TestFormatTarget:
+    def test_valid_asset_key(self):
+        assert format_target('#asset#server01#server01') == 'asset: server01'
+
+    def test_valid_addomain_key(self):
+        assert format_target('#addomain#example.local#example.local') == 'addomain: example.local'
+
+    def test_short_key_returns_as_is(self):
+        assert format_target('short') == 'short'
+
+    def test_empty_string(self):
+        assert format_target('') == 'N/A'
+
+    def test_none_input(self):
+        assert format_target(None) == 'N/A'
+
+    def test_two_part_key(self):
+        assert format_target('#asset') == '#asset'
+
+
+# --- format_days tests ---
+
+class TestFormatDays:
+    def test_all_days_enabled(self):
+        weekly = {day: {'enabled': True, 'time': '10:00'} for day in DAYS}
+        result = format_days(weekly)
+        assert result == 'Mo Tu We Th Fr Sa Su'
+
+    def test_no_days_enabled(self):
+        weekly = {day: {'enabled': False, 'time': ''} for day in DAYS}
+        assert format_days(weekly) == 'None'
+
+    def test_weekdays_only(self):
+        weekly = {}
+        for day in DAYS:
+            weekly[day] = {'enabled': day not in ['saturday', 'sunday'], 'time': '09:00'}
+        result = format_days(weekly)
+        assert result == 'Mo Tu We Th Fr'
+
+    def test_empty_schedule(self):
+        assert format_days({}) == 'None'
+
+    def test_none_schedule(self):
+        assert format_days(None) == 'None'
+
+    def test_single_day(self):
+        weekly = {day: {'enabled': False, 'time': ''} for day in DAYS}
+        weekly['wednesday'] = {'enabled': True, 'time': '14:00'}
+        result = format_days(weekly)
+        assert result == 'We'
+
+
+# --- format_status tests ---
+
+class TestFormatStatus:
+    COLORS = {
+        'primary': 'cyan',
+        'accent': 'magenta',
+        'dim': 'dim',
+        'success': 'green',
+        'warning': 'yellow',
+        'error': 'red',
+    }
+
+    def test_active_status(self):
+        result = format_status('active', self.COLORS)
+        assert 'active' in result
+        assert self.COLORS['success'] in result
+
+    def test_paused_status(self):
+        result = format_status('paused', self.COLORS)
+        assert 'paused' in result
+        assert self.COLORS['warning'] in result
+
+    def test_expired_status(self):
+        result = format_status('expired', self.COLORS)
+        assert 'expired' in result
+        assert self.COLORS['dim'] in result
+
+    def test_unknown_status(self):
+        result = format_status('something_else', self.COLORS)
+        assert 'something_else' in result
+
+    def test_none_status(self):
+        result = format_status(None, self.COLORS)
+        assert 'unknown' in result
+
+    def test_uppercase_status_normalized(self):
+        result = format_status('ACTIVE', self.COLORS)
+        assert 'active' in result
+
+
+# --- format_date tests ---
+
+class TestFormatDate:
+    def test_valid_iso_date(self):
+        assert format_date('2024-06-15T10:30:00Z') == '2024-06-15'
+
+    def test_none_input(self):
+        assert format_date(None) == 'N/A'
+
+    def test_empty_string(self):
+        assert format_date('') == 'N/A'
+
+    def test_invalid_format_returns_truncated(self):
+        result = format_date('not-a-date-at-all')
+        assert result == 'not-a-date'
+
+
+# --- format_datetime tests ---
+
+class TestFormatDatetime:
+    def test_valid_iso_datetime(self):
+        result = format_datetime('2024-06-15T10:30:00Z')
+        assert '2024-06-15' in result
+        assert '10:30' in result
+        assert 'UTC' in result
+
+    def test_none_input(self):
+        assert format_datetime(None) == 'N/A'
+
+    def test_empty_string(self):
+        assert format_datetime('') == 'N/A'
+
+
+# --- format_next_execution tests ---
+
+class TestFormatNextExecution:
+    def test_none_input(self):
+        assert format_next_execution(None) == 'Not scheduled'
+
+    def test_empty_string(self):
+        assert format_next_execution('') == 'Not scheduled'
+
+    def test_past_time_shows_overdue(self):
+        result = format_next_execution('2020-01-01T00:00:00Z')
+        assert result == 'Overdue'
+
+    def test_far_future_shows_date(self):
+        result = format_next_execution('2099-12-31T23:59:00Z')
+        assert '2099-12-31' in result
+
+
+# --- configure_weekly_schedule tests ---
+
+class TestConfigureWeeklySchedule:
+    def test_all_days_configured(self, monkeypatch):
+        menu = MockMenuBase()
+        # Mock Prompt.ask to return times for weekdays, empty for weekends
+        times = iter(['09:00', '09:00', '09:00', '09:00', '09:00', '', ''])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule_helpers.Prompt.ask',
+            lambda *a, **k: next(times)
+        )
+
+        result = configure_weekly_schedule(menu)
+        assert result is not None
+        assert result['monday']['enabled'] is True
+        assert result['monday']['time'] == '09:00'
+        assert result['saturday']['enabled'] is False
+        assert result['sunday']['enabled'] is False
+
+    def test_no_days_enabled_returns_none(self, monkeypatch):
+        menu = MockMenuBase()
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule_helpers.Prompt.ask',
+            lambda *a, **k: ''
+        )
+
+        result = configure_weekly_schedule(menu)
+        assert result is None
+
+    def test_invalid_time_format_skipped(self, monkeypatch):
+        menu = MockMenuBase()
+        # First day gets invalid time, second gets valid, rest empty
+        times = iter(['abc', '14:30', '', '', '', '', ''])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule_helpers.Prompt.ask',
+            lambda *a, **k: next(times)
+        )
+
+        result = configure_weekly_schedule(menu)
+        assert result is not None
+        assert result['monday']['enabled'] is False
+        assert result['tuesday']['enabled'] is True
+        assert result['tuesday']['time'] == '14:30'
+
+    def test_out_of_range_time_skipped(self, monkeypatch):
+        menu = MockMenuBase()
+        # Hour 25 is invalid
+        times = iter(['25:00', '10:00', '', '', '', '', ''])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule_helpers.Prompt.ask',
+            lambda *a, **k: next(times)
+        )
+
+        result = configure_weekly_schedule(menu)
+        assert result['monday']['enabled'] is False
+        assert result['tuesday']['enabled'] is True
+
+    def test_hour_only_input(self, monkeypatch):
+        menu = MockMenuBase()
+        # "10" without minutes should be treated as 10:00
+        times = iter(['10', '', '', '', '', '', ''])
+        monkeypatch.setattr(
+            'praetorian_cli.ui.aegis.commands.schedule_helpers.Prompt.ask',
+            lambda *a, **k: next(times)
+        )
+
+        result = configure_weekly_schedule(menu)
+        assert result['monday']['enabled'] is True
+        assert result['monday']['time'] == '10:00'
+
+
+# --- ScheduleCompleter tests ---
+
+class TestScheduleCompleter:
+    def test_completions_returned_for_matching_input(self):
+        schedules = [
+            {
+                'scheduleId': 'abc123-def456',
+                'capabilityName': 'windows-smb',
+                'status': 'active',
+                'targetKey': '#asset#server01#server01',
+                'clientId': 'C.1',
+            }
+        ]
+        completer = ScheduleCompleter(schedules, agent_lookup={'C.1': 'server01'})
+
+        class FakeDoc:
+            text_before_cursor = 'abc'
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        assert len(completions) == 1
+        assert completions[0].text == 'abc123-def456'
+
+    def test_no_completions_for_non_matching(self):
+        schedules = [
+            {
+                'scheduleId': 'abc123',
+                'capabilityName': 'windows-smb',
+                'status': 'active',
+                'targetKey': '',
+                'clientId': '',
+            }
+        ]
+        completer = ScheduleCompleter(schedules)
+
+        class FakeDoc:
+            text_before_cursor = 'zzz'
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        assert len(completions) == 0
+
+    def test_empty_input_returns_all(self):
+        schedules = [
+            {'scheduleId': 'aaa', 'capabilityName': 'cap1', 'status': 'active', 'targetKey': '', 'clientId': ''},
+            {'scheduleId': 'bbb', 'capabilityName': 'cap2', 'status': 'paused', 'targetKey': '', 'clientId': ''},
+        ]
+        completer = ScheduleCompleter(schedules)
+
+        class FakeDoc:
+            text_before_cursor = ''
+
+        completions = list(completer.get_completions(FakeDoc(), None))
+        assert len(completions) == 2
+
+
+# --- find_schedule_by_prefix tests ---
+
+class MockSchedules:
+    def __init__(self, schedules=None):
+        self._schedules = schedules or []
+
+    def list(self, pages=1):
+        return self._schedules, None
+
+
+class TestFindScheduleByPrefix:
+    def test_finds_by_prefix(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([
+            {'scheduleId': 'abc123-def456', 'capabilityName': 'test'},
+            {'scheduleId': 'xyz789', 'capabilityName': 'other'},
+        ])})()
+
+        schedule, full_id = find_schedule_by_prefix(menu, 'abc')
+        assert full_id == 'abc123-def456'
+        assert schedule['capabilityName'] == 'test'
+
+    def test_returns_none_when_not_found(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([
+            {'scheduleId': 'abc123', 'capabilityName': 'test'},
+        ])})()
+
+        schedule, full_id = find_schedule_by_prefix(menu, 'zzz')
+        assert schedule is None
+        assert full_id is None
+
+    def test_returns_none_on_empty_list(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([])})()
+
+        schedule, full_id = find_schedule_by_prefix(menu, 'abc')
+        assert schedule is None
+        assert full_id is None
+
+    def test_returns_none_on_api_error(self):
+        class BrokenSchedules:
+            def list(self, pages=1):
+                raise Exception("API error")
+
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': BrokenSchedules()})()
+
+        schedule, full_id = find_schedule_by_prefix(menu, 'abc')
+        assert schedule is None
+        assert full_id is None
+
+
+# --- complete_schedule_ids tests ---
+
+class TestCompleteScheduleIds:
+    def test_matches_by_id_prefix(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([
+            {'scheduleId': 'abc123-def456', 'capabilityName': 'test', 'clientId': ''},
+        ])})()
+
+        results = complete_schedule_ids(menu, 'abc')
+        assert len(results) == 1
+        assert results[0] == 'abc123-def'  # Short ID (first 10 chars)
+
+    def test_matches_by_capability_name(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([
+            {'scheduleId': 'abc123-def456', 'capabilityName': 'windows-smb', 'clientId': ''},
+        ])})()
+
+        results = complete_schedule_ids(menu, 'windows')
+        assert len(results) == 1
+
+    def test_no_matches_returns_empty(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([
+            {'scheduleId': 'abc123', 'capabilityName': 'test', 'clientId': ''},
+        ])})()
+
+        results = complete_schedule_ids(menu, 'zzz')
+        assert len(results) == 0
+
+    def test_empty_schedules_returns_empty(self):
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': MockSchedules([])})()
+
+        results = complete_schedule_ids(menu, '')
+        assert len(results) == 0
+
+    def test_api_error_returns_empty(self):
+        class BrokenSchedules:
+            def list(self, pages=1):
+                raise Exception("API error")
+
+        menu = MockMenuBase()
+        menu.sdk = type('SDK', (), {'schedules': BrokenSchedules()})()
+
+        results = complete_schedule_ids(menu, 'abc')
+        assert len(results) == 0

--- a/praetorian_cli/sdk/test/ui/test_aegis_schedules_sdk.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_schedules_sdk.py
@@ -1,0 +1,186 @@
+"""Tests for SDK schedules entity - verifies routing through self.api helpers."""
+
+import pytest
+from unittest.mock import MagicMock
+from praetorian_cli.sdk.entities.schedules import Schedules
+
+pytestmark = pytest.mark.tui
+
+
+class TestCreate:
+    """Test that create() builds the correct body and routes through self.api.post."""
+
+    def _make_schedules(self):
+        api = MagicMock()
+        api.post.return_value = {'scheduleId': 'new-id', 'status': 'active'}
+        return Schedules(api), api
+
+    def test_create_minimal_body(self):
+        sched, api = self._make_schedules()
+        weekly = {'monday': {'enabled': True, 'time': '10:00'}}
+
+        sched.create(
+            capability_name='windows-smb',
+            target_key='#asset#host#host',
+            weekly_schedule=weekly,
+            start_date='2024-01-15T00:00:00Z',
+        )
+
+        api.post.assert_called_once()
+        call_args = api.post.call_args
+        assert call_args[0][0] == 'capability/schedule'
+        body = call_args[0][1]
+        assert body['capabilityName'] == 'windows-smb'
+        assert body['targetKey'] == '#asset#host#host'
+        assert body['weeklySchedule'] == weekly
+        assert body['startDate'] == '2024-01-15T00:00:00Z'
+        assert 'endDate' not in body
+        assert 'config' not in body
+        assert 'clientId' not in body
+
+    def test_create_with_all_optional_fields(self):
+        sched, api = self._make_schedules()
+        weekly = {'monday': {'enabled': True, 'time': '10:00'}}
+
+        sched.create(
+            capability_name='ad-enum',
+            target_key='#addomain#example.local#example.local',
+            weekly_schedule=weekly,
+            start_date='2024-01-15T00:00:00Z',
+            end_date='2024-12-31T23:59:59Z',
+            config={'aegis': 'true', 'credential_id': 'cred-123'},
+            client_id='C.abc123',
+        )
+
+        body = api.post.call_args[0][1]
+        assert body['endDate'] == '2024-12-31T23:59:59Z'
+        assert body['config']['credential_id'] == 'cred-123'
+        assert body['clientId'] == 'C.abc123'
+
+    def test_create_returns_api_response(self):
+        sched, api = self._make_schedules()
+        weekly = {'monday': {'enabled': True, 'time': '10:00'}}
+
+        result = sched.create(
+            capability_name='test',
+            target_key='#asset#h#h',
+            weekly_schedule=weekly,
+            start_date='2024-01-15T00:00:00Z',
+        )
+        assert result['scheduleId'] == 'new-id'
+
+
+class TestUpdate:
+    """Test that update() builds the correct body and routes through self.api.put."""
+
+    def _make_schedules(self):
+        api = MagicMock()
+        api.put.return_value = {'scheduleId': 'test-id', 'status': 'active'}
+        return Schedules(api), api
+
+    def test_update_only_weekly_schedule(self):
+        sched, api = self._make_schedules()
+        weekly = {'tuesday': {'enabled': True, 'time': '14:00'}}
+
+        sched.update(schedule_id='test-id', weekly_schedule=weekly)
+
+        api.put.assert_called_once()
+        assert api.put.call_args[0][0] == 'capability/schedule/test-id'
+        body = api.put.call_args[0][1]
+        assert body['weeklySchedule'] == weekly
+        assert 'startDate' not in body
+        assert 'endDate' not in body
+
+    def test_update_no_fields_sends_empty_body(self):
+        sched, api = self._make_schedules()
+
+        sched.update(schedule_id='test-id')
+
+        body = api.put.call_args[0][1]
+        assert body == {}
+
+
+class TestDelete:
+    """Test delete routes through self.api.delete."""
+
+    def test_delete_calls_api_delete(self):
+        api = MagicMock()
+        api.delete.return_value = {}
+        sched = Schedules(api)
+
+        sched.delete('del-id')
+
+        api.delete.assert_called_once_with('capability/schedule/del-id', {}, {})
+
+
+class TestPause:
+    """Test pause routes through self.api.patch."""
+
+    def test_pause_calls_api_patch(self):
+        api = MagicMock()
+        api.patch.return_value = {'scheduleId': 'sched-id', 'status': 'paused'}
+        sched = Schedules(api)
+
+        result = sched.pause('sched-id')
+
+        api.patch.assert_called_once_with('capability/schedule/sched-id/pause')
+        assert result['status'] == 'paused'
+
+
+class TestResume:
+    """Test resume routes through self.api.patch."""
+
+    def test_resume_calls_api_patch(self):
+        api = MagicMock()
+        api.patch.return_value = {'scheduleId': 'sched-id', 'status': 'active'}
+        sched = Schedules(api)
+
+        result = sched.resume('sched-id')
+
+        api.patch.assert_called_once_with('capability/schedule/sched-id/resume')
+        assert result['status'] == 'active'
+
+
+class TestList:
+    """Test list() queries with correct key prefix."""
+
+    def test_list_returns_schedules(self):
+        api = MagicMock()
+        api.my.return_value = {
+            'capabilityschedules': [
+                {'scheduleId': 'a', 'status': 'active'},
+                {'scheduleId': 'b', 'status': 'paused'},
+            ],
+            'offset': None,
+        }
+        sched = Schedules(api)
+
+        schedules, offset = sched.list()
+
+        assert len(schedules) == 2
+        assert offset is None
+        api.my.assert_called_once_with({'key': '#capability_schedule#'}, pages=1)
+
+    def test_list_empty_returns_empty(self):
+        api = MagicMock()
+        api.my.return_value = {'capabilityschedules': [], 'offset': None}
+        sched = Schedules(api)
+
+        schedules, offset = sched.list()
+
+        assert schedules == []
+
+
+class TestGet:
+    """Test get() passes correct key to search."""
+
+    def test_get_builds_correct_key(self):
+        api = MagicMock()
+        api.search = MagicMock()
+        api.search.by_exact_key.return_value = {'scheduleId': 'test-id'}
+        sched = Schedules(api)
+
+        result = sched.get('test-id')
+
+        api.search.by_exact_key.assert_called_once_with('#capability_schedule#test-id')
+        assert result['scheduleId'] == 'test-id'

--- a/praetorian_cli/ui/aegis/commands/help.py
+++ b/praetorian_cli/ui/aegis/commands/help.py
@@ -9,7 +9,7 @@ from ..constants import DEFAULT_COLORS
 def handle_help(menu, args):
     """Show help for commands or a specific command."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
-    if args and args[0] in ['ssh', 'list', 'info', 'job', 'set']:
+    if args and args[0] in ['ssh', 'list', 'info', 'job', 'schedule', 'set']:
         menu.console.print(f"\nHelp for '{args[0]}' command - see main help for details\n")
         menu.pause()
         return
@@ -34,6 +34,12 @@ def handle_help(menu, args):
     commands_table.add_row("job list", "List recent jobs for selected agent")
     commands_table.add_row("job capabilities [--details]", "List available capabilities")
     commands_table.add_row("job run <capability>", "Run capability on selected agent")
+    commands_table.add_row("schedule list", "List scheduled jobs")
+    commands_table.add_row("schedule add", "Create a new scheduled job")
+    commands_table.add_row("schedule view <id>", "View schedule details")
+    commands_table.add_row("schedule edit <id>", "Edit a schedule")
+    commands_table.add_row("schedule delete <id>", "Delete a schedule")
+    commands_table.add_row("schedule pause/resume <id>", "Pause or resume a schedule")
     commands_table.add_row("reload", "Refresh agent list from server")
     commands_table.add_row("help [command]", "Show this help or command-specific help")
     commands_table.add_row("clear", "Clear terminal screen")
@@ -65,6 +71,10 @@ def handle_help(menu, args):
     examples_table.add_row("job capabilities", "List available capabilities")
     examples_table.add_row("job caps --details", "Show full capability descriptions")
     examples_table.add_row("job run windows-enum", "Run capability on selected agent")
+    examples_table.add_row("schedule list", "List all scheduled jobs")
+    examples_table.add_row("schedule add", "Create a new scheduled job")
+    examples_table.add_row("schedule view abc123", "View schedule details")
+    examples_table.add_row("schedule pause abc123", "Pause a scheduled job")
     examples_table.add_row("info", "Show agent details")
     examples_table.add_row("info --raw", "Show raw agent data (JSON format)")
 

--- a/praetorian_cli/ui/aegis/commands/info.py
+++ b/praetorian_cli/ui/aegis/commands/info.py
@@ -1,3 +1,6 @@
+from ..constants import DEFAULT_COLORS
+
+
 def handle_info(menu, args):
     """Show detailed information for the selected agent."""
     if not menu.selected_agent:
@@ -7,11 +10,12 @@ def handle_info(menu, args):
 
     # Check for raw flag
     raw = ('--raw' in args) or ('-r' in args)
-    
+
     try:
         _show_agent_info(menu, menu.selected_agent, raw=raw)
     except Exception as e:
-        menu.console.print(f"[red]Error getting agent info: {e}[/red]")
+        colors = getattr(menu, 'colors', DEFAULT_COLORS)
+        menu.console.print(f"[{colors['error']}]Error getting agent info: {e}[/{colors['error']}]")
         menu.pause()
 
 
@@ -20,18 +24,18 @@ def _show_agent_info(menu, agent, raw=False):
     import json
     from datetime import datetime
     
-    colors = getattr(menu, 'colors', {})
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
     hostname = agent.hostname or 'Unknown'
-    
+
     # Clear screen and show header
     menu.clear_screen()
     menu.console.print()
-    menu.console.print(f"  [{colors.get('primary', 'cyan')}]Agent Details[/{colors.get('primary', 'cyan')}]")
+    menu.console.print(f"  [{colors['primary']}]Agent Details[/{colors['primary']}]")
     menu.console.print()
 
     if raw:
         # Raw JSON dump with minimal styling
-        menu.console.print(f"  [{colors.get('dim', 'dim')}]Raw agent data:[/{colors.get('dim', 'dim')}]")
+        menu.console.print(f"  [{colors['dim']}]Raw agent data:[/{colors['dim']}]")
         menu.console.print()
         # Convert agent to dict for JSON serialization
         agent_dict = agent.to_dict() if hasattr(agent, 'to_dict') else agent.__dict__
@@ -80,21 +84,21 @@ def _show_agent_info(menu, agent, raw=False):
         is_online = (current_time - last_seen_seconds) < 60
         last_seen_str = datetime.fromtimestamp(last_seen_seconds).strftime("%Y-%m-%d %H:%M:%S")
         if is_online:
-            status_text = f"[{colors.get('success', 'green')}]● online[/{colors.get('success', 'green')}]"
+            status_text = f"[{colors['success']}]● online[/{colors['success']}]"
         else:
-            status_text = f"[{colors.get('error', 'red')}]○ offline[/{colors.get('error', 'red')}]"
+            status_text = f"[{colors['error']}]○ offline[/{colors['error']}]"
     else:
         last_seen_str = "never"
-        status_text = f"[{colors.get('error', 'red')}]○ offline[/{colors.get('error', 'red')}]"
+        status_text = f"[{colors['error']}]○ offline[/{colors['error']}]"
         is_online = False
 
     # Simple, clean output
     menu.console.print(f"  [bold white]{hostname}[/bold white]  {status_text}")
-    menu.console.print(f"  [{colors.get('dim', 'dim')}]{fqdn}[/{colors.get('dim', 'dim')}]")
+    menu.console.print(f"  [{colors['dim']}]{fqdn}[/{colors['dim']}]")
     menu.console.print()
     
     # System info
-    menu.console.print(f"  [{colors.get('dim', 'dim')}]System[/{colors.get('dim', 'dim')}]")
+    menu.console.print(f"  [{colors['dim']}]System[/{colors['dim']}]")
     menu.console.print(f"    OS:           {os_info} {os_version}")
     menu.console.print(f"    Architecture: {architecture}")
     if ip_info:
@@ -114,7 +118,7 @@ def _show_agent_info(menu, agent, raw=False):
         public_hostname = cf_status.hostname or 'N/A'
         authorized_users = cf_status.authorized_users or ''
         
-        menu.console.print(f"  [{colors.get('warning', 'yellow')}]Tunnel active[/{colors.get('warning', 'yellow')}]")
+        menu.console.print(f"  [{colors['warning']}]Tunnel active[/{colors['warning']}]")
         menu.console.print(f"    Name:      {tunnel_name}")
         menu.console.print(f"    Public:    {public_hostname}")
         
@@ -122,7 +126,7 @@ def _show_agent_info(menu, agent, raw=False):
             users_list = [u.strip() for u in authorized_users.split(',')]
             menu.console.print(f"    Authorized: {', '.join(users_list)}")
     else:
-        menu.console.print(f"  [{colors.get('dim', 'dim')}]No tunnel configured[/{colors.get('dim', 'dim')}]")
+        menu.console.print(f"  [{colors['dim']}]No tunnel configured[/{colors['dim']}]")
     
     menu.console.print()
     menu.pause()

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -1,0 +1,340 @@
+"""Shared helpers for job and schedule commands - capability picker, domain/credential
+selectors, parameter configuration."""
+
+import json
+from rich.prompt import Prompt, Confirm
+from prompt_toolkit import prompt as pt_prompt
+from prompt_toolkit.completion import Completer, Completion, FuzzyCompleter
+from ..constants import DEFAULT_COLORS
+
+
+# ---------------------------------------------------------------------------
+# Capability helpers
+# ---------------------------------------------------------------------------
+
+def _parse_capability_name(name):
+    """Extract OS, category, and tool from capability name.
+
+    Pattern: {os}-{category}-{tool}[-{action}]
+    Examples:
+        windows-ad-umber-collect -> os=windows, category=ad, tool=umber
+        windows-smb-snaffler -> os=windows, category=smb, tool=snaffler
+        linux-enum-linpeas -> os=linux, category=enum, tool=linpeas
+    """
+    parts = name.split('-')
+    if len(parts) >= 3:
+        return {'os': parts[0], 'category': parts[1], 'tool': parts[2]}
+    elif len(parts) == 2:
+        return {'os': parts[0], 'category': parts[1], 'tool': ''}
+    else:
+        return {'os': '', 'category': '', 'tool': name}
+
+
+class CapabilityCompleter(Completer):
+    """Custom completer for capabilities with metadata display."""
+
+    def __init__(self, capabilities):
+        """Initialize with list of capability dicts from API."""
+        self.capabilities = capabilities
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor.lower()
+
+        for cap in self.capabilities:
+            name = cap.get('name', '')
+            name_lower = name.lower()
+            target = cap.get('target', 'asset').lower()
+            description = cap.get('description', '') or ''
+            parsed = _parse_capability_name(name)
+            category = parsed.get('category', '')
+
+            # Build searchable text (name + category + target)
+            searchable = f"{name_lower} {category} {target}"
+
+            # Check if input matches any part
+            if not text or text in searchable:
+                # Format: name    [target]  category  description
+                desc_truncated = description[:35] + '...' if len(description) > 35 else description
+                display_meta = f"[{target}] {category:<6} {desc_truncated}"
+
+                yield Completion(
+                    name,
+                    start_position=-len(document.text_before_cursor),
+                    display=name,
+                    display_meta=display_meta,
+                )
+
+
+def capability_needs_credentials(capability_info):
+    """Check if a capability requires credentials based on its parameters."""
+    credential_params = {'username', 'password', 'domain'}
+    parameters = capability_info.get('parameters', [])
+    if isinstance(parameters, dict):
+        param_names = {k.lower() for k in parameters.keys()}
+    elif isinstance(parameters, list):
+        param_names = {p.get('name', '').lower() for p in parameters}
+    else:
+        return False
+    return bool(credential_params & param_names)
+
+
+# ---------------------------------------------------------------------------
+# Interactive pickers
+# ---------------------------------------------------------------------------
+
+def interactive_capability_picker(menu, suggested=None):
+    """Interactive capability picker with fuzzy search."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    if suggested:
+        # Validate the suggested capability first
+        capability_info = menu.sdk.aegis.validate_capability(suggested)
+        if capability_info:
+            # Show the suggested capability and ask for confirmation
+            desc = (capability_info.get('description', '') or '')[:60]
+            target = capability_info.get('target', 'asset')
+            menu.console.print(f"\n  Suggested capability:")
+            menu.console.print(f"    {suggested} [{target}]")
+            menu.console.print(f"    [{colors['dim']}]{desc}[/{colors['dim']}]")
+
+            if Confirm.ask("  Use this capability?", default=True):
+                return suggested
+            # If they decline, continue to show the full picker below
+
+    try:
+        # Determine agent OS for filtering
+        agent_os = detect_agent_os(menu)
+
+        # Get capabilities filtered by OS
+        caps = menu.sdk.aegis.get_capabilities(surface_filter='internal', agent_os=agent_os)
+
+        if not caps:
+            # Fallback to all capabilities
+            caps = menu.sdk.aegis.get_capabilities(surface_filter='internal')
+
+        if not caps:
+            menu.console.print("  No capabilities available.")
+            return None
+
+        # Sort capabilities by name
+        caps.sort(key=lambda x: x.get('name', ''))
+
+        if agent_os:
+            menu.console.print(f"\n  [{colors['dim']}]Showing {agent_os.title()} capabilities ({len(caps)} available)[/{colors['dim']}]")
+        else:
+            menu.console.print(f"\n  [{colors['dim']}]{len(caps)} capabilities available[/{colors['dim']}]")
+
+        menu.console.print(f"  [{colors['dim']}]Type to filter, Tab to complete, Enter to select, Ctrl+C to cancel[/{colors['dim']}]")
+
+        # Create fuzzy completer with capability metadata
+        base_completer = CapabilityCompleter(caps)
+        fuzzy_completer = FuzzyCompleter(base_completer)
+
+        try:
+            # Use prompt_toolkit for fuzzy search
+            result = pt_prompt(
+                "  Select capability: ",
+                completer=fuzzy_completer,
+                complete_while_typing=True,
+            )
+
+            if result and result.strip():
+                return result.strip()
+            else:
+                menu.console.print("  No capability selected.")
+                return None
+
+        except KeyboardInterrupt:
+            menu.console.print("\n  Cancelled")
+            return None
+        except EOFError:
+            menu.console.print("\n  Cancelled")
+            return None
+
+    except Exception as e:
+        menu.console.print(f"  Error loading capabilities: {e}")
+        return Prompt.ask("  Enter capability name manually")
+
+
+def detect_agent_os(menu):
+    """Detect the operating system of the selected agent"""
+    if not menu.selected_agent:
+        return None
+
+    os_field = (menu.selected_agent.os or '').lower()
+
+    if os_field:
+        if 'linux' in os_field or os_field in ['ubuntu', 'centos', 'debian', 'rhel', 'fedora', 'suse']:
+            return 'linux'
+        elif 'windows' in os_field or os_field in ['win32', 'win64', 'nt']:
+            return 'windows'
+
+    return None
+
+
+def select_domain(menu):
+    """Interactive domain selection with numbered list."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    try:
+        menu.console.print(f"  [{colors['dim']}]Looking for available domains...[/{colors['dim']}]")
+
+        domains = menu.sdk.aegis.get_available_ad_domains()
+
+        menu.console.print(f"  [{colors['dim']}]Found {len(domains)} domains[/{colors['dim']}]")
+
+        if domains:
+            menu.console.print(f"\n  Available domains:")
+            for i, domain in enumerate(domains[:10], 1):
+                menu.console.print(f"    {i:2d}. {domain}")
+
+            if len(domains) > 10:
+                menu.console.print(f"    [{colors['dim']}]... and {len(domains) - 10} more[/{colors['dim']}]")
+
+            menu.console.print(f"     0. Enter domain manually")
+
+            while True:
+                try:
+                    choice = Prompt.ask("  Choose domain", default="1")
+                    choice_num = int(choice.strip())
+
+                    if choice_num == 0:
+                        return Prompt.ask("  Enter domain name")
+                    elif 1 <= choice_num <= min(len(domains), 10):
+                        return domains[choice_num - 1]
+                    else:
+                        menu.console.print(f"  Please enter a number between 0 and {min(len(domains), 10)}")
+
+                except ValueError:
+                    menu.console.print("  Please enter a valid number")
+                except KeyboardInterrupt:
+                    return None
+        else:
+            menu.console.print(f"  [{colors['dim']}]No domains found in assets. You can still enter one manually.[/{colors['dim']}]")
+            return Prompt.ask("  Enter domain name (e.g., contoso.com, example.local)")
+
+    except Exception as e:
+        menu.console.print(f"  [{colors['dim']}]Error during domain selection: {e}[/{colors['dim']}]")
+        return Prompt.ask("  Enter domain name (e.g., contoso.com, example.local)")
+
+
+def select_credentials(menu):
+    """Interactive credential selection with numbered list.
+
+    Returns:
+        tuple: (credential_key, credential_display_name) or (None, None) if skipped
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    try:
+        menu.console.print(f"  [{colors['dim']}]Fetching available credentials...[/{colors['dim']}]")
+
+        all_credentials, _ = menu.sdk.credentials.list()
+        credentials = [c for c in all_credentials if c.get('type') == 'active-directory']
+
+        if not credentials:
+            menu.console.print(f"  [{colors['dim']}]No active-directory credentials found.[/{colors['dim']}]")
+            return None, None
+
+        menu.console.print(f"\n  Available credentials:")
+        for i, cred in enumerate(credentials[:10], 1):
+            name = cred.get('name', 'Unknown')
+            username = cred.get('username', '')
+            display = f"{name} ({username})" if username else name
+            menu.console.print(f"    {i:2d}. {display}")
+
+        if len(credentials) > 10:
+            menu.console.print(f"    [{colors['dim']}]... and {len(credentials) - 10} more[/{colors['dim']}]")
+
+        menu.console.print(f"     0. Skip credential attachment")
+
+        while True:
+            try:
+                choice = Prompt.ask("  Choose credential", default="1")
+                choice_num = int(choice.strip())
+
+                if choice_num == 0:
+                    menu.console.print("  Skipped credential attachment.")
+                    return None, None
+                elif 1 <= choice_num <= min(len(credentials), 10):
+                    selected = credentials[choice_num - 1]
+                    name = selected.get('name', 'Unknown')
+                    username = selected.get('username', '')
+                    display_name = f"{name} ({username})" if username else name
+                    menu.console.print(f"  [{colors['success']}]Credential selected: {display_name}[/{colors['success']}]")
+                    return selected.get('key', ''), display_name
+                else:
+                    menu.console.print(f"  Please enter a number between 0 and {min(len(credentials), 10)}")
+
+            except ValueError:
+                menu.console.print("  Please enter a valid number")
+            except KeyboardInterrupt:
+                menu.console.print("  Skipped")
+                return None, None
+
+    except Exception as e:
+        menu.console.print(f"  [{colors['dim']}]Error fetching credentials: {e}[/{colors['dim']}]")
+        return None, None
+
+
+def configure_parameters(menu, capability_info, has_credential=False):
+    """Interactive parameter configuration - returns dict of parameter values.
+
+    Args:
+        menu: Menu instance with console access
+        capability_info: Capability information with parameters
+        has_credential: If True, skip Username/Password/Domain params (they come from credential)
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    parameters = capability_info.get('parameters', [])
+    if not parameters:
+        return {}
+
+    # Parameters that come from credentials (skip if credential attached)
+    credential_params = {'Username', 'Password', 'Domain'}
+
+    menu.console.print(f"\n  [{colors['dim']}]Configure parameters (press Enter to use default):[/{colors['dim']}]")
+
+    configured = {}
+
+    # Handle both dict format (legacy/tests) and list format (actual API)
+    if isinstance(parameters, dict):
+        # Dict format: {'timeout': '300', 'threads': '10'}
+        for param_name, default_value in parameters.items():
+            # Skip credential params if credential is attached
+            if has_credential and param_name in credential_params:
+                continue
+            value = Prompt.ask(f"  {param_name}", default=str(default_value))
+            configured[param_name] = value
+    elif isinstance(parameters, list):
+        # List format: [{'name': 'timeout', 'default': 300}, {'name': 'threads', 'default': 10}]
+        for param in parameters:
+            param_name = param.get('name', '')
+            default_value = param.get('default', '')
+            if param_name:
+                # Skip credential params if credential is attached
+                if has_credential and param_name in credential_params:
+                    continue
+                value = Prompt.ask(f"  {param_name}", default=str(default_value))
+                configured[param_name] = value
+
+    return configured
+
+
+def resolve_addomain_target_key(menu, domain):
+    """Query the assets API to resolve an AD domain to its actual asset key (with SID).
+
+    Returns:
+        str: The actual asset key, or None if the domain asset was not found.
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    try:
+        assets, _ = menu.sdk.assets.list(key_prefix=f"#addomain#{domain}")
+        if assets and len(assets) > 0:
+            return assets[0].get('key')
+    except Exception as e:
+        menu.console.print(f"  [{colors['error']}]Error querying domain asset: {e}[/{colors['error']}]")
+
+    return None

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -1,0 +1,551 @@
+"""Schedule command handlers for Aegis TUI."""
+
+from datetime import datetime, timezone
+from rich.table import Table
+from rich.box import MINIMAL
+from rich.prompt import Prompt, Confirm
+from ..constants import DEFAULT_COLORS
+from .schedule_helpers import (
+    DAYS, DAY_ABBREVS,
+    format_target, format_days, format_status,
+    format_next_execution, format_date, format_datetime,
+    configure_weekly_schedule, interactive_schedule_picker,
+    complete_schedule_ids, invalidate_schedule_cache,
+)
+from .job_helpers import (
+    interactive_capability_picker,
+    select_domain,
+    select_credentials,
+    configure_parameters,
+    capability_needs_credentials,
+    resolve_addomain_target_key,
+)
+
+
+def handle_schedule(menu, args):
+    """Handle schedule command with subcommands: list, view, add, edit, delete, pause, resume."""
+    if not args:
+        show_schedule_help(menu)
+        return
+
+    subcommand = args[0].lower()
+    if subcommand == 'list':
+        list_schedules(menu)
+    elif subcommand == 'view':
+        view_schedule(menu, args[1:])
+    elif subcommand == 'add':
+        add_schedule(menu)
+    elif subcommand == 'edit':
+        edit_schedule(menu, args[1:])
+    elif subcommand == 'delete':
+        delete_schedule(menu, args[1:])
+    elif subcommand == 'pause':
+        pause_schedule(menu, args[1:])
+    elif subcommand == 'resume':
+        resume_schedule(menu, args[1:])
+    else:
+        menu.console.print(f"\n  Unknown schedule subcommand: {subcommand}")
+        show_schedule_help(menu)
+
+
+def show_schedule_help(menu):
+    help_text = """
+  Schedule Commands
+
+  schedule list                   List all scheduled jobs
+  schedule view [id]              View schedule details (interactive picker)
+  schedule add                    Create a new scheduled job (interactive)
+  schedule edit [id]              Edit an existing schedule (interactive picker)
+  schedule delete [id]            Delete a schedule (interactive picker)
+  schedule pause [id]             Pause a schedule (interactive picker)
+  schedule resume [id]            Resume a paused schedule (interactive picker)
+
+  Examples:
+    schedule list                  # List all schedules
+    schedule view                  # Interactive fuzzy picker to select schedule
+    schedule view abc123           # View schedule by ID prefix
+    schedule add                   # Create new schedule interactively
+    schedule edit                  # Interactive fuzzy picker then edit
+    schedule edit abc123           # Edit schedule by ID prefix
+    schedule delete abc123         # Delete schedule
+    schedule pause abc123          # Pause schedule
+    schedule resume abc123         # Resume paused schedule
+"""
+    menu.console.print(help_text)
+    menu.pause()
+
+
+def list_schedules(menu):
+    """List all schedules for the current user."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    try:
+        schedules, _ = menu.sdk.schedules.list()
+
+        if not schedules:
+            menu.console.print("\n  No scheduled jobs found\n")
+            menu.console.print("  Use 'schedule add' to create one.\n")
+            menu.pause()
+            return
+
+        # Sort by next execution time
+        schedules.sort(key=lambda s: s.get('nextExecution', '') or 'zzz')
+
+        # Use cached agent lookup from menu (built when agents were loaded)
+        agent_lookup = getattr(menu, 'agent_lookup', {})
+        table = Table(
+            show_header=True,
+            header_style=f"bold {colors['primary']}",
+            border_style=colors['dim'],
+            box=MINIMAL,
+            show_lines=False,
+            padding=(0, 2),
+            pad_edge=False
+        )
+
+        table.add_column("ID", style=f"bold {colors['accent']}", width=10, no_wrap=True)
+        table.add_column("CAPABILITY", style="white", min_width=20, no_wrap=True)
+        table.add_column("AGENT", style=f"{colors['success']}", min_width=15, no_wrap=True)
+        table.add_column("TARGET", style=f"{colors['dim']}", min_width=15, no_wrap=True)
+        table.add_column("DAYS", style="white", width=21, no_wrap=True)
+        table.add_column("STATUS", width=8, justify="center", no_wrap=True)
+        table.add_column("NEXT RUN", style=f"{colors['dim']}", width=12, justify="right", no_wrap=True)
+
+        menu.console.print()
+        menu.console.print("  Scheduled Jobs")
+        menu.console.print()
+
+        for schedule in schedules:
+            schedule_id = schedule.get('scheduleId', '')[:10]
+            capability = schedule.get('capabilityName', 'unknown')
+            target_key = schedule.get('targetKey', '')
+            status = schedule.get('status', 'unknown')
+            next_exec = schedule.get('nextExecution', '')
+            client_id = schedule.get('clientId', '')
+
+            # Get agent hostname from lookup, fall back to client_id or config
+            if client_id and client_id in agent_lookup:
+                agent_display = agent_lookup[client_id]
+            elif client_id:
+                # Show shortened client_id if no hostname found
+                agent_display = client_id[:15] + '...' if len(client_id) > 15 else client_id
+            else:
+                # Try to get from config
+                config = schedule.get('config', {})
+                client_id_from_config = config.get('client_id', '')
+                if client_id_from_config and client_id_from_config in agent_lookup:
+                    agent_display = agent_lookup[client_id_from_config]
+                elif client_id_from_config:
+                    agent_display = client_id_from_config[:15] + '...' if len(client_id_from_config) > 15 else client_id_from_config
+                else:
+                    agent_display = '—'
+
+            # Format target display
+            target_display = format_target(target_key)
+
+            # Format days display
+            days_display = format_days(schedule.get('weeklySchedule', {}))
+
+            # Format status with color
+            status_display = format_status(status, colors)
+
+            # Format next execution
+            next_display = format_next_execution(next_exec)
+
+            table.add_row(schedule_id, capability, agent_display, target_display, days_display, status_display, next_display)
+
+        menu.console.print(table)
+        menu.console.print()
+        menu.pause()
+
+    except Exception as e:
+        menu.console.print(f"[{colors['error']}]Error listing schedules: {e}[/{colors['error']}]")
+        menu.pause()
+
+
+def view_schedule(menu, args):
+    """View detailed information about a schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Use interactive picker if no ID provided, otherwise validate the provided one
+    suggested_id = args[0] if args else None
+    schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule view")
+
+    if not schedule:
+        if suggested_id:
+            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+        menu.pause()
+        return
+
+    try:
+        # Use cached agent lookup from menu
+        agent_lookup = getattr(menu, 'agent_lookup', {})
+
+        menu.console.print()
+        menu.console.print(f"  [bold {colors['primary']}]Schedule Details[/]")
+        menu.console.print()
+        menu.console.print(f"  ID:            {schedule.get('scheduleId', 'N/A')}")
+        menu.console.print(f"  Capability:    {schedule.get('capabilityName', 'N/A')}")
+        menu.console.print(f"  Target:        {schedule.get('targetKey', 'N/A')}")
+        menu.console.print(f"  Status:        {format_status(schedule.get('status', 'unknown'), colors)}")
+
+        # Show agent information
+        client_id = schedule.get('clientId', '')
+        if not client_id:
+            config = schedule.get('config', {})
+            client_id = config.get('client_id', '')
+
+        if client_id:
+            agent_hostname = agent_lookup.get(client_id, '')
+            if agent_hostname:
+                menu.console.print(f"  Agent:         [{colors['success']}]{agent_hostname}[/{colors['success']}]")
+                menu.console.print(f"  Client ID:     [{colors['dim']}]{client_id}[/{colors['dim']}]")
+            else:
+                menu.console.print(f"  Client ID:     {client_id}")
+
+        menu.console.print()
+        menu.console.print(f"  [bold {colors['primary']}]Schedule[/]")
+        weekly = schedule.get('weeklySchedule', {})
+        for day, abbrev in zip(DAYS, DAY_ABBREVS):
+            day_sched = weekly.get(day, {})
+            if day_sched.get('enabled'):
+                time_str = day_sched.get('time', 'N/A')
+                menu.console.print(f"    {abbrev}: [{colors['success']}]✓ {time_str} UTC[/{colors['success']}]")
+            else:
+                menu.console.print(f"    {abbrev}: [{colors['dim']}]—[/{colors['dim']}]")
+
+        menu.console.print()
+        menu.console.print(f"  [bold {colors['primary']}]Dates[/]")
+        menu.console.print(f"  Start:         {format_date(schedule.get('startDate', ''))}")
+        end_date = schedule.get('endDate', '')
+        menu.console.print(f"  End:           {format_date(end_date) if end_date else 'No end date'}")
+
+        menu.console.print()
+        menu.console.print(f"  [bold {colors['primary']}]Execution[/]")
+        next_exec = schedule.get('nextExecution', '')
+        last_exec = schedule.get('lastExecution', '')
+        menu.console.print(f"  Next:          {format_datetime(next_exec) if next_exec else 'Not scheduled'}")
+        menu.console.print(f"  Last:          {format_datetime(last_exec) if last_exec else 'Never'}")
+
+        # Show config if present
+        config = schedule.get('config', {})
+        if config:
+            menu.console.print()
+            menu.console.print(f"  [bold {colors['primary']}]Configuration[/]")
+            for key, value in config.items():
+                # Hide sensitive values
+                if 'password' in key.lower() or 'secret' in key.lower():
+                    value = '********'
+                menu.console.print(f"    {key}: {value}")
+
+        menu.console.print()
+        menu.pause()
+
+    except Exception as e:
+        menu.console.print(f"[{colors['error']}]Error viewing schedule: {e}[/{colors['error']}]")
+        menu.pause()
+
+
+def add_schedule(menu):
+    """Interactively create a new schedule."""
+    if not menu.selected_agent:
+        menu.console.print("\n  No agent selected. Use 'set <id>' to select one.\n")
+        menu.pause()
+        return
+
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    menu.console.print(f"\n  [bold {colors['primary']}]Create New Schedule[/bold {colors['primary']}]\n")
+
+    # Select capability
+    capability = interactive_capability_picker(menu)
+    if not capability:
+        return
+
+    # Get capability info
+    capability_info = menu.sdk.aegis.validate_capability(capability)
+    if not capability_info:
+        menu.console.print(f"  [{colors['error']}]Invalid capability: '{capability}'[/{colors['error']}]")
+        menu.pause()
+        return
+
+    target_type = capability_info.get('target', 'asset').lower()
+    hostname = menu.selected_agent.hostname or 'Unknown'
+
+    # Create target key
+    if target_type == 'addomain':
+        domain = select_domain(menu)
+        if not domain:
+            return
+
+        target_key = resolve_addomain_target_key(menu, domain)
+        if not target_key:
+            menu.console.print(f"  [{colors['error']}]No asset found for domain '{domain}'.[/{colors['error']}]")
+            menu.console.print(f"  [{colors['dim']}]The domain must exist as an asset before scheduling jobs against it.[/{colors['dim']}]")
+            menu.console.print(f"  [{colors['dim']}]Add it first with: praetorian chariot add asset --dns {domain} --type addomain[/{colors['dim']}]")
+            menu.pause()
+            return
+
+        target_display = f"domain {domain}"
+    else:
+        target_key = f"#asset#{hostname}#{hostname}"
+        target_display = f"asset {hostname}"
+
+    menu.console.print(f"  Target: {target_display}")
+
+    # Configure weekly schedule
+    menu.console.print(f"\n  [{colors['dim']}]Configure weekly schedule (24-hour UTC times)[/{colors['dim']}]")
+    weekly_schedule = configure_weekly_schedule(menu)
+    if not weekly_schedule:
+        menu.console.print("  Cancelled\n")
+        menu.pause()
+        return
+
+    # Configure start date
+    now = datetime.now(timezone.utc)
+    default_start = now.strftime('%Y-%m-%dT00:00:00Z')
+    start_date = Prompt.ask("  Start date (RFC3339)", default=default_start)
+
+    # Configure end date
+    end_date = Prompt.ask("  End date (RFC3339, leave empty for no end)", default="")
+
+    # Configure parameters
+    config = {}
+    config['aegis'] = 'true'
+    config['client_id'] = menu.selected_agent.client_id or ''
+    config['manual'] = 'true'
+
+    # Handle credentials if needed
+    if capability_needs_credentials(capability_info):
+        if Confirm.ask("  This capability may require credentials. Add them?"):
+            credential_key, _ = select_credentials(menu)
+            if credential_key:
+                parts = credential_key.split('#')
+                if len(parts) >= 5:
+                    config['credential_id'] = parts[-1]
+
+    # Handle large artifact storage - always offer the option
+    # Default to True if capability metadata says it supports it, or if capability name suggests large output
+    capability_suggests_large = capability_info.get('largeArtifact', False) or any(
+        keyword in capability.lower() for keyword in ['snaffler', 'bloodhound', 'sharphound', 'umber', 'dump', 'collect', 'extract']
+    )
+    if Confirm.ask("  Enable large artifact storage? (Results will be uploaded to S3)", default=capability_suggests_large):
+        config['largeArtifact'] = 'true'
+
+    # Optional parameters
+    custom_params = configure_parameters(menu, capability_info, has_credential=bool(config.get('credential_id')))
+    if custom_params:
+        config.update(custom_params)
+
+    # Confirm
+    menu.console.print(f"\n  [bold {colors['primary']}]Summary[/]")
+    menu.console.print(f"  Capability: {capability}")
+    menu.console.print(f"  Target: {target_display}")
+    menu.console.print(f"  Days: {format_days(weekly_schedule)}")
+    menu.console.print(f"  Start: {start_date}")
+    if end_date:
+        menu.console.print(f"  End: {end_date}")
+
+    if not Confirm.ask("\n  Create this schedule?"):
+        menu.console.print("  Cancelled\n")
+        menu.pause()
+        return
+
+    try:
+        result = menu.sdk.schedules.create(
+            capability_name=capability,
+            target_key=target_key,
+            weekly_schedule=weekly_schedule,
+            start_date=start_date,
+            end_date=end_date if end_date else None,
+            config=config,
+            client_id=menu.selected_agent.client_id
+        )
+
+        invalidate_schedule_cache(menu)
+        schedule_id = result.get('scheduleId', 'unknown')
+        menu.console.print(f"\n  [{colors['success']}]✓ Schedule created successfully[/{colors['success']}]")
+        menu.console.print(f"  Schedule ID: {schedule_id}")
+        menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
+
+    except Exception as e:
+        menu.console.print(f"\n[{colors['error']}]Error creating schedule: {e}[/{colors['error']}]")
+
+    menu.console.print()
+    menu.pause()
+
+
+def edit_schedule(menu, args):
+    """Edit an existing schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Use interactive picker if no ID provided, otherwise validate the provided one
+    suggested_id = args[0] if args else None
+    schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule edit")
+
+    if not schedule:
+        if suggested_id:
+            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+        menu.pause()
+        return
+
+    try:
+        menu.console.print(f"\n  [bold {colors['primary']}]Edit Schedule: {schedule_id[:10]}[/]")
+        menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
+        menu.console.print()
+
+        # Edit weekly schedule
+        if Confirm.ask("  Edit weekly schedule?"):
+            weekly_schedule = configure_weekly_schedule(menu)
+            if not weekly_schedule:
+                menu.console.print("  Schedule edit cancelled\n")
+                menu.pause()
+                return
+        else:
+            weekly_schedule = None
+
+        # Edit start date
+        current_start = schedule.get('startDate', '')
+        if Confirm.ask("  Edit start date?"):
+            start_date = Prompt.ask("  Start date (RFC3339)", default=current_start)
+        else:
+            start_date = None
+
+        # Edit end date
+        current_end = schedule.get('endDate', '')
+        if Confirm.ask("  Edit end date?"):
+            end_date = Prompt.ask("  End date (RFC3339, empty to remove)", default=current_end)
+        else:
+            end_date = None
+
+        # Confirm changes
+        if weekly_schedule is None and start_date is None and end_date is None:
+            menu.console.print("  No changes made.\n")
+            menu.pause()
+            return
+
+        if not Confirm.ask("\n  Save changes?"):
+            menu.console.print("  Cancelled\n")
+            menu.pause()
+            return
+
+        result = menu.sdk.schedules.update(
+            schedule_id=schedule_id,
+            weekly_schedule=weekly_schedule,
+            start_date=start_date,
+            end_date=end_date
+        )
+
+        invalidate_schedule_cache(menu)
+        menu.console.print(f"\n[{colors['success']}]✓ Schedule updated successfully[/{colors['success']}]")
+        menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
+
+    except Exception as e:
+        menu.console.print(f"\n[{colors['error']}]Error updating schedule: {e}[/{colors['error']}]")
+
+    menu.console.print()
+    menu.pause()
+
+
+def delete_schedule(menu, args):
+    """Delete a schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Use interactive picker if no ID provided, otherwise validate the provided one
+    suggested_id = args[0] if args else None
+    schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule delete")
+
+    if not schedule:
+        if suggested_id:
+            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+        menu.pause()
+        return
+
+    try:
+        menu.console.print(f"\n  Schedule: {schedule_id[:10]}")
+        menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
+        menu.console.print(f"  Target: {format_target(schedule.get('targetKey', ''))}")
+
+        if not Confirm.ask(f"\n  [{colors['error']}]Delete this schedule?[/{colors['error']}]"):
+            menu.console.print("  Cancelled\n")
+            menu.pause()
+            return
+
+        menu.sdk.schedules.delete(schedule_id)
+        invalidate_schedule_cache(menu)
+        menu.console.print(f"\n[{colors['success']}]✓ Schedule deleted successfully[/{colors['success']}]")
+
+    except Exception as e:
+        menu.console.print(f"\n[{colors['error']}]Error deleting schedule: {e}[/{colors['error']}]")
+
+    menu.console.print()
+    menu.pause()
+
+
+def pause_schedule(menu, args):
+    """Pause a schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Use interactive picker if no ID provided, otherwise validate the provided one
+    suggested_id = args[0] if args else None
+    schedule, full_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule pause")
+
+    if not schedule:
+        if suggested_id:
+            menu.console.print(f"\n[{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
+        menu.pause()
+        return
+
+    try:
+        result = menu.sdk.schedules.pause(full_id)
+        invalidate_schedule_cache(menu)
+        menu.console.print(f"\n[{colors['success']}]✓ Schedule paused[/{colors['success']}]")
+        menu.console.print(f"  Status: {result.get('status', 'paused')}")
+
+    except Exception as e:
+        menu.console.print(f"\n[{colors['error']}]Error pausing schedule: {e}[/{colors['error']}]")
+
+    menu.console.print()
+    menu.pause()
+
+
+def resume_schedule(menu, args):
+    """Resume a paused schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Use interactive picker if no ID provided, otherwise validate the provided one
+    suggested_id = args[0] if args else None
+    schedule, full_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule resume")
+
+    if not schedule:
+        if suggested_id:
+            menu.console.print(f"\n[{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
+        menu.pause()
+        return
+
+    try:
+        result = menu.sdk.schedules.resume(full_id)
+        invalidate_schedule_cache(menu)
+        menu.console.print(f"\n[{colors['success']}]✓ Schedule resumed[/{colors['success']}]")
+        menu.console.print(f"  Status: {result.get('status', 'active')}")
+        menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
+
+    except Exception as e:
+        menu.console.print(f"\n[{colors['error']}]Error resuming schedule: {e}[/{colors['error']}]")
+
+    menu.console.print()
+    menu.pause()
+
+
+def complete(menu, text, tokens):
+    """Autocomplete for schedule command."""
+    sub = ['list', 'view', 'add', 'edit', 'delete', 'pause', 'resume']
+
+    # Complete subcommands
+    if len(tokens) <= 2:
+        return [s for s in sub if s.startswith(text)]
+
+    # Complete schedule IDs for commands that take them
+    subcommand = tokens[1].lower() if len(tokens) > 1 else ''
+    if subcommand in ['view', 'edit', 'delete', 'pause', 'resume']:
+        return complete_schedule_ids(menu, text)
+
+    return []

--- a/praetorian_cli/ui/aegis/commands/schedule_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/schedule_helpers.py
@@ -1,0 +1,319 @@
+"""Helper functions for schedule commands - formatters, completers, and interactive pickers."""
+
+import time
+from datetime import datetime, timezone
+from rich.prompt import Prompt
+from prompt_toolkit import prompt as pt_prompt
+from prompt_toolkit.completion import Completer, Completion, FuzzyCompleter
+from ..constants import DEFAULT_COLORS
+
+
+DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+DAY_ABBREVS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+
+# --- Formatting helpers ---
+
+def format_target(target_key):
+    """Format target key for display."""
+    if not target_key:
+        return 'N/A'
+    parts = target_key.split('#')
+    if len(parts) >= 3:
+        target_type = parts[1]
+        target_name = parts[2]
+        return f"{target_type}: {target_name}"
+    return target_key
+
+
+def format_days(weekly_schedule):
+    """Format weekly schedule days for compact display."""
+    if not weekly_schedule:
+        return 'None'
+    enabled = []
+    for day, abbrev in zip(DAYS, DAY_ABBREVS):
+        day_sched = weekly_schedule.get(day, {})
+        if day_sched.get('enabled'):
+            enabled.append(abbrev[:2])
+    return ' '.join(enabled) if enabled else 'None'
+
+
+def format_status(status, colors):
+    """Format status with color."""
+    status = status.lower() if status else 'unknown'
+    if status == 'active':
+        return f"[{colors['success']}]●[/{colors['success']}] active"
+    elif status == 'paused':
+        return f"[{colors['warning']}]◐[/{colors['warning']}] paused"
+    elif status == 'expired':
+        return f"[{colors['dim']}]○[/{colors['dim']}] expired"
+    return f"[{colors['dim']}]?[/{colors['dim']}] {status}"
+
+
+def format_next_execution(next_exec):
+    """Format next execution time for display."""
+    if not next_exec:
+        return 'Not scheduled'
+    try:
+        dt = datetime.fromisoformat(next_exec.replace('Z', '+00:00'))
+        now = datetime.now(timezone.utc)
+        diff = dt - now
+
+        if diff.total_seconds() < 0:
+            return 'Overdue'
+        elif diff.days == 0:
+            hours = int(diff.total_seconds() // 3600)
+            if hours == 0:
+                minutes = int(diff.total_seconds() // 60)
+                return f"in {minutes}m"
+            return f"in {hours}h"
+        elif diff.days == 1:
+            return 'Tomorrow'
+        elif diff.days < 7:
+            return dt.strftime('%a %H:%M')
+        else:
+            return dt.strftime('%Y-%m-%d')
+    except Exception:
+        return next_exec[:16]
+
+
+def format_date(date_str):
+    """Format date string for display."""
+    if not date_str:
+        return 'N/A'
+    try:
+        dt = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+        return dt.strftime('%Y-%m-%d')
+    except Exception:
+        return date_str[:10]
+
+
+def format_datetime(dt_str):
+    """Format datetime string for display."""
+    if not dt_str:
+        return 'N/A'
+    try:
+        dt = datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
+        return dt.strftime('%Y-%m-%d %H:%M UTC')
+    except Exception:
+        return dt_str[:19]
+
+
+# --- Interactive helpers ---
+
+def configure_weekly_schedule(menu):
+    """Interactively configure weekly schedule."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    weekly = {}
+
+    menu.console.print(f"  [{colors['dim']}]Enter time in HH:MM format (24-hour UTC), or leave empty to skip day[/{colors['dim']}]")
+
+    for day, abbrev in zip(DAYS, DAY_ABBREVS):
+        time_input = Prompt.ask(f"  {abbrev}", default="")
+        if time_input.strip():
+            # Validate time format
+            try:
+                parts = time_input.split(':')
+                hour = int(parts[0])
+                minute = int(parts[1]) if len(parts) > 1 else 0
+                if 0 <= hour <= 23 and 0 <= minute <= 59:
+                    weekly[day] = {'enabled': True, 'time': f"{hour:02d}:{minute:02d}"}
+                else:
+                    menu.console.print(f"    [{colors['warning']}]Invalid time, skipping {abbrev}[/{colors['warning']}]")
+                    weekly[day] = {'enabled': False, 'time': ''}
+            except (ValueError, IndexError):
+                menu.console.print(f"    [{colors['warning']}]Invalid format, skipping {abbrev}[/{colors['warning']}]")
+                weekly[day] = {'enabled': False, 'time': ''}
+        else:
+            weekly[day] = {'enabled': False, 'time': ''}
+
+    # Check at least one day is enabled
+    if not any(d.get('enabled') for d in weekly.values()):
+        menu.console.print(f"  [{colors['error']}]At least one day must be enabled[/{colors['error']}]")
+        return None
+
+    return weekly
+
+
+# --- Completers ---
+
+class ScheduleCompleter(Completer):
+    """Custom completer for schedules with metadata display."""
+
+    def __init__(self, schedules, agent_lookup=None):
+        """Initialize with list of schedule dicts from API."""
+        self.schedules = schedules
+        self.agent_lookup = agent_lookup or {}
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor.lower()
+
+        for schedule in self.schedules:
+            schedule_id = schedule.get('scheduleId', '')
+            capability = schedule.get('capabilityName', 'unknown')
+            status = schedule.get('status', 'unknown')
+            target_key = schedule.get('targetKey', '')
+            client_id = schedule.get('clientId', '')
+
+            # Get agent hostname from lookup
+            agent_name = self.agent_lookup.get(client_id, '') if client_id else ''
+
+            # Parse target for display
+            target_parts = target_key.split('#') if target_key else []
+            target_display = target_parts[2] if len(target_parts) >= 3 else ''
+
+            # Short ID for display
+            short_id = schedule_id[:10] if schedule_id else ''
+
+            # Build searchable text
+            searchable = f"{short_id} {capability} {status} {agent_name} {target_display}".lower()
+
+            # Check if input matches
+            if not text or text in searchable:
+                # Format: id  capability  [status]  agent/target
+                location = agent_name or target_display or 'N/A'
+                display_meta = f"{capability[:25]:<25} [{status}] {location}"
+
+                yield Completion(
+                    schedule_id,
+                    start_position=-len(document.text_before_cursor),
+                    display=short_id,
+                    display_meta=display_meta,
+                )
+
+
+# --- Schedule lookup and picker ---
+
+def get_cached_schedules(menu):
+    """Return schedules from a 30-second TTL cache on *menu*, refreshing from the API as needed."""
+    cache = getattr(menu, '_schedule_cache', {'ts': 0, 'items': []})
+    now = time.time()
+    if now - cache['ts'] > 30 or not cache['items']:
+        schedules, _ = menu.sdk.schedules.list()
+        cache['items'] = schedules or []
+        cache['ts'] = now
+        menu._schedule_cache = cache
+    return cache['items']
+
+
+def invalidate_schedule_cache(menu):
+    """Invalidate the schedule cache so the next read fetches fresh data from the API."""
+    menu._schedule_cache = {'ts': 0, 'items': []}
+
+
+def find_schedule_by_prefix(menu, prefix, schedules=None):
+    """Find a schedule by ID prefix. Returns (schedule, full_id) or (None, None).
+
+    If *schedules* is provided, searches that list instead of calling the API.
+    """
+    try:
+        if schedules is None:
+            schedules, _ = menu.sdk.schedules.list()
+        for schedule in schedules:
+            schedule_id = schedule.get('scheduleId', '')
+            if schedule_id.startswith(prefix):
+                return schedule, schedule_id
+        return None, None
+    except Exception:
+        return None, None
+
+
+def interactive_schedule_picker(menu, suggested=None, prompt_prefix="schedule"):
+    """Interactive schedule picker with fuzzy search.
+
+    If suggested is provided and matches a schedule prefix, returns it directly.
+    Otherwise shows an inline fuzzy picker.
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    try:
+        # Fetch once and reuse for both prefix lookup and picker
+        schedules, _ = menu.sdk.schedules.list()
+
+        if suggested:
+            # Check if suggested is a valid prefix - use directly without confirmation
+            schedule, full_id = find_schedule_by_prefix(menu, suggested, schedules=schedules)
+            if schedule:
+                return schedule, full_id
+
+        if not schedules:
+            menu.console.print("  No schedules available.")
+            return None, None
+
+        # Sort by capability name
+        schedules.sort(key=lambda x: x.get('capabilityName', ''))
+
+        # Get agent lookup for display
+        agent_lookup = getattr(menu, 'agent_lookup', {})
+
+        # Create fuzzy completer
+        base_completer = ScheduleCompleter(schedules, agent_lookup)
+        fuzzy_completer = FuzzyCompleter(base_completer)
+
+        try:
+            # Inline prompt - appears right after the command
+            result = pt_prompt(
+                f"{prompt_prefix} ",
+                completer=fuzzy_completer,
+                complete_while_typing=True,
+            )
+
+            if result and result.strip():
+                schedule_id = result.strip()
+                # Find the full schedule object
+                for s in schedules:
+                    if s.get('scheduleId') == schedule_id:
+                        return s, schedule_id
+                # If exact match failed, try prefix (reuse already-fetched list)
+                return find_schedule_by_prefix(menu, schedule_id, schedules=schedules)
+            else:
+                menu.console.print("  Cancelled.")
+                return None, None
+
+        except KeyboardInterrupt:
+            menu.console.print("\n  Cancelled")
+            return None, None
+        except EOFError:
+            menu.console.print("\n  Cancelled")
+            return None, None
+
+    except Exception as e:
+        menu.console.print(f"  Error loading schedules: {e}")
+        schedule_id = Prompt.ask("  Enter schedule ID manually")
+        if schedule_id:
+            return find_schedule_by_prefix(menu, schedule_id)
+        return None, None
+
+
+def complete_schedule_ids(menu, text):
+    """Return schedule IDs matching the prefix for tab completion (cached)."""
+    try:
+        schedules = get_cached_schedules(menu)
+        if not schedules:
+            return []
+
+        agent_lookup = getattr(menu, 'agent_lookup', {})
+        options = []
+
+        for schedule in schedules:
+            schedule_id = schedule.get('scheduleId', '')
+            capability = schedule.get('capabilityName', '')
+            client_id = schedule.get('clientId', '')
+            agent_name = agent_lookup.get(client_id, '') if client_id else ''
+
+            # Use short ID for completion
+            short_id = schedule_id[:10] if schedule_id else ''
+
+            # Match against ID prefix
+            if short_id.lower().startswith(text.lower()):
+                options.append(short_id)
+            # Also match against capability name for convenience
+            elif capability.lower().startswith(text.lower()):
+                options.append(short_id)
+            # And agent name
+            elif agent_name and agent_name.lower().startswith(text.lower()):
+                options.append(short_id)
+
+        return options
+    except Exception:
+        return []

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -1,8 +1,11 @@
 from ..utils import parse_agent_identifier
+from ..constants import DEFAULT_COLORS
 
 
 def handle_set(menu, args):
     """Select an agent by index, client_id, or hostname."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
     if not args:
         menu.console.print("\n  No agent selected. Use 'set <id>' to select one.\n")
         menu.pause()
@@ -17,8 +20,8 @@ def handle_set(menu, args):
         menu.console.print(f"\n  Selected: {hostname}\n")
     else:
         displayed_count = len(menu.displayed_agents)
-        menu.console.print(f"\n[red]  Agent not found:[/red] {selection}")
-        menu.console.print(f"[dim]  Use agent number (1-{displayed_count}), client ID, or hostname[/dim]\n")
+        menu.console.print(f"\n[{colors['error']}]  Agent not found:[/{colors['error']}] {selection}")
+        menu.console.print(f"[{colors['dim']}]  Use agent number (1-{displayed_count}), client ID, or hostname[/{colors['dim']}]\n")
         menu.pause()
 
 

--- a/praetorian_cli/ui/aegis/commands/ssh.py
+++ b/praetorian_cli/ui/aegis/commands/ssh.py
@@ -1,4 +1,5 @@
 from praetorian_cli.handlers.ssh_utils import SSHArgumentParser
+from ..constants import DEFAULT_COLORS
 
 def _print_help(menu):
     help_text = """
@@ -78,7 +79,8 @@ def handle_ssh(menu, args):
             display_info=True
         )
     except Exception as e:
-        menu.console.print(f"[red]SSH error: {e}[/red]")
+        colors = getattr(menu, 'colors', DEFAULT_COLORS)
+        menu.console.print(f"[{colors['error']}]SSH error: {e}[/{colors['error']}]")
         menu.pause()
 
 

--- a/praetorian_cli/ui/aegis/constants.py
+++ b/praetorian_cli/ui/aegis/constants.py
@@ -3,18 +3,8 @@
 Constants for the Aegis UI layer
 """
 
-DEFAULT_COLORS = {
-    'primary': '#5F47B7',      # Primary purple
-    'secondary': '#8F7ECD',    # Secondary purple  
-    'accent': '#BFB5E2',       # Tertiary purple
-    'dark': '#0D0D28',         # Dark primary
-    'dark_sec': '#191933',     # Dark secondary
-    'success': '#4CAF50',      # Green
-    'error': '#F44336',        # Red
-    'warning': '#FFC107',      # Yellow
-    'info': '#2196F3',         # Blue
-    'text': '#FFFFFF',         # White text
-    'dim': '#B6B6BE'           # Light secondary
-}
+from .theme import AEGIS_COLORS
+
+DEFAULT_COLORS = AEGIS_COLORS
 
 

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -18,9 +18,13 @@ from rich.table import Table
 from rich.text import Text
 from rich.box import MINIMAL
 
+from prompt_toolkit import prompt as pt_prompt
+from prompt_toolkit.completion import Completer, Completion, FuzzyCompleter
+
 from praetorian_cli.sdk.chariot import Chariot
 from praetorian_cli.sdk.model.aegis import Agent
 
+from .theme import AEGIS_RICH_THEME
 from .utils import (
     relative_time, format_os_display,
     compute_agent_groups, get_agent_display_style
@@ -33,14 +37,107 @@ from .commands.list import handle_list as cmd_handle_list
 from .commands.ssh import handle_ssh as cmd_handle_ssh
 from .commands.info import handle_info as cmd_handle_info
 from .commands.job import handle_job as cmd_handle_job
+from .commands.schedule import handle_schedule as cmd_handle_schedule
 
-# Command completers
-from .commands.set import complete as comp_set
-from .commands.help import complete as comp_help
-from .commands.list import complete as comp_list
-from .commands.ssh import complete as comp_ssh
-from .commands.job import complete as comp_job
+from .commands.schedule_helpers import get_cached_schedules
 from .constants import DEFAULT_COLORS
+
+
+class MenuCompleter(Completer):
+    """Completer for the main menu with command and argument completion."""
+
+    def __init__(self, menu):
+        self.menu = menu
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        words = text.split()
+
+        # Determine what we're completing
+        if not words or (len(words) == 1 and not text.endswith(' ')):
+            # Completing first word (command)
+            prefix = words[0].lower() if words else ''
+            for cmd in self.menu.commands:
+                if cmd.startswith(prefix):
+                    yield Completion(cmd, start_position=-len(prefix))
+        else:
+            # Completing arguments
+            cmd = words[0].lower()
+            # Get the text after the command
+            after_cmd = text.split(None, 1)[1] if len(text.split(None, 1)) > 1 else ''
+            current_word = words[-1] if not text.endswith(' ') else ''
+
+            completions = self._get_argument_completions(cmd, after_cmd, current_word)
+            for comp in completions:
+                yield comp
+
+    def _get_argument_completions(self, cmd, after_cmd, current_word):
+        """Get argument completions for a command."""
+        words = after_cmd.split()
+
+        if cmd == 'schedule':
+            subcommands = ['list', 'view', 'add', 'edit', 'delete', 'pause', 'resume']
+
+            if not words or (len(words) == 1 and not after_cmd.endswith(' ')):
+                # Complete subcommand
+                prefix = words[0].lower() if words else ''
+                for sub in subcommands:
+                    if sub.startswith(prefix):
+                        yield Completion(sub, start_position=-len(prefix))
+            elif len(words) >= 1:
+                # Complete schedule ID for commands that need it
+                subcmd = words[0].lower()
+                if subcmd in ['view', 'edit', 'delete', 'pause', 'resume']:
+                    yield from self._get_schedule_completions(current_word)
+
+        elif cmd == 'set':
+            # Complete agent numbers/hostnames
+            for i, agent in enumerate(self.menu.displayed_agents, 1):
+                idx_str = str(i)
+                hostname = agent.hostname or ''
+                if idx_str.startswith(current_word) or hostname.lower().startswith(current_word.lower()):
+                    display = f"{idx_str} - {hostname}"
+                    yield Completion(idx_str, start_position=-len(current_word), display=display)
+
+        elif cmd == 'job':
+            subcommands = ['list', 'run', 'capabilities', 'caps']
+            if not words or (len(words) == 1 and not after_cmd.endswith(' ')):
+                prefix = words[0].lower() if words else ''
+                for sub in subcommands:
+                    if sub.startswith(prefix):
+                        yield Completion(sub, start_position=-len(prefix))
+
+    def _get_schedule_completions(self, prefix):
+        """Get schedule ID completions with metadata (cached to avoid per-keystroke API calls)."""
+        try:
+            schedules = get_cached_schedules(self.menu)
+            if not schedules:
+                return
+
+            agent_lookup = getattr(self.menu, 'agent_lookup', {})
+
+            for schedule in schedules:
+                schedule_id = schedule.get('scheduleId', '')
+                capability = schedule.get('capabilityName', 'unknown')
+                status = schedule.get('status', '')
+                client_id = schedule.get('clientId', '')
+                agent_name = agent_lookup.get(client_id, '') if client_id else ''
+
+                short_id = schedule_id[:10] if schedule_id else ''
+
+                # Match against ID, capability, or agent
+                searchable = f"{short_id} {capability} {agent_name}".lower()
+                if not prefix or prefix.lower() in searchable:
+                    location = agent_name or 'N/A'
+                    display_meta = f"{capability[:20]} [{status}] {location}"
+                    yield Completion(
+                        schedule_id,
+                        start_position=-len(prefix),
+                        display=short_id,
+                        display_meta=display_meta
+                    )
+        except Exception:
+            pass
 
 
 class AegisMenu:
@@ -48,45 +145,46 @@ class AegisMenu:
     
     def __init__(self, sdk: Chariot):
         self.sdk: Chariot = sdk
-        self.console = Console()
+        self.console = Console(theme=AEGIS_RICH_THEME)
         self.verbose = VERBOSE
         self.agents: List[Agent] = []
         self.selected_agent: Optional[Agent] = None  
         self._first_render = True
         self.agent_computed_data = {}  
         self.current_prompt = "> "
-        self.displayed_agents: List[Agent] = []  # Track currently displayed agents 
-        
+        self.displayed_agents: List[Agent] = []  # Track currently displayed agents
+        self.agent_lookup: dict[str, str] = {}  # client_id -> hostname mapping for fast lookups
+        self._schedule_cache: dict = {'ts': 0, 'items': []}  # Cached schedules with TTL
+
         self.user_email, self.username = self.sdk.get_current_user()
         
         self.colors = DEFAULT_COLORS
         
         self.commands = [
-            'set', 'ssh', 'info', 'list', 'job', 'reload', 'clear', 'help', 'quit', 'exit'
+            'set', 'ssh', 'info', 'list', 'job', 'schedule', 'reload', 'clear', 'help', 'quit', 'exit'
         ]
-
-        self._init_autocomplete()
     
     
     def run(self) -> None:
         """Main interface loop"""
         self.clear_screen()
         self.reload_agents()
-        
+
         if self.agents:
             self.show_agents_list()
-        
+
         while True:
             try:
                 self.show_main_menu()
                 choice = self.get_input()
-                
+
                 if not self.handle_choice(choice):
                     break
-                    
+
             except KeyboardInterrupt:
-                self.console.print("\n[dim]Goodbye![/dim]")
-                break
+                # Ctrl-C during command execution - cancel and return to prompt
+                self.console.print(f"\n[{self.colors['dim']}]Cancelled[/{self.colors['dim']}]")
+                continue
     
     def handle_choice(self, choice: str) -> bool:
         """Dead simple command dispatch"""
@@ -96,7 +194,7 @@ class AegisMenu:
         try:
             args = shlex.split(choice)
         except ValueError:
-            self.console.print(f"[red]Invalid command syntax: {choice}[/red]")
+            self.console.print(f"[{self.colors['error']}]Invalid command syntax: {choice}[/{self.colors['error']}]")
             self.pause()
             return True
         
@@ -132,7 +230,10 @@ class AegisMenu:
             
         elif command == 'job':
             cmd_handle_job(self, cmd_args)
-                
+
+        elif command == 'schedule':
+            cmd_handle_schedule(self, cmd_args)
+
         else:
             self.console.print(f"\n  Unknown command: {command}")
             self.console.print(f"  [{self.colors['dim']}]Type 'help' for available commands[/{self.colors['dim']}]\n")
@@ -149,7 +250,7 @@ class AegisMenu:
         self.load_agents()
         
         if self.verbose and self.agents:
-            self.console.print(f"[green]Loaded {len(self.agents)} agents successfully[/green]")
+            self.console.print(f"[{self.colors['success']}]Loaded {len(self.agents)} agents successfully[/{self.colors['success']}]")
         
     
     def _compute_agent_status(self) -> None:
@@ -271,100 +372,37 @@ class AegisMenu:
         self._first_render = False
     
     def get_input(self) -> str:
-        """Get user input with minimal context-aware prompt"""
+        """Get user input with auto-completing fuzzy prompt.
+
+        Returns:
+            str: User input (empty string on Ctrl-C to redisplay prompt)
+            "quit": If Ctrl-D was pressed (exit program)
+        """
         try:
             if self.selected_agent:
                 hostname = self.selected_agent.hostname
                 self.current_prompt = f"{hostname}> "
             else:
                 self.current_prompt = "> "
-            
-            user_input = input(self.current_prompt).strip()
-            return user_input
-        except (EOFError, KeyboardInterrupt):
+
+            # Use prompt_toolkit for auto-completion as you type
+            completer = FuzzyCompleter(MenuCompleter(self))
+            user_input = pt_prompt(
+                self.current_prompt,
+                completer=completer,
+                complete_while_typing=True,
+            )
+            return user_input.strip()
+        except KeyboardInterrupt:
+            # Ctrl-C: cancel current input, return to prompt
+            self.console.print()
+            return ""
+        except EOFError:
+            # Ctrl-D: exit program
             return "quit"
 
-    def _init_autocomplete(self) -> None:
-        """Attach a minimal Tab-completion using readline when available."""
-        try:
-            import readline  # type: ignore
-        except Exception:
-            self._readline = None
-            return
-
-        self._readline = readline
-
-        try:
-            delims = readline.get_completer_delims()
-            for ch in "-/.":
-                delims = delims.replace(ch, "")
-            readline.set_completer_delims(delims)
-        except Exception:
-            pass
-
-        def completer(text: str, state: int):
-            try:
-                buf = readline.get_line_buffer()
-                beg = getattr(readline, 'get_begidx', lambda: len(buf))()
-                before = buf[:beg]
-                try:
-                    tokens = shlex.split(before)
-                except Exception:
-                    tokens = before.split()
-
-                if not tokens:
-                    options = [c for c in self.commands if c.startswith(text)]
-                else:
-                    cmd = tokens[0]
-
-                    if len(tokens) == 1 and not before.endswith(' '):
-                        options = [c for c in self.commands if c.startswith(text)]
-                    else:
-                        options = self._autocomplete_options_for(cmd, text, tokens)
-
-                options = sorted(set(options))
-                return options[state] if state < len(options) else None
-            except Exception:
-                return None
-
-        try:
-            self._readline.set_completer(completer)
-            doc = getattr(self._readline, "__doc__", "") or ""
-            if "libedit" in doc.lower():
-                # macOS default: libedit compatibility layer
-                self._readline.parse_and_bind("bind ^I rl_complete")
-            else:
-                # GNU readline
-                self._readline.parse_and_bind('tab: complete')
-        except Exception:
-            pass
-
-    def _autocomplete_options_for(self, cmd: str, text: str, tokens: list[str]) -> list[str]:
-        """Return simple context-aware options for completion."""
-        # Top-level fallbacks
-        if cmd in ['quit', 'exit', 'clear', 'reload']:
-            return []
-
-        if cmd == 'help':
-            return comp_help(self, text, tokens)
-
-        if cmd == 'list':
-            return comp_list(self, text, tokens)
-
-        if cmd == 'set':
-            return comp_set(self, text, tokens)
-
-        if cmd == 'job':
-            return comp_job(self, text, tokens)
-
-        if cmd == 'ssh':
-            return comp_ssh(self, text, tokens)
-
-        # Default: no suggestions
-        return []
-    
     def load_agents(self) -> None:
-        """Load agents from SDK"""
+        """Load agents from SDK and build lookup cache"""
         try:
             with self.console.status(
                 f"[{self.colors['dim']}]Loading agents...[/{self.colors['dim']}]",
@@ -373,17 +411,24 @@ class AegisMenu:
             ):
                 agents, _ = self.sdk.aegis.list()
                 self.agents = agents or []
-                
+
+                # Build agent_lookup for fast client_id -> hostname mapping
+                self.agent_lookup = {}
+                for agent in self.agents:
+                    if agent.client_id and agent.hostname:
+                        self.agent_lookup[agent.client_id] = agent.hostname
+
             if self.verbose or not self.agents:
                 agent_count = len(self.agents)
                 if agent_count > 0:
-                    self.console.print(f"[green]✓ Loaded {agent_count} agents[/green]")
+                    self.console.print(f"[{self.colors['success']}]✓ Loaded {agent_count} agents[/{self.colors['success']}]")
                 else:
-                    self.console.print(f"[yellow]⚠ No agents found[/yellow]")
-                    
+                    self.console.print(f"[{self.colors['warning']}]⚠ No agents found[/{self.colors['warning']}]")
+
         except Exception as e:
-            self.console.print(f"[red]✗ Error loading agents: {e}[/red]")
+            self.console.print(f"[{self.colors['error']}]✗ Error loading agents: {e}[/{self.colors['error']}]")
             self.agents = []
+            self.agent_lookup = {}
     
     def pause(self):
         """Professional pause with styling"""

--- a/praetorian_cli/ui/aegis/theme.py
+++ b/praetorian_cli/ui/aegis/theme.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Centralized color theme for the Aegis TUI.
+
+All color constants and Rich style definitions live here so that every
+module in the aegis UI package can import them from a single source of
+truth.  When updating the palette, only this file needs to change.
+"""
+
+from rich.theme import Theme
+
+# ---------------------------------------------------------------------------
+# Brand palette
+# ---------------------------------------------------------------------------
+PRIMARY_RED = "#e63948"       # CTAs, threats, high priority, errors
+SECONDARY_BLUE = "#11C3DB"   # Links, info, headers, titles, selected items
+COMPLEMENTARY_GOLD = "#D4AF37"  # Brand accents, highlights, important labels
+SECONDARY_TEXT = "#A0A4A8"   # Helper text, captions, disabled items
+
+# Success green (complements the palette)
+SUCCESS_GREEN = "#4CAF50"
+
+# Dark-mode backgrounds
+DARK_BG_PRIMARY = "#0D0D0D"
+DARK_BG_SECONDARY = "#1F252A"
+DARK_BG_TERTIARY = "#3A4044"
+
+# Light-mode backgrounds (defined for completeness; terminal TUI uses dark)
+LIGHT_BG_PRIMARY = "#F7F8F9"
+LIGHT_BG_SECONDARY = "#FFFFFF"
+LIGHT_BG_TERTIARY = "#E6E9EC"
+
+# ---------------------------------------------------------------------------
+# Semantic color map  (used by menu.py / commands via ``menu.colors``)
+#
+# Keys are referenced throughout the TUI as  ``colors['primary']`` etc.
+# ---------------------------------------------------------------------------
+AEGIS_COLORS = {
+    "primary": SECONDARY_BLUE,          # Headers, titles, spinner
+    "secondary": PRIMARY_RED,           # CTAs, threats, high priority
+    "accent": COMPLEMENTARY_GOLD,       # Brand accents, highlights
+    "dark": DARK_BG_PRIMARY,            # Darkest background
+    "dark_sec": DARK_BG_SECONDARY,      # Secondary dark background
+    "dark_tert": DARK_BG_TERTIARY,      # Tertiary dark background
+    "success": SUCCESS_GREEN,           # Positive status, confirmations
+    "error": PRIMARY_RED,               # Errors, failures, delete actions
+    "warning": COMPLEMENTARY_GOLD,      # Warnings, paused state
+    "info": SECONDARY_BLUE,             # Informational, queued state
+    "text": "#FFFFFF",                  # Primary text
+    "dim": SECONDARY_TEXT,              # Secondary / helper text
+}
+
+# ---------------------------------------------------------------------------
+# Rich Theme object -- can be passed to ``Console(theme=...)`` for
+# console-wide semantic markup like ``[error]...[/error]``.
+# ---------------------------------------------------------------------------
+AEGIS_RICH_THEME = Theme({
+    "error": f"bold {PRIMARY_RED}",
+    "warning": f"{COMPLEMENTARY_GOLD}",
+    "success": f"{SUCCESS_GREEN}",
+    "info": f"{SECONDARY_BLUE}",
+    "dim": f"{SECONDARY_TEXT}",
+    "accent": f"{COMPLEMENTARY_GOLD}",
+    "primary": f"{SECONDARY_BLUE}",
+    "heading": f"bold {SECONDARY_BLUE}",
+})

--- a/praetorian_cli/ui/aegis/utils.py
+++ b/praetorian_cli/ui/aegis/utils.py
@@ -38,13 +38,13 @@ def relative_time(ts_seconds: float, now_seconds: float) -> str:
 def format_job_status(status: str, colors: dict) -> Text:
     """Format job status for display with appropriate color"""
     status_upper = status.upper()
-    
+
     if status_upper.startswith('JP'):  # Job Passed
         return Text("PASSED", style=f"{colors['success']}")
     elif status_upper.startswith('JF'):  # Job Failed
         return Text("FAILED", style=f"{colors['error']}")
     elif status_upper.startswith('JR'):  # Job Running
-        return Text("RUNNING", style=f"{colors['warning']}")
+        return Text("RUNNING", style=f"{colors['accent']}")
     elif status_upper.startswith('JQ'):  # Job Queued
         return Text("QUEUED", style=f"{colors['info']}")
     else:
@@ -112,8 +112,8 @@ def get_agent_display_style(group: str, colors: dict) -> dict:
     if group == 'active_tunnel':
         return {
             'status': Text("online", style=f"{colors['success']}"),
-            'tunnel': Text("active", style=f"{colors['warning']}"),
-            'idx_style': f"{colors['warning']}",
+            'tunnel': Text("active", style=f"{colors['accent']}"),
+            'idx_style': f"{colors['accent']}",
             'hostname_style': "bold white"
         }
     elif group == 'online':


### PR DESCRIPTION
## Summary

- Add schedule management commands (list, view, add, edit, delete, pause, resume) with fuzzy auto-completion
- Fix credential passthrough to use UUID matching CLI behavior (avoids 403 errors from fetching credential values)
- Add AD domain asset key resolution from database (with SID) instead of constructing incorrect keys
- Extract shared job/schedule helpers into `job_helpers.py` to eliminate DRY violations
- Add large artifact storage prompt for S3 upload
- Centralize theme and color constants
- Fix `get_input()` type safety (return empty string on Ctrl-C, not None)
- Add schedule cache with TTL and invalidation after write operations

## Test plan

- [x] All 11 TUI tests pass (`pytest -m tui`)
- [ ] Manual test: `schedule list`, `schedule add`, `schedule view`, `schedule delete`
- [ ] Manual test: `job run` with AD domain capability (verify asset lookup blocks on missing domain)
- [ ] Manual test: `job run` with credential attachment (verify UUID passthrough, no 403)
- [ ] Manual test: Ctrl-C at prompt returns cleanly without traceback