### PR TITLE
feat: add Generic asset type support

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -18,20 +18,19 @@ def add():
 
 @add.command()
 @cli_handler
-@click.option('-d', '--dns', required=True, help='The DNS of the asset')
-@click.option('-n', '--name', required=False, help='The name of the asset, e.g, IP address')
+@click.option('-g', '--group', required=True, help='The group of the asset (e.g., domain name, project ID)')
+@click.option('-i', '--identifier', required=False, help='The specific identifier of the asset (e.g., IP address)')
 @click.option('-t', '--type', 'asset_type', required=False, help='The type of the asset (asset, generic, repository, etc.)', default=Kind.ASSET.value)
 @click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), required=False,
               default=Asset.ACTIVE.value, help=f'Status of the asset', show_default=True)
 @click.option('-f', '--surface', required=False, default='', help=f'Attack surface of the asset', show_default=False)
 @click.option('-r', '--resource-type', required=False, default='', help='Cloud resource type (e.g., compute.googleapis.com/Instance, AWS::EC2::Instance)')
-def asset(sdk, name, dns, asset_type, status, surface, resource_type):
+def asset(sdk, identifier, group, asset_type, status, surface, resource_type):
     """ Add an asset
 
-    Add an asset to the Guard database. This command requires a DNS name for the asset.
-    Optionally, a name can be provided to give the asset more specific information,
-    such as IP address. If no name is provided, the DNS name will be used as the name.
-    The DNS is the group and the name is the specific identifier. This is for legacy reasons.
+    Add an asset to the Guard database. This command requires a group for the asset.
+    Optionally, an identifier can be provided to give the asset more specific information,
+    such as IP address. If no identifier is provided, the group will be used as the identifier.
 
     The type can be one of the following: asset, generic, addomain, repository, webapplication,
     gcpresource, awsresource, azureresource.
@@ -47,16 +46,16 @@ def asset(sdk, name, dns, asset_type, status, surface, resource_type):
 
     \b
     Example usages:
-        - guard add asset --dns example.com
-        - guard add asset --dns example.com --name 1.2.3.4
-        - guard add asset --dns internal.example.com --name 10.2.3.4 --surface internal
-        - guard add asset --dns https://example.com --name 'Example Web Application' --type webapplication
-        - guard add asset --dns my-project-id --name 'projects/my-proj/zones/us-central1-a/instances/vm1' --type gcpresource --resource-type 'compute.googleapis.com/Instance'
-        - guard add asset --dns "my-custom-id" --name "any string here" --type generic
+        - guard add asset --group example.com
+        - guard add asset --group example.com --identifier 1.2.3.4
+        - guard add asset --group internal.example.com --identifier 10.2.3.4 --surface internal
+        - guard add asset --group https://example.com --identifier 'Example Web Application' --type webapplication
+        - guard add asset --group my-project-id --identifier 'projects/my-proj/zones/us-central1-a/instances/vm1' --type gcpresource --resource-type 'compute.googleapis.com/Instance'
+        - guard add asset --group "my-custom-id" --identifier "any string here" --type generic
     """
-    if not name:
-        name = dns
-    sdk.assets.add(dns, name, asset_type, status, surface, resource_type=resource_type)
+    if not identifier:
+        identifier = group
+    sdk.assets.add(group, identifier, asset_type, status, surface, resource_type=resource_type)
 
 
 @add.command()

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -20,7 +20,7 @@ def add():
 @cli_handler
 @click.option('-d', '--dns', required=True, help='The DNS of the asset')
 @click.option('-n', '--name', required=False, help='The name of the asset, e.g, IP address')
-@click.option('-t', '--type', 'asset_type', required=False, help='The type of the asset (asset, repository, etc.)', default=Kind.ASSET.value)
+@click.option('-t', '--type', 'asset_type', required=False, help='The type of the asset (asset, generic, repository, etc.)', default=Kind.ASSET.value)
 @click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), required=False,
               default=Asset.ACTIVE.value, help=f'Status of the asset', show_default=True)
 @click.option('-f', '--surface', required=False, default='', help=f'Attack surface of the asset', show_default=False)
