### PR TITLE
feat(aegis): cp tab-completion, cleaner rsync output, and prompt history

### DIFF
--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
+import shutil
 import subprocess
+import time
 from praetorian_cli.sdk.model.aegis import Agent
 from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
 
@@ -348,7 +350,162 @@ class Aegis:
 
         result = subprocess.run(ssh_command)
         return result.returncode
-    
+
+    def copy_to_agent(self, agent: Agent, local_path: str, remote_path: str,
+                      direction: str = 'upload', user: str = None,
+                      ssh_options: List[str] = None, display_info: bool = True,
+                      use_rsync: bool = True) -> int:
+        """Copy files to/from an Aegis agent using rsync (with scp fallback).
+
+        :param agent: Target agent
+        :param local_path: Local file or directory path
+        :param remote_path: Remote file or directory path
+        :param direction: 'upload' or 'download'
+        :param user: SSH username (resolved from API if omitted)
+        :param ssh_options: Extra SSH flags (e.g. ['-i', '~/.ssh/key'])
+        :param display_info: Print connection banner
+        :param use_rsync: Try rsync first; fall back to scp on failure
+        :return: Process exit code
+        """
+        ssh_options = ssh_options or []
+
+        if not user:
+            _, user = self.api.get_current_user()
+
+        is_valid, error_msg = validate_agent_for_ssh(agent)
+        if not is_valid:
+            raise Exception(error_msg)
+
+        hostname = agent.hostname or 'Unknown'
+        cf_status = agent.health_check.cloudflared_status
+        public_hostname = cf_status.hostname
+        tunnel_name = cf_status.tunnel_name or 'N/A'
+
+        remote_spec = f'{user}@{public_hostname}'
+
+        # Build the base SSH command string for rsync's -e flag
+        ssh_parts = ['ssh', '-o', 'ConnectTimeout=10', '-o', 'ServerAliveInterval=30']
+        ssh_parts.extend(ssh_options)
+        ssh_cmd_str = ' '.join(ssh_parts)
+
+        if display_info:
+            action = 'Upload to' if direction == 'upload' else 'Download from'
+            print(f"\033[1;36m→ {action} {hostname}\033[0m")
+            print(f"\033[34m  Gateway: {public_hostname}\033[0m")
+            print(f"\033[33m  Tunnel:  {tunnel_name}\033[0m")
+            print(f"\033[35m  User:    {user}\033[0m")
+            if direction == 'upload':
+                print(f"\033[32m  Local:   {local_path}\033[0m")
+                print(f"\033[32m  Remote:  {remote_path}\033[0m")
+            else:
+                print(f"\033[32m  Remote:  {remote_path}\033[0m")
+                print(f"\033[32m  Local:   {local_path}\033[0m")
+            print("")
+
+        # Try rsync first if available and requested
+        rsync_path, _, _ = self._find_rsync()
+        if use_rsync and rsync_path:
+            cmd = self._build_rsync_command(ssh_cmd_str, local_path, remote_spec, remote_path, direction)
+            t0 = time.monotonic()
+            result = subprocess.run(cmd)
+            elapsed = time.monotonic() - t0
+            # Exit code 127 means rsync not found on the remote side
+            if result.returncode == 127:
+                print("\033[33mrsync not available on remote — falling back to scp\033[0m")
+            else:
+                self._print_transfer_summary(result.returncode, elapsed)
+                return result.returncode
+
+        # scp fallback
+        cmd = self._build_scp_command(ssh_options, local_path, remote_spec, remote_path, direction)
+        t0 = time.monotonic()
+        result = subprocess.run(cmd)
+        elapsed = time.monotonic() - t0
+        self._print_transfer_summary(result.returncode, elapsed)
+        return result.returncode
+
+    @staticmethod
+    def _find_rsync() -> tuple:
+        """Find the best local rsync binary and its version.
+
+        macOS ships openrsync at /usr/bin/rsync (reports as 2.6.9) which
+        shadows Homebrew's real rsync. This method prefers Homebrew's
+        binary when available.
+
+        Returns (path, major, minor) or (None, 0, 0) if not found.
+        """
+        import re
+        # Prefer Homebrew rsync over macOS openrsync
+        candidates = [
+            '/opt/homebrew/bin/rsync',  # Apple Silicon
+            '/usr/local/bin/rsync',     # Intel Mac
+        ]
+        # Fall back to whatever is on PATH
+        path_rsync = shutil.which('rsync')
+        if path_rsync:
+            candidates.append(path_rsync)
+
+        for path in candidates:
+            try:
+                out = subprocess.run(
+                    [path, '--version'], capture_output=True, text=True, timeout=5,
+                ).stdout
+                m = re.search(r'version\s+(\d+)\.(\d+)', out)
+                if m:
+                    major, minor = int(m.group(1)), int(m.group(2))
+                    # Skip openrsync (reports 2.6.9, missing modern flags)
+                    if 'openrsync' in out:
+                        continue
+                    return path, major, minor
+            except Exception:
+                continue
+
+        # No real rsync found; return whatever is on PATH (may be openrsync)
+        if path_rsync:
+            return path_rsync, 2, 6
+        return None, 0, 0
+
+    def _build_rsync_command(self, ssh_cmd_str: str, local_path: str,
+                             remote_spec: str, remote_path: str,
+                             direction: str) -> List[str]:
+        """Build an rsync command list.
+
+        Uses --info=progress2 for a single overall progress line when the
+        local rsync supports it (>= 3.1.0). Falls back to quiet -az for
+        stock macOS openrsync.
+        """
+        rsync_path, major, minor = self._find_rsync()
+        cmd = [rsync_path or 'rsync', '-az', '--partial']
+        if (major, minor) >= (3, 1):
+            cmd.append('--info=progress2')
+        cmd += ['-e', ssh_cmd_str]
+        if direction == 'upload':
+            cmd += [local_path, f'{remote_spec}:{remote_path}']
+        else:
+            cmd += [f'{remote_spec}:{remote_path}', local_path]
+        return cmd
+
+    def _build_scp_command(self, ssh_options: List[str], local_path: str,
+                           remote_spec: str, remote_path: str,
+                           direction: str) -> List[str]:
+        """Build an scp command list."""
+        cmd = ['scp', '-r', '-o', 'ConnectTimeout=10']
+        cmd.extend(ssh_options)
+        if direction == 'upload':
+            cmd += [local_path, f'{remote_spec}:{remote_path}']
+        else:
+            cmd += [f'{remote_spec}:{remote_path}', local_path]
+        return cmd
+
+    @staticmethod
+    def _print_transfer_summary(returncode: int, elapsed: float) -> None:
+        """Print a colorized one-line transfer summary."""
+        elapsed_str = f"{elapsed:.1f}s"
+        if returncode == 0:
+            print(f"\033[32m✓ Transfer complete ({elapsed_str})\033[0m")
+        else:
+            print(f"\033[31m✗ Transfer failed (exit code {returncode})\033[0m")
+
     def run_job(self, agent: Agent, capabilities: list = None, config: str = None):
         """
         Run a job on an Aegis agent.

--- a/praetorian_cli/sdk/test/ui/test_aegis_cp.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_cp.py
@@ -1,0 +1,292 @@
+from unittest.mock import patch, MagicMock
+import pytest
+from prompt_toolkit.document import Document
+from prompt_toolkit.completion import CompleteEvent
+from praetorian_cli.ui.aegis.commands.cp import handle_cp
+from praetorian_cli.ui.aegis.menu import MenuCompleter, _remote_ls_lookup_or_fetch
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
+
+pytestmark = pytest.mark.tui
+
+
+class Menu(MockMenuBase):
+    def __init__(self):
+        super().__init__()
+        self.sdk = MockSDK()
+        self.selected_agent = MockAgent()
+        # Remote file listing state (mirrors AegisMenu)
+        self._remote_ls_cache = {}
+        self._remote_ls_pending = set()
+
+    def prefetch_agent_home(self, agent=None):
+        agent = agent or self.selected_agent
+        if not agent or not getattr(agent, 'has_tunnel', False):
+            return
+        try:
+            public_hostname = agent.health_check.cloudflared_status.hostname
+            if not public_hostname:
+                return
+        except Exception:
+            return
+        client_id = getattr(agent, 'client_id', '') or ''
+        for directory in ('~', '/tmp'):
+            _remote_ls_lookup_or_fetch(
+                self, (client_id, directory), public_hostname, directory,
+            )
+
+
+def test_handle_cp_help_message():
+    menu = Menu()
+    handle_cp(menu, ["help"])
+    assert any("CP Command" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_dash_h_message():
+    menu = Menu()
+    handle_cp(menu, ["-h"])
+    assert any("CP Command" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_upload():
+    menu = Menu()
+    handle_cp(menu, ["./local.txt", ":/tmp/remote.txt"])
+    assert len(menu.sdk.aegis.calls) == 1
+    call = menu.sdk.aegis.calls[0]
+    assert call['method'] == 'copy_to_agent'
+    assert call['direction'] == 'upload'
+    assert call['local_path'] == './local.txt'
+    assert call['remote_path'] == '/tmp/remote.txt'
+
+
+def test_handle_cp_download():
+    menu = Menu()
+    handle_cp(menu, [":/etc/passwd", "./loot/passwd"])
+    assert len(menu.sdk.aegis.calls) == 1
+    call = menu.sdk.aegis.calls[0]
+    assert call['method'] == 'copy_to_agent'
+    assert call['direction'] == 'download'
+    assert call['local_path'] == './loot/passwd'
+    assert call['remote_path'] == '/etc/passwd'
+
+
+def test_handle_cp_both_remote_error():
+    menu = Menu()
+    handle_cp(menu, [":/remote1", ":/remote2"])
+    assert any("both paths cannot be remote" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_neither_remote_error():
+    menu = Menu()
+    handle_cp(menu, ["./local1", "./local2"])
+    assert any("one path must be remote" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_no_agent_selected():
+    menu = Menu()
+    menu.selected_agent = None
+    handle_cp(menu, ["./file", ":/tmp/file"])
+    assert any("No agent selected" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_wrong_arg_count():
+    menu = Menu()
+    handle_cp(menu, ["./only_one_path"])
+    assert any("exactly two paths" in l for l in menu.console.lines)
+    assert len(menu.sdk.aegis.calls) == 0
+
+
+def test_handle_cp_user_option():
+    menu = Menu()
+    handle_cp(menu, ["-u", "root", "./file", ":/tmp/file"])
+    assert len(menu.sdk.aegis.calls) == 1
+    call = menu.sdk.aegis.calls[0]
+    assert call['user'] == 'root'
+    assert call['direction'] == 'upload'
+
+
+def test_handle_cp_no_rsync_flag():
+    menu = Menu()
+    handle_cp(menu, ["--no-rsync", "./file", ":/tmp/file"])
+    assert len(menu.sdk.aegis.calls) == 1
+    call = menu.sdk.aegis.calls[0]
+    assert call['use_rsync'] is False
+
+
+def test_handle_cp_identity_option():
+    menu = Menu()
+    handle_cp(menu, ["-i", "~/.ssh/id_rsa", "./file", ":/tmp/file"])
+    assert len(menu.sdk.aegis.calls) == 1
+    call = menu.sdk.aegis.calls[0]
+    assert call['ssh_options'] == ['-i', '~/.ssh/id_rsa']
+
+
+def test_cp_completion_returns_file_paths(tmp_path):
+    """Tab-completing a local path argument for 'cp' yields file path results."""
+    # Create a temp file so PathCompleter has something to find
+    test_file = tmp_path / "testfile.txt"
+    test_file.write_text("data")
+
+    menu = Menu()
+    menu.commands = ['cp']
+    completer = MenuCompleter(menu)
+
+    # Simulate typing: cp <tmp_path>/test
+    text = f"cp {tmp_path}/test"
+    doc = Document(text, len(text))
+    event = CompleteEvent()
+    completions = list(completer.get_completions(doc, event))
+    # PathCompleter returns the suffix to append (e.g. "file.txt" for "test" -> "testfile.txt")
+    # Check display text which shows the full filename
+    displays = [c.display for c in completions]
+    assert len(completions) > 0
+    assert any("testfile.txt" in str(d) for d in displays)
+
+
+def test_cp_completion_option_flags():
+    """Tab-completing flags for 'cp' yields option completions."""
+    menu = Menu()
+    menu.commands = ['cp']
+    completer = MenuCompleter(menu)
+
+    text = "cp --no"
+    doc = Document(text, len(text))
+    event = CompleteEvent()
+    completions = list(completer.get_completions(doc, event))
+    texts = [c.text for c in completions]
+    assert '--no-rsync' in texts
+
+
+def test_cp_completion_skips_remote_paths_without_agent():
+    """Remote paths yield no completions when no agent is selected."""
+    menu = Menu()
+    menu.selected_agent = None
+    menu.commands = ['cp']
+    completer = MenuCompleter(menu)
+
+    text = "cp :/tmp/rem"
+    doc = Document(text, len(text))
+    event = CompleteEvent()
+    completions = list(completer.get_completions(doc, event))
+    assert completions == []
+
+
+def test_cp_completion_remote_paths_via_ssh():
+    """Remote paths complete by listing files on the agent via SSH (async fetch)."""
+    import time as _time
+    menu = Menu()
+    menu.commands = ['cp']
+    menu.sdk.aegis.api = MagicMock()
+    menu.sdk.aegis.api.get_current_user.return_value = ('user@example.com', 'testuser')
+
+    completer = MenuCompleter(menu)
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "remote_file.txt\nbackups/\nremote_log.txt\n"
+
+    with patch('praetorian_cli.ui.aegis.menu.subprocess.run', return_value=fake_result) as mock_run:
+        text = "cp :/tmp/remote"
+        doc = Document(text, len(text))
+        event = CompleteEvent()
+
+        # First call fires background thread, returns nothing (toolbar shows loading)
+        completions = list(completer.get_completions(doc, event))
+        assert completions == []
+
+        # Wait for background thread to populate cache (on the menu, not completer)
+        for _ in range(50):
+            if ('C.1', '/tmp') in menu._remote_ls_cache:
+                break
+            _time.sleep(0.05)
+
+        # Second call returns cached results
+        completions = list(completer.get_completions(doc, event))
+
+    assert mock_run.called
+    ssh_cmd = mock_run.call_args[0][0]
+    assert 'ssh' in ssh_cmd[0]
+    assert 'ls -1F /tmp' in ' '.join(ssh_cmd)
+
+    texts = [c.text for c in completions]
+    assert any('remote_file.txt' in t for t in texts)
+    assert any('remote_log.txt' in t for t in texts)
+    assert not any('backups' in t for t in texts)
+
+
+def test_cp_completion_remote_caches_results():
+    """Repeated remote completions in the same directory use cached SSH results."""
+    import time as _time
+    menu = Menu()
+    menu.commands = ['cp']
+    menu.sdk.aegis.api = MagicMock()
+    menu.sdk.aegis.api.get_current_user.return_value = ('user@example.com', 'testuser')
+
+    completer = MenuCompleter(menu)
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "file_a.txt\nfile_b.txt\n"
+
+    with patch('praetorian_cli.ui.aegis.menu.subprocess.run', return_value=fake_result) as mock_run:
+        text = "cp :/home/file_a"
+        doc = Document(text, len(text))
+
+        # First call fires background thread
+        list(completer.get_completions(doc, CompleteEvent()))
+
+        # Wait for background thread (cache lives on menu)
+        for _ in range(50):
+            if ('C.1', '/home') in menu._remote_ls_cache:
+                break
+            _time.sleep(0.05)
+
+        # Second call uses cache
+        completions1 = list(completer.get_completions(doc, CompleteEvent()))
+
+        # Different prefix, same directory — still cached
+        text = "cp :/home/file_b"
+        doc = Document(text, len(text))
+        completions2 = list(completer.get_completions(doc, CompleteEvent()))
+
+    # SSH should only have been called once
+    assert mock_run.call_count == 1
+    assert len(completions1) > 0
+    assert len(completions2) > 0
+
+
+def test_set_prefetches_agent_home():
+    """Selecting an agent via 'set' prefetches ~ so cp completions are instant."""
+    import time as _time
+    from praetorian_cli.ui.aegis.commands.set import handle_set
+
+    menu = Menu()
+    menu.commands = ['set', 'cp']
+    menu.displayed_agents = [MockAgent()]
+    menu.agents = menu.displayed_agents
+    menu._remote_ls_cache = {}
+    menu._remote_ls_pending = set()
+    menu.sdk.aegis.api = MagicMock()
+    menu.sdk.aegis.api.get_current_user.return_value = ('u@example.com', 'testuser')
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "Documents/\nfile.txt\n"
+
+    with patch('praetorian_cli.ui.aegis.menu.subprocess.run', return_value=fake_result):
+        handle_set(menu, ['1'])
+
+        # Wait for background prefetch
+        for _ in range(50):
+            if ('C.1', '~') in menu._remote_ls_cache:
+                break
+            _time.sleep(0.05)
+
+    assert ('C.1', '~') in menu._remote_ls_cache
+    _, entries = menu._remote_ls_cache[('C.1', '~')]
+    assert 'Documents/' in entries
+    assert 'file.txt' in entries

--- a/praetorian_cli/sdk/test/ui/test_aegis_proxy.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_proxy.py
@@ -1,0 +1,279 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from threading import Event
+
+from praetorian_cli.ui.aegis.commands.proxy import (
+    handle_proxy,
+    stop_all_proxies,
+    _format_uptime,
+    complete,
+    ProxyInfo,
+)
+from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
+
+pytestmark = pytest.mark.tui
+
+
+class Menu(MockMenuBase):
+    def __init__(self):
+        super().__init__()
+        self.sdk = MockSDK()
+        self.selected_agent = MockAgent()
+        self._active_proxies = {}
+
+
+# --- help ---
+
+def test_help_explicit():
+    menu = Menu()
+    handle_proxy(menu, ['help'])
+    assert any('Proxy Command' in l for l in menu.console.lines)
+
+
+def test_help_no_args():
+    menu = Menu()
+    handle_proxy(menu, [])
+    assert any('Proxy Command' in l for l in menu.console.lines)
+
+
+def test_help_dash_h():
+    menu = Menu()
+    handle_proxy(menu, ['-h'])
+    assert any('Proxy Command' in l for l in menu.console.lines)
+
+
+# --- validation ---
+
+def test_no_agent_selected():
+    menu = Menu()
+    menu.selected_agent = None
+    handle_proxy(menu, ['1080'])
+    assert any('No agent selected' in l for l in menu.console.lines)
+
+
+def test_no_tunnel():
+    menu = Menu()
+    menu.selected_agent.has_tunnel = False
+    handle_proxy(menu, ['1080'])
+    assert any('no active tunnel' in l for l in menu.console.lines)
+
+
+def test_invalid_port_string():
+    menu = Menu()
+    handle_proxy(menu, ['abc'])
+    assert any('Invalid port' in l for l in menu.console.lines)
+
+
+def test_port_out_of_range():
+    menu = Menu()
+    handle_proxy(menu, ['99999'])
+    assert any('between 1 and 65535' in l for l in menu.console.lines)
+
+
+def test_port_zero():
+    menu = Menu()
+    handle_proxy(menu, ['0'])
+    assert any('between 1 and 65535' in l for l in menu.console.lines)
+
+
+# --- start ---
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_start_success(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None  # still running
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+
+    assert 1080 in menu._active_proxies
+    assert any('started' in l for l in menu.console.lines)
+    mock_popen.assert_called_once()
+    cmd = mock_popen.call_args[0][0]
+    assert '-D' in cmd
+    assert '1080' in cmd
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_start_with_user(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['8080', '-u', 'admin'])
+
+    assert 8080 in menu._active_proxies
+    cmd = mock_popen.call_args[0][0]
+    assert any('admin@' in arg for arg in cmd)
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_port_conflict(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    # Start first proxy
+    handle_proxy(menu, ['1080'])
+    assert 1080 in menu._active_proxies
+
+    # Try starting same port
+    handle_proxy(menu, ['1080'])
+    assert any('already running' in l for l in menu.console.lines)
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_immediate_failure(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = 1  # exited immediately
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+    assert 1080 not in menu._active_proxies
+    assert any('Failed to start' in l for l in menu.console.lines)
+
+
+# --- list ---
+
+def test_list_empty():
+    menu = Menu()
+    handle_proxy(menu, ['list'])
+    assert any('No active proxies' in l for l in menu.console.lines)
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_list_with_entries(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+    menu.console.lines.clear()
+
+    handle_proxy(menu, ['list'])
+    # MockConsole stores Rich Table objects; verify a table was printed
+    # and "No active proxies" was NOT printed
+    assert not any('No active proxies' in l for l in menu.console.lines)
+    assert any('Table' in str(type(l)) or 'Table' in l for l in menu.console.lines)
+
+
+# --- stop ---
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_stop_port(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+    assert 1080 in menu._active_proxies
+
+    handle_proxy(menu, ['stop', '1080'])
+    assert 1080 not in menu._active_proxies
+    proc.terminate.assert_called()
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_stop_all(mock_popen):
+    proc1 = MagicMock()
+    proc1.poll.return_value = None
+    proc1.wait.return_value = 0
+    proc2 = MagicMock()
+    proc2.poll.return_value = None
+    proc2.wait.return_value = 0
+    mock_popen.side_effect = [proc1, proc2]
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+    handle_proxy(menu, ['9050'])
+    assert len(menu._active_proxies) == 2
+
+    handle_proxy(menu, ['stop', 'all'])
+    assert len(menu._active_proxies) == 0
+
+
+def test_stop_nonexistent():
+    menu = Menu()
+    handle_proxy(menu, ['stop', '9999'])
+    assert any('No proxy running' in l for l in menu.console.lines)
+
+
+def test_stop_missing_arg():
+    menu = Menu()
+    handle_proxy(menu, ['stop'])
+    assert any('Usage' in l for l in menu.console.lines)
+
+
+# --- stop_all_proxies cleanup ---
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_stop_all_proxies_cleanup(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+    assert 1080 in menu._active_proxies
+
+    stop_all_proxies(menu)
+    assert len(menu._active_proxies) == 0
+    proc.terminate.assert_called()
+
+
+# --- _format_uptime ---
+
+def test_format_uptime_seconds():
+    assert _format_uptime(45) == '45s'
+    assert _format_uptime(0) == '0s'
+    assert _format_uptime(59) == '59s'
+
+
+def test_format_uptime_minutes():
+    assert _format_uptime(60) == '1m'
+    assert _format_uptime(180) == '3m'
+    assert _format_uptime(3599) == '59m'
+
+
+def test_format_uptime_hours():
+    assert _format_uptime(3600) == '1h'
+    assert _format_uptime(4800) == '1h20m'
+    assert _format_uptime(7200) == '2h'
+
+
+# --- tab completion ---
+
+def test_complete_subcommands():
+    menu = Menu()
+    result = complete(menu, '', [])
+    assert 'list' in result
+    assert 'stop' in result
+    assert 'help' in result
+
+
+def test_complete_subcommand_prefix():
+    menu = Menu()
+    result = complete(menu, 'li', [])
+    assert result == ['list']
+
+
+@patch('praetorian_cli.ui.aegis.commands.proxy.subprocess.Popen')
+def test_complete_stop_ports(mock_popen):
+    proc = MagicMock()
+    proc.poll.return_value = None
+    mock_popen.return_value = proc
+
+    menu = Menu()
+    handle_proxy(menu, ['1080'])
+
+    result = complete(menu, '', ['proxy', 'stop'])
+    assert 'all' in result
+    assert '1080' in result

--- a/praetorian_cli/sdk/test/ui_mocks.py
+++ b/praetorian_cli/sdk/test/ui_mocks.py
@@ -20,6 +20,21 @@ class MockAegis:
             'display_info': display_info,
         })
 
+    def copy_to_agent(self, agent, local_path, remote_path, direction='upload',
+                      user=None, ssh_options=None, display_info=True, use_rsync=True):
+        self.calls.append({
+            'method': 'copy_to_agent',
+            'agent': agent,
+            'local_path': local_path,
+            'remote_path': remote_path,
+            'direction': direction,
+            'user': user,
+            'ssh_options': ssh_options or [],
+            'display_info': display_info,
+            'use_rsync': use_rsync,
+        })
+        return 0
+
     def run_job(self, agent, capabilities=None, config=None):
         self.calls.append({
             'method': 'run_job',

--- a/praetorian_cli/ui/aegis/commands/cp.py
+++ b/praetorian_cli/ui/aegis/commands/cp.py
@@ -1,0 +1,132 @@
+from praetorian_cli.handlers.ssh_utils import SSHArgumentParser
+from ..constants import DEFAULT_COLORS
+
+
+def _print_help(menu):
+    help_text = """
+  CP Command — Copy files to/from an agent via rsync (scp fallback)
+
+  Use ':' prefix for remote paths.
+
+  Usage:
+    cp <local_path> :<remote_path>       Upload file/directory
+    cp :<remote_path> <local_path>       Download file/directory
+
+  Options:
+    -u, --user USER       SSH username
+    -i IDENTITY_FILE      Identity (private key) file
+    --no-rsync            Force scp instead of rsync
+
+  Examples:
+    cp ./exploit.sh :/tmp/exploit.sh
+    cp :/etc/passwd ./loot/passwd
+    cp -u root ./tools :/opt/tools
+    cp --no-rsync ./file.txt :/tmp/file.txt
+"""
+    menu.console.print(f"\n{help_text}")
+
+
+def handle_cp(menu, args):
+    """Copy files to/from the selected agent."""
+    if not menu.selected_agent:
+        menu.console.print("\n  No agent selected. Use 'set <id>' to select one.\n")
+        menu.pause()
+        return
+
+    if (len(args) and args[0].lower() == 'help') or any(a in ('-h', '--help') for a in args):
+        _print_help(menu)
+        menu.pause()
+        return
+
+    parser = SSHArgumentParser(console=menu.console)
+
+    if not parser.validate_agent_ssh_availability(menu.selected_agent):
+        menu.pause()
+        return
+
+    # Parse options and collect positional paths
+    user = None
+    key = None
+    use_rsync = True
+    paths = []
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ('-u', '--user'):
+            if i + 1 >= len(args):
+                menu.console.print("[red]Error: -u requires a username[/red]")
+                menu.pause()
+                return
+            user = args[i + 1]
+            i += 2
+        elif arg in ('-i',):
+            if i + 1 >= len(args):
+                menu.console.print("[red]Error: -i requires a key file path[/red]")
+                menu.pause()
+                return
+            key = args[i + 1]
+            i += 2
+        elif arg == '--no-rsync':
+            use_rsync = False
+            i += 1
+        elif arg.startswith('-'):
+            menu.console.print(f"[red]Error: Unknown option '{arg}'[/red]")
+            menu.pause()
+            return
+        else:
+            paths.append(arg)
+            i += 1
+
+    if len(paths) != 2:
+        menu.console.print("[red]Error: cp requires exactly two paths (source and destination)[/red]")
+        menu.console.print("[dim]Usage: cp <src> <dst>   (prefix remote path with ':')[/dim]")
+        menu.pause()
+        return
+
+    src, dst = paths
+    src_remote = src.startswith(':')
+    dst_remote = dst.startswith(':')
+
+    if src_remote and dst_remote:
+        menu.console.print("[red]Error: both paths cannot be remote[/red]")
+        menu.pause()
+        return
+    if not src_remote and not dst_remote:
+        menu.console.print("[red]Error: one path must be remote (prefix with ':')[/red]")
+        menu.pause()
+        return
+
+    if src_remote:
+        direction = 'download'
+        remote_path = src[1:]
+        local_path = dst
+    else:
+        direction = 'upload'
+        local_path = src
+        remote_path = dst[1:]
+
+    ssh_options = []
+    if key:
+        ssh_options.extend(['-i', key])
+
+    try:
+        menu.sdk.aegis.copy_to_agent(
+            agent=menu.selected_agent,
+            local_path=local_path,
+            remote_path=remote_path,
+            direction=direction,
+            user=user,
+            ssh_options=ssh_options,
+            display_info=True,
+            use_rsync=use_rsync,
+        )
+    except Exception as e:
+        colors = getattr(menu, 'colors', DEFAULT_COLORS)
+        menu.console.print(f"[{colors['error']}]Copy error: {e}[/{colors['error']}]")
+        menu.pause()
+
+
+def complete(menu, text, tokens):
+    opts = ['help', '-h', '--help', '-u', '--user', '-i', '--no-rsync']
+    return [o for o in opts if o.startswith(text)]

--- a/praetorian_cli/ui/aegis/commands/help.py
+++ b/praetorian_cli/ui/aegis/commands/help.py
@@ -9,7 +9,7 @@ from ..constants import DEFAULT_COLORS
 def handle_help(menu, args):
     """Show help for commands or a specific command."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
