### PR TITLE
feat: add --title flag to risk CLI commands

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -144,7 +144,7 @@ def webhook(sdk):
               help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
-@click.option('--display-name', '-dn', default='', help='Human-readable display name for the risk')
+@click.option('--display-name', '-dn', default=None, help='Human-readable display name for the risk')
 def risk(sdk, name, asset, status, comment, capability, display_name):
     """ Add a risk
 

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -144,7 +144,8 @@ def webhook(sdk):
               help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
-def risk(sdk, name, asset, status, comment, capability):
+@click.option('--display-name', '-dn', default='', help='Human-readable display name for the risk')
+def risk(sdk, name, asset, status, comment, capability, display_name):
     """ Add a risk
 
     This command adds a risk to Guard. A risk must have an associated asset.
@@ -161,7 +162,7 @@ def risk(sdk, name, asset, status, comment, capability):
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC --capability red-team
     """
-    sdk.risks.add(asset, name, status, comment, capability)
+    sdk.risks.add(asset, name, status, comment, capability, display_name)
 
 
 @add.command()

--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -144,8 +144,8 @@ def webhook(sdk):
               help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
-@click.option('--display-name', '-dn', default=None, help='Human-readable display name for the risk')
-def risk(sdk, name, asset, status, comment, capability, display_name):
+@click.option('--title', '-t', default=None, help='Human-readable title for the risk')
+def risk(sdk, name, asset, status, comment, capability, title):
     """ Add a risk
 
     This command adds a risk to Guard. A risk must have an associated asset.