@@ -33,7 +33,7 @@ def asset(sdk, name, dns, asset_type, status, surface, resource_type):
     such as IP address. If no name is provided, the DNS name will be used as the name.
     The DNS is the group and the name is the specific identifier. This is for legacy reasons.
 
-    The type can be one of the following: asset, addomain, repository, webapplication,
+    The type can be one of the following: asset, generic, addomain, repository, webapplication,
     gcpresource, awsresource, azureresource.
 
     For cloud resource types (gcpresource, awsresource, azureresource), the --resource-type
@@ -52,6 +52,7 @@ def asset(sdk, name, dns, asset_type, status, surface, resource_type):
         - guard add asset --dns internal.example.com --name 10.2.3.4 --surface internal
         - guard add asset --dns https://example.com --name 'Example Web Application' --type webapplication
         - guard add asset --dns my-project-id --name 'projects/my-proj/zones/us-central1-a/instances/vm1' --type gcpresource --resource-type 'compute.googleapis.com/Instance'
+        - guard add asset --dns "my-custom-id" --name "any string here" --type generic
     """
     if not name:
         name = dns

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -18,8 +18,8 @@ def add():
 
 @add.command()
 @cli_handler
-@click.option('-g', '--group', required=True, help='The group of the asset (e.g., domain name, project ID)')
-@click.option('-i', '--identifier', required=False, help='The specific identifier of the asset (e.g., IP address)')
+@click.option('-g', '--group', '--dns', required=True, help='The group of the asset (e.g., domain name, project ID)')
+@click.option('-i', '--identifier', '--name', required=False, help='The specific identifier of the asset (e.g., IP address)')
 @click.option('-t', '--type', 'asset_type', required=False, help='The type of the asset (asset, generic, repository, etc.)', default=Kind.ASSET.value)
 @click.option('-s', '--status', type=click.Choice([s.value for s in Asset]), required=False,
               default=Asset.ACTIVE.value, help=f'Status of the asset', show_default=True)

--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -12,7 +12,7 @@ def list():
 
 
 @list.command()
-@list_params('DNS', has_type=True)
+@list_params('group', has_type=True)
 def assets(chariot, filter, model_type, details, offset, page):
     """ List assets
 
@@ -30,7 +30,7 @@ def assets(chariot, filter, model_type, details, offset, page):
 
 
 @list.command()
-@list_params('DNS of the associated assets')
+@list_params('group of the associated assets')
 def risks(chariot, filter, details, offset, page):
     """ List risks
 
@@ -98,7 +98,7 @@ def integrations(chariot, filter, details, offset, page):
 
 
 @list.command()
-@list_params('DNS of the job asset')
+@list_params('group of the job asset')
 def jobs(chariot, filter, details, offset, page):
     """
     List jobs
@@ -177,7 +177,7 @@ def attributes(chariot, filter, key, details, offset, page):
 
 
 @list.command()
-@list_params('DNS')
+@list_params('group')
 @click.option('-t', '--type', help='Filter by seed type (e.g., asset, addomain)')
 def seeds(chariot, type, filter, details, offset, page):
     """ List seeds
@@ -198,7 +198,7 @@ def seeds(chariot, type, filter, details, offset, page):
 
 
 @list.command()
-@list_params('DNS')
+@list_params('group')
 def preseeds(chariot, filter, details, offset, page):
     """ List adjacent domain discovery patterns (pre-seeds)
 

--- a/praetorian_cli/sdk/model/globals.py
+++ b/praetorian_cli/sdk/model/globals.py
@@ -100,6 +100,7 @@ class AgentType(Enum):
 
 class Kind(Enum):
     ASSET = 'asset'
+    GENERIC = 'generic'
     REPOSITORY = 'repository'
     INTEGRATION = 'integration'
     ADDOMAIN = 'addomain'

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -302,6 +302,7 @@ class Relationship:
 class Node:
     class Label(Enum):
         ASSET = 'Asset'
+        GENERIC = 'Generic'
         REPOSITORY = 'Repository'
         INTEGRATION = 'Integration'
         ADDOMAIN = 'ADDomain'