-    if args and args[0] in ['ssh', 'list', 'info', 'job', 'schedule', 'set']:
+    if args and args[0] in ['ssh', 'cp', 'list', 'info', 'job', 'schedule', 'set']:
         menu.console.print(f"\nHelp for '{args[0]}' command - see main help for details\n")
         menu.pause()
         return
@@ -30,6 +30,7 @@ def handle_help(menu, args):
     commands_table.add_row("set <id>", "Select an agent by number, client_id, or hostname")
     commands_table.add_row("list [--all]", "List online agents (--all shows offline too)")
     commands_table.add_row("ssh [options]", "SSH to selected agent (use 'ssh --help' for options)")
+    commands_table.add_row("cp <src> <dst>", "Copy files to/from agent (use ':' for remote paths)")
     commands_table.add_row("info [--raw]", "Show detailed information for selected agent")
     commands_table.add_row("job list", "List recent jobs for selected agent")
     commands_table.add_row("job capabilities [--details]", "List available capabilities")
@@ -66,6 +67,8 @@ def handle_help(menu, args):
     examples_table.add_row("set 1", "Select first agent")
     examples_table.add_row("set abc", "Select agent by hostname")
     examples_table.add_row("ssh -D 1080", "SSH with SOCKS proxy on port 1080")
+    examples_table.add_row("cp ./file.txt :/tmp/file.txt", "Upload file to agent")
+    examples_table.add_row("cp :/etc/hosts ./hosts", "Download file from agent")
     examples_table.add_row("list --all", "Show all agents including offline")
     examples_table.add_row("job list", "List recent jobs")
     examples_table.add_row("job capabilities", "List available capabilities")

