### PR TITLE
Use headers for API key auth on token endpoint

### DIFF
--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -95,7 +95,10 @@ class Keychain:
             if self.has_api_key():
                 response = requests.get(
                     f"{self.base_url()}/token",
-                    params={'id': self.api_key_id(), 'key': self.api_key_secret()}
+                    headers={
+                        'X-GUARD-API-KEY-ID': self.api_key_id(),
+                        'X-GUARD-API-KEY-SECRET': self.api_key_secret(),
+                    }
                 )
                 if response.status_code != 200:
                     error(f"API key authentication failed: {response.text}")


### PR DESCRIPTION
Fixes OFFSEC-2292 — `praetorian_cli/sdk/keychain.py` stops sending the API key id/secret as `?id=&key=` query parameters on the `/token` request and sends them as `X-GUARD-API-KEY-ID` / `X-GUARD-API-KEY-SECRET` headers instead, keeping the secret out of access logs, proxy/CDN logs, shell history and Referer headers.