@@ -389,6 +390,7 @@ WEBPAGE_NODE = [Node.Label.WEBPAGE]
 
 KIND_TO_LABEL = {
     Kind.ASSET.value: Node.Label.ASSET,
+    Kind.GENERIC.value: Node.Label.GENERIC,
     Kind.RISK.value: Node.Label.RISK,
     Kind.ATTRIBUTE.value: Node.Label.ATTRIBUTE,
     Kind.PORT.value: Node.Label.PORT,

--- a/praetorian_cli/sdk/model/utils.py
+++ b/praetorian_cli/sdk/model/utils.py
@@ -29,3 +29,6 @@ def setting_key(name):
 
 def configuration_key(name):
     return f'#configuration#{name}'
+
+def generic_key(dns, name):
+    return f'#generic#{dns}#{name}'

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -294,7 +294,7 @@ class TestZCli:
 
     def test_webapplication_cli(self):
         o = make_test_values(lambda: None)
-        self.verify(f'add asset --dns "{o.webapp_name}" --name "{o.webapp_url}" --type webapplication')
+        self.verify(f'add asset --group "{o.webapp_name}" --identifier "{o.webapp_url}" --type webapplication')
         self.verify(f'get asset "{o.webapp_key}"', expected_stdout=[o.webapp_key, o.webapp_url, o.webapp_name, '"status"', '"A"'])
         self.verify(f'list assets -f "{o.webapp_key}"', expected_stdout=[o.webapp_key])
         self.verify(f'delete asset "{o.webapp_key}"', ignore_stdout=True)

--- a/praetorian_cli/ui/aegis/commands/job.py
+++ b/praetorian_cli/ui/aegis/commands/job.py
@@ -148,7 +148,7 @@ def run_job(menu, args):
         if not target_key:
             menu.console.print(f"  [{colors['error']}]No asset found for domain '{domain}'.[/{colors['error']}]")
             menu.console.print(f"  [{colors['dim']}]The domain must exist as an asset before running jobs against it.[/{colors['dim']}]")
-            menu.console.print(f"  [{colors['dim']}]Add it first with: praetorian chariot add asset --dns {domain} --type addomain[/{colors['dim']}]")
+            menu.console.print(f"  [{colors['dim']}]Add it first with: praetorian chariot add asset --group {domain} --type addomain[/{colors['dim']}]")
             menu.pause()
             return
 

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -280,7 +280,7 @@ def add_schedule(menu):
         if not target_key:
             menu.console.print(f"  [{colors['error']}]No asset found for domain '{domain}'.[/{colors['error']}]")
             menu.console.print(f"  [{colors['dim']}]The domain must exist as an asset before scheduling jobs against it.[/{colors['dim']}]")
-            menu.console.print(f"  [{colors['dim']}]Add it first with: praetorian chariot add asset --dns {domain} --type addomain[/{colors['dim']}]")
+            menu.console.print(f"  [{colors['dim']}]Add it first with: praetorian chariot add asset --group {domain} --type addomain[/{colors['dim']}]")
             menu.pause()
             return
 


### PR DESCRIPTION
## Summary
- Adds client-side support for the new Generic asset type (model defined in tabularium)
- `Kind.GENERIC` enum, `Node.Label.GENERIC`, `KIND_TO_LABEL` mapping, `generic_key()` helper
- Updated `guard add asset` help text and examples

## Changes
- `praetorian_cli/sdk/model/globals.py` — `GENERIC = 'generic'` in Kind enum
- `praetorian_cli/sdk/model/query.py` — Node.Label + KIND_TO_LABEL entry
- `praetorian_cli/handlers/add.py` — help text and example for `--type generic`
- `praetorian_cli/sdk/model/utils.py` — `generic_key()` helper

## Test plan
- [x] `guard add asset --dns "my-custom-id" --name "any string" --type generic` works end-to-end
- [x] `guard list assets --type generic` returns generic assets

Depends on: tabularium PR for Generic model
Relates to: https://linear.app/praetorianlabs/issue/PS-551