--- a/praetorian_cli/ui/aegis/commands/help.py
+++ b/praetorian_cli/ui/aegis/commands/help.py
@@ -9,7 +9,7 @@ from ..constants import DEFAULT_COLORS
 def handle_help(menu, args):
     """Show help for commands or a specific command."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
-    if args and args[0] in ['ssh', 'cp', 'list', 'info', 'job', 'schedule', 'set']:
+    if args and args[0] in ['ssh', 'cp', 'list', 'info', 'job', 'schedule', 'set', 'proxy']:
         menu.console.print(f"\nHelp for '{args[0]}' command - see main help for details\n")
         menu.pause()
         return
@@ -41,6 +41,9 @@ def handle_help(menu, args):
     commands_table.add_row("schedule edit <id>", "Edit a schedule")
     commands_table.add_row("schedule delete <id>", "Delete a schedule")
     commands_table.add_row("schedule pause/resume <id>", "Pause or resume a schedule")
+    commands_table.add_row("proxy <port>", "Start SOCKS proxy on localhost:<port>")
+    commands_table.add_row("proxy list", "Show active proxies")
+    commands_table.add_row("proxy stop <port|all>", "Stop a proxy or all proxies")
     commands_table.add_row("reload", "Refresh agent list from server")
     commands_table.add_row("help [command]", "Show this help or command-specific help")
     commands_table.add_row("clear", "Clear terminal screen")
@@ -78,6 +81,9 @@ def handle_help(menu, args):
     examples_table.add_row("schedule add", "Create a new scheduled job")
     examples_table.add_row("schedule view abc123", "View schedule details")
     examples_table.add_row("schedule pause abc123", "Pause a scheduled job")
+    examples_table.add_row("proxy 1080", "Start SOCKS proxy on port 1080")
+    examples_table.add_row("proxy list", "Show active proxies with uptime")
+    examples_table.add_row("proxy stop 1080", "Stop proxy on port 1080")
     examples_table.add_row("info", "Show agent details")
     examples_table.add_row("info --raw", "Show raw agent data (JSON format)")
 

--- a/praetorian_cli/ui/aegis/commands/proxy.py
+++ b/praetorian_cli/ui/aegis/commands/proxy.py
@@ -1,0 +1,337 @@
+"""Proxy command — start, list, and stop background SOCKS proxies."""
+
+import subprocess
+import time
+from dataclasses import dataclass, field
+from threading import Thread, Event
+
+from ..constants import DEFAULT_COLORS
+
+
+@dataclass
+class ProxyInfo:
+    port: int
+    agent: object
+    user: str
+    public_hostname: str
+    process: subprocess.Popen
+    started_at: float
+    monitor_thread: Thread
+    stop_event: Event
+    reconnect_count: int = 0
+    max_reconnects: int = 5
+    _ssh_cmd: list = field(default_factory=list)
+
+
+def handle_proxy(menu, args):
+    """Entry point — routes to start/list/stop/help."""
+    if not args:
+        _print_help(menu)
+        menu.pause()
+        return
+
+    subcmd = args[0].lower()
+
+    if subcmd in ('help', '-h', '--help'):
+        _print_help(menu)
+        menu.pause()
+    elif subcmd == 'list':
+        _handle_list(menu)
+    elif subcmd == 'stop':
+        _handle_stop(menu, args[1:])
+    else:
+        _handle_start(menu, args)
+
+
+def _handle_start(menu, args):
+    """Parse port + optional -u, validate agent, launch proxy."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    if not menu.selected_agent:
+        menu.console.print(f"\n  No agent selected. Use 'set <id>' to select one.\n")
+        menu.pause()
+        return
+
+    agent = menu.selected_agent
+    if not getattr(agent, 'has_tunnel', False):
+        menu.console.print(f"[{colors['error']}]Agent has no active tunnel[/{colors['error']}]")
+        menu.pause()
+        return
+
+    # Parse args: first positional is port, -u <user> optional
+    port = None
+    user = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ('-u', '--user'):
+            if i + 1 >= len(args):
+                menu.console.print(f"[{colors['error']}]Error: -u requires a username[/{colors['error']}]")
+                menu.pause()
+                return
+            user = args[i + 1]
+            i += 2
+        elif port is None:
+            try:
+                port = int(arg)
+            except ValueError:
+                menu.console.print(f"[{colors['error']}]Invalid port: {arg}[/{colors['error']}]")
+                menu.pause()
+                return
+            i += 1
+        else:
+            i += 1
+
+    if port is None:
+        menu.console.print(f"[{colors['error']}]Usage: proxy <port> [-u user][/{colors['error']}]")
+        menu.pause()
+        return
+
+    if port < 1 or port > 65535:
+        menu.console.print(f"[{colors['error']}]Port must be between 1 and 65535[/{colors['error']}]")
+        menu.pause()
+        return
+
+    proxies = getattr(menu, '_active_proxies', {})
+    if port in proxies:
+        menu.console.print(f"[{colors['warning']}]Proxy already running on port {port}[/{colors['warning']}]")
+        menu.pause()
+        return
+
+    try:
+        public_hostname = agent.health_check.cloudflared_status.hostname
+    except Exception:
+        menu.console.print(f"[{colors['error']}]Cannot determine agent hostname[/{colors['error']}]")
+        menu.pause()
+        return
+
+    if not user:
+        try:
+            _, user = menu.sdk.aegis.api.get_current_user()
+        except Exception:
+            user = 'root'
+
+    info = _start_proxy_process(port, agent, user, public_hostname)
+    if info is None or info.process.poll() is not None:
+        menu.console.print(f"[{colors['error']}]Failed to start proxy on port {port}[/{colors['error']}]")
+        menu.pause()
+        return
+
+    if not hasattr(menu, '_active_proxies'):
+        menu._active_proxies = {}
+    menu._active_proxies[port] = info
+    menu.console.print(f"[{colors['success']}]SOCKS proxy started on localhost:{port}[/{colors['success']}]")
+
+
+def _start_proxy_process(port, agent, user, hostname):
+    """Launch SSH SOCKS proxy and spawn monitor thread. Returns ProxyInfo."""
+    ssh_cmd = [
+        'ssh',
+        '-o', 'ConnectTimeout=10',
+        '-o', 'ServerAliveInterval=30',
+        '-o', 'ExitOnForwardFailure=yes',
+        '-o', 'StrictHostKeyChecking=accept-new',
+        '-D', str(port),
+        '-N',
+        f'{user}@{hostname}',
+    ]
+
+    try:
+        process = subprocess.Popen(
+            ssh_cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+
+    stop_event = Event()
+    info = ProxyInfo(
+        port=port,
+        agent=agent,
+        user=user,
+        public_hostname=hostname,
+        process=process,
+        started_at=time.monotonic(),
+        monitor_thread=None,
+        stop_event=stop_event,
+        _ssh_cmd=ssh_cmd,
+    )
+
+    thread = Thread(target=_monitor_proxy, args=(info,), daemon=True)
+    info.monitor_thread = thread
+    thread.start()
+
+    return info
+
+
+def _monitor_proxy(info):
+    """Daemon thread — poll process, auto-reconnect on death."""
+    while not info.stop_event.is_set():
+        info.stop_event.wait(timeout=2.0)
+        if info.stop_event.is_set():
+            break
+        if info.process.poll() is not None:
+            # Process died
+            if info.reconnect_count >= info.max_reconnects:
+                break
+            info.reconnect_count += 1
+            try:
+                info.process = subprocess.Popen(
+                    info._ssh_cmd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                break
+
+
+def _handle_list(menu):
+    """Rich table of active proxies with status."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    proxies = getattr(menu, '_active_proxies', {})
+
+    if not proxies:
+        menu.console.print(f"\n  [{colors['dim']}]No active proxies[/{colors['dim']}]\n")
+        return
+
+    from rich.table import Table
+    from rich.box import MINIMAL
+
+    table = Table(
+        show_header=True,
+        header_style=f"bold {colors['primary']}",
+        border_style=colors['dim'],
+        box=MINIMAL,
+        show_lines=False,
+        padding=(0, 2),
+        pad_edge=False,
+    )
+
+    table.add_column("PORT", style=f"bold {colors['success']}", width=8, no_wrap=True)
+    table.add_column("AGENT", style="white", min_width=15, no_wrap=True)
+    table.add_column("USER", style=f"{colors['dim']}", width=12, no_wrap=True)
+    table.add_column("UPTIME", style=f"{colors['dim']}", width=10, no_wrap=True)
+    table.add_column("STATUS", width=12, no_wrap=True)
+
+    now = time.monotonic()
+    for port in sorted(proxies):
+        info = proxies[port]
+        hostname = getattr(info.agent, 'hostname', 'unknown')
+        uptime = _format_uptime(now - info.started_at)
+        alive = info.process.poll() is None
+        status = f"[{colors['success']}]running[/{colors['success']}]" if alive else f"[{colors['error']}]dead[/{colors['error']}]"
+        table.add_row(str(port), hostname, info.user, uptime, status)
+
+    menu.console.print()
+    menu.console.print(table)
+    menu.console.print()
+
+
+def _handle_stop(menu, args):
+    """Stop by port or 'all'."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    proxies = getattr(menu, '_active_proxies', {})
+
+    if not args:
+        menu.console.print(f"[{colors['error']}]Usage: proxy stop <port|all>[/{colors['error']}]")
+        menu.pause()
+        return
+
+    if args[0].lower() == 'all':
+        if not proxies:
+            menu.console.print(f"[{colors['dim']}]No active proxies to stop[/{colors['dim']}]")
+            return
+        stop_all_proxies(menu)
+        menu.console.print(f"[{colors['success']}]All proxies stopped[/{colors['success']}]")
+        return
+
+    try:
+        port = int(args[0])
+    except ValueError:
+        menu.console.print(f"[{colors['error']}]Invalid port: {args[0]}[/{colors['error']}]")
+        menu.pause()
+        return
+
+    if port not in proxies:
+        menu.console.print(f"[{colors['warning']}]No proxy running on port {port}[/{colors['warning']}]")
+        menu.pause()
+        return
+
+    _stop_single_proxy(menu, port)
+    menu.console.print(f"[{colors['success']}]Proxy on port {port} stopped[/{colors['success']}]")
+
+
+def _stop_single_proxy(menu, port):
+    """SIGTERM -> wait 3s -> SIGKILL, remove from dict."""
+    proxies = getattr(menu, '_active_proxies', {})
+    info = proxies.pop(port, None)
+    if info is None:
+        return
+    info.stop_event.set()
+    try:
+        info.process.terminate()
+        info.process.wait(timeout=3)
+    except Exception:
+        try:
+            info.process.kill()
+        except Exception:
+            pass
+
+
+def stop_all_proxies(menu):
+    """Stop all proxies — called on TUI exit."""
+    proxies = getattr(menu, '_active_proxies', {})
+    ports = list(proxies.keys())
+    for port in ports:
+        _stop_single_proxy(menu, port)
+
+
+def _format_uptime(seconds):
+    """Format uptime: 45s / 3m / 1h20m."""
+    seconds = int(seconds)
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    remaining_minutes = minutes % 60
+    if remaining_minutes:
+        return f"{hours}h{remaining_minutes}m"
+    return f"{hours}h"
+
+
+def complete(menu, text, tokens):
+    """Tab complete subcommands + active ports."""
+    subcommands = ['list', 'stop', 'help']
+    # If first token after 'proxy' is 'stop', suggest ports + 'all'
+    if len(tokens) >= 2 and tokens[1].lower() == 'stop':
+        proxies = getattr(menu, '_active_proxies', {})
+        options = ['all'] + [str(p) for p in sorted(proxies)]
+        return [o for o in options if o.startswith(text)]
+    return [s for s in subcommands if s.startswith(text)]
+
+
+def _print_help(menu):
+    """Show help text."""
+    help_text = """
+  Proxy Command — Background SOCKS proxy via SSH
+
+  Usage:
+    proxy <port> [-u user]       Start SOCKS proxy on localhost:<port>
+    proxy list                   Show active proxies
+    proxy stop <port>            Stop a specific proxy
+    proxy stop all               Stop all proxies
+    proxy help                   Show this help
+
+  Examples:
+    proxy 1080                   Start SOCKS proxy on port 1080
+    proxy 9050 -u admin          Start proxy as specific user
+    proxy list                   Show running proxies
+    proxy stop 1080              Stop proxy on port 1080
+    proxy stop all               Stop all proxies
+"""
+    menu.console.print(f"\n{help_text}")

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -18,6 +18,9 @@ def handle_set(menu, args):
         menu.selected_agent = selected_agent
         hostname = selected_agent.hostname
         menu.console.print(f"\n  Selected: {hostname}\n")
+        # Pre-fetch home directory listing so cp tab-completion is instant
+        if hasattr(menu, 'prefetch_agent_home'):
+            menu.prefetch_agent_home(selected_agent)
     else:
         displayed_count = len(menu.displayed_agents)
         menu.console.print(f"\n[{colors['error']}]  Agent not found:[/{colors['error']}] {selection}")


### PR DESCRIPTION
## Summary

- **Local file path tab-completion** for `cp` using `PathCompleter` (handles `~`, symlinks, directories)
- **Remote file path tab-completion** via background SSH `ls` — non-blocking with 30s cache TTL
- **Pre-fetch `~` and `/tmp`** when agent is selected so remote completions are instant by the time `cp :` is typed
- **Subdirectory pre-fetching** — visible directory completions trigger background fetches so drilling deeper is instant
- **"loading remote files…" toolbar** shown during SSH fetches via `bottom_toolbar`
- **Cleaner rsync output** — replaced `-avz --progress --human-readable` with `-az --partial`; detects Homebrew rsync vs macOS openrsync to conditionally use `--info=progress2`
- **Colorized transfer summary** — `✓ Transfer complete (1.2s)` / `✗ Transfer failed (exit code N)` after every transfer
- **Up/down arrow history** via `InMemoryHistory` for command recall across prompts
- **17 tests** covering cp operations, local/remote completion, caching, prefetch-on-set

## Test plan

- [ ] `cd modules/praetorian-cli && python3 -m pytest praetorian_cli/sdk/test/ui/test_aegis_cp.py -v`
- [ ] `set <agent>` then `cp :` — verify remote completions appear without delay
- [ ] `cp ./local<TAB>` — verify local file path completion works
- [ ] `cp --<TAB>` — verify option flag completion
- [ ] Transfer a file and verify clean summary output (no per-file rsync noise)
- [ ] Up arrow recalls previous commands