@@ -162,7 +162,7 @@ def risk(sdk, name, asset, status, comment, capability, display_name):
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC --capability red-team
     """
-    sdk.risks.add(asset, name, status, comment, capability, display_name)
+    sdk.risks.add(asset, name, status, comment, capability, title)
 
 
 @add.command()

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -37,7 +37,7 @@ def asset(chariot, key, status, surface):
 @click.option('-s', '--status', type=click.Choice([s.value for s in Risk]), help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-r', '--remove-comment', type=int, default=None, help='Remove comment at index (0, 1, ... or -1 for most recent)')
-@click.option('--display-name', '-dn', default='', help='Human-readable display name for the risk')
+@click.option('--display-name', '-dn', default=None, help='Human-readable display name for the risk')
 def risk(chariot, key, status, comment, remove_comment, display_name):
     """ Update the status and comment of a risk
 

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -37,7 +37,8 @@ def asset(chariot, key, status, surface):
 @click.option('-s', '--status', type=click.Choice([s.value for s in Risk]), help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-r', '--remove-comment', type=int, default=None, help='Remove comment at index (0, 1, ... or -1 for most recent)')
-def risk(chariot, key, status, comment, remove_comment):
+@click.option('--display-name', '-dn', default='', help='Human-readable display name for the risk')
+def risk(chariot, key, status, comment, remove_comment, display_name):
     """ Update the status and comment of a risk
 
     \b
@@ -54,7 +55,7 @@ def risk(chariot, key, status, comment, remove_comment):
     if comment and remove_comment is not None:
         raise click.UsageError("Cannot use --comment and --remove-comment together")
 
-    chariot.risks.update(key, status, comment, remove_comment)
+    chariot.risks.update(key, status, comment, remove_comment, display_name)
 
 
 @update.command()

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -37,8 +37,8 @@ def asset(chariot, key, status, surface):
 @click.option('-s', '--status', type=click.Choice([s.value for s in Risk]), help=f'Status of the risk')
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-r', '--remove-comment', type=int, default=None, help='Remove comment at index (0, 1, ... or -1 for most recent)')
-@click.option('--display-name', '-dn', default=None, help='Human-readable display name for the risk')
-def risk(chariot, key, status, comment, remove_comment, display_name):
+@click.option('--title', '-t', default=None, help='Human-readable title for the risk')
+def risk(chariot, key, status, comment, remove_comment, title):
     """ Update the status and comment of a risk
 
     \b
@@ -55,7 +55,7 @@ def risk(chariot, key, status, comment, remove_comment, display_name):
     if comment and remove_comment is not None:
         raise click.UsageError("Cannot use --comment and --remove-comment together")
 
-    chariot.risks.update(key, status, comment, remove_comment, display_name)
+    chariot.risks.update(key, status, comment, remove_comment, title)
 
 
 @update.command()

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -9,7 +9,7 @@ class Risks:
     def __init__(self, api):
         self.api = api
 
-    def add(self, asset_key, name, status, comment=None, capability='', display_name=''):
+    def add(self, asset_key, name, status, comment=None, capability='', display_name=None):
         """
         Add a risk to an existing asset.
 
@@ -24,12 +24,12 @@ class Risks:
         :param capability: Optional capability that discovered this risk
         :type capability: str
         :param display_name: Optional human-readable display name for the risk
-        :type display_name: str
+        :type display_name: str or None
         :return: The created risk object
         :rtype: dict
         """
         body = dict(key=asset_key, name=name, status=status, comment=comment, source=capability)
-        if display_name:
+        if display_name is not None:
             body['displayName'] = display_name
         return self.api.upsert('risk', body)['risks'][0]
 
@@ -49,7 +49,7 @@ class Risks:
             risk['affected_assets'] = self.affected_assets(key)
         return risk
 
-    def update(self, key, status=None, comment=None, remove_comment=None, display_name=''):
+    def update(self, key, status=None, comment=None, remove_comment=None, display_name=None):
         """
         Update a risk's status and/or comment, or remove a comment.
 
@@ -62,7 +62,7 @@ class Risks:
         :param remove_comment: Index of comment to remove (0, 1, ... or -1 for most recent)
         :type remove_comment: int or None
         :param display_name: Optional human-readable display name for the risk
-        :type display_name: str
+        :type display_name: str or None
         :return: API response containing update results
         :rtype: dict
         """
@@ -71,7 +71,7 @@ class Risks:
             params = params | dict(status=status)
         if comment:
             params = params | dict(comment=comment)
-        if display_name:
+        if display_name is not None:
             params['displayName'] = display_name
         if remove_comment is not None:
             index = self.resolve_comment_entry_index(key, remove_comment)

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -9,7 +9,7 @@ class Risks:
     def __init__(self, api):
         self.api = api
 
-    def add(self, asset_key, name, status, comment=None, capability=''):
+    def add(self, asset_key, name, status, comment=None, capability='', display_name=''):
         """
         Add a risk to an existing asset.
 
@@ -23,10 +23,15 @@ class Risks:
         :type comment: str or None
         :param capability: Optional capability that discovered this risk
         :type capability: str
+        :param display_name: Optional human-readable display name for the risk
+        :type display_name: str
         :return: The created risk object
         :rtype: dict
         """
-        return self.api.upsert('risk', dict(key=asset_key, name=name, status=status, comment=comment, source=capability))['risks'][0]
+        body = dict(key=asset_key, name=name, status=status, comment=comment, source=capability)
+        if display_name:
+            body['displayName'] = display_name
+        return self.api.upsert('risk', body)['risks'][0]
 
     def get(self, key, details=False):
         """
@@ -44,7 +49,7 @@ class Risks:
             risk['affected_assets'] = self.affected_assets(key)
         return risk
 
-    def update(self, key, status=None, comment=None, remove_comment=None):
+    def update(self, key, status=None, comment=None, remove_comment=None, display_name=''):
         """
         Update a risk's status and/or comment, or remove a comment.
 
@@ -56,6 +61,8 @@ class Risks:
         :type comment: str or None
         :param remove_comment: Index of comment to remove (0, 1, ... or -1 for most recent)
         :type remove_comment: int or None
+        :param display_name: Optional human-readable display name for the risk
+        :type display_name: str
         :return: API response containing update results
         :rtype: dict
         """
@@ -64,6 +71,8 @@ class Risks:
             params = params | dict(status=status)
         if comment:
             params = params | dict(comment=comment)
+        if display_name:
+            params['displayName'] = display_name
         if remove_comment is not None:
             index = self.resolve_comment_entry_index(key, remove_comment)
             params = params | dict(remove=index)

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -9,7 +9,7 @@ class Risks:
     def __init__(self, api):
         self.api = api
 
-    def add(self, asset_key, name, status, comment=None, capability='', display_name=None):
+    def add(self, asset_key, name, status, comment=None, capability='', title=None):
         """
         Add a risk to an existing asset.
 
@@ -23,14 +23,14 @@ class Risks:
         :type comment: str or None
         :param capability: Optional capability that discovered this risk
         :type capability: str
-        :param display_name: Optional human-readable display name for the risk
-        :type display_name: str or None
+        :param title: Optional human-readable title for the risk
+        :type title: str or None
         :return: The created risk object
         :rtype: dict
         """
         body = dict(key=asset_key, name=name, status=status, comment=comment, source=capability)
-        if display_name is not None:
-            body['displayName'] = display_name
+        if title is not None:
+            body['title'] = title
         return self.api.upsert('risk', body)['risks'][0]
 
     def get(self, key, details=False):
@@ -49,7 +49,7 @@ class Risks:
             risk['affected_assets'] = self.affected_assets(key)
         return risk
 
-    def update(self, key, status=None, comment=None, remove_comment=None, display_name=None):
+    def update(self, key, status=None, comment=None, remove_comment=None, title=None):
         """
         Update a risk's status and/or comment, or remove a comment.
 
@@ -61,8 +61,8 @@ class Risks:
         :type comment: str or None
         :param remove_comment: Index of comment to remove (0, 1, ... or -1 for most recent)
         :type remove_comment: int or None
-        :param display_name: Optional human-readable display name for the risk
-        :type display_name: str or None
+        :param title: Optional human-readable title for the risk
+        :type title: str or None
         :return: API response containing update results
         :rtype: dict
         """
@@ -71,8 +71,8 @@ class Risks:
             params = params | dict(status=status)
         if comment:
             params = params | dict(comment=comment)
-        if display_name is not None:
-            params['displayName'] = display_name
+        if title is not None:
+            params['title'] = title
         if remove_comment is not None:
             index = self.resolve_comment_entry_index(key, remove_comment)
             params = params | dict(remove=index)

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -83,9 +83,11 @@ class TestRisk:
         assert risk['title'] == title
 
     def test_update_risk_with_title(self):
+        r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, title='Original Title')
+        risk_key = r['key']
         title = f'Updated Title {self.risk_name}'
-        self.sdk.risks.update(self.risk_key, title=title)
-        risk = self.get_risk()
+        self.sdk.risks.update(risk_key, title=title)
+        risk = self.sdk.risks.get(risk_key)
         assert risk['title'] == title
 
     def teardown_class(self):

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -76,5 +76,17 @@ class TestRisk:
     def get_risk(self):
         return self.sdk.risks.get(self.risk_key)
 
+    def test_add_risk_with_title(self):
+        title = f'Test Title {self.risk_name}'
+        r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, title=title)
+        risk = self.sdk.risks.get(r['key'])
+        assert risk['title'] == title
+
+    def test_update_risk_with_title(self):
+        title = f'Updated Title {self.risk_name}'
+        self.sdk.risks.update(self.risk_key, title=title)
+        risk = self.get_risk()
+        assert risk['title'] == title
+
     def teardown_class(self):
         clean_test_entities(self.sdk, self)


### PR DESCRIPTION
## Summary
- Adds `--title` option to `guard add risk` and `guard update risk` commands
- SDK `risks.add()` and `risks.update()` conditionally include `title` in API body when provided
- Uses `None` sentinel (not empty string) to distinguish omission from explicit empty string
- Enables users to set human-readable names for risks (e.g., `--title "SQL Injection"` instead of showing "sql-injection")

Ref: https://linear.app/praetorianlabs/issue/PS-575

### Companion PRs (merge order)
1. [tabularium#218](https://github.com/praetorian-inc/tabularium/pull/218) - Merge first (model changes)
2. [guard#4658](https://github.com/praetorian-inc/guard/pull/4658) - Update go.mod to stable tag, then merge
3. **[praetorian-cli#178](https://github.com/praetorian-inc/praetorian-cli/pull/178)** - Merge independently ← this PR

## Test plan
- [x] `guard add risk example.com sql-injection TI --title "SQL Injection"` creates risk with title
- [x] `guard update risk '#risk#example.com#sql-injection' --title "Updated Name"` updates title
- [x] Omitting `--title` does not send title field (backward compatible)