### PR TITLE
feat: interactive account selection when --account omitted

### DIFF
--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -1,4 +1,44 @@
+import sys
+
 import click
+
+
+def prompt_account_selection(sdk):
+    """Prompt the user to select an account if none was explicitly provided.
+
+    Temporarily clears the keychain account so the API call lists accounts
+    from the login principal's perspective. Restores the original account
+    on failure or if no accounts are available.
+    """
+    keychain = sdk.keychain
+    keychain.load()
+    saved_account = keychain.account
+    keychain.account = None
+    try:
+        accounts_data, _ = sdk.accounts.list()
+        account_names = sorted(set(a['name'] for a in accounts_data))
+        if account_names:
+            click.echo('Available accounts:')
+            for i, acct in enumerate(account_names, 1):
+                click.echo(f'  {i}. {acct}')
+            raw = click.prompt('Select account (or "exit" to quit)')
+            if raw.strip().lower() == 'exit':
+                raise SystemExit(0)
+            try:
+                choice = int(raw)
+            except ValueError:
+                click.echo(f'Error: invalid input: {raw}')
+                raise SystemExit(1)
+            if choice < 1 or choice > len(account_names):
+                click.echo(f'Error: must be between 1 and {len(account_names)}')
+                raise SystemExit(1)
+            sdk.accounts.assume_role(account_names[choice - 1])
+        else:
+            keychain.account = saved_account
+    except (KeyboardInterrupt, click.Abort, SystemExit):
+        raise SystemExit(0)
+    except Exception:
+        keychain.account = saved_account
 
 
 @click.group()
@@ -14,4 +54,8 @@ def chariot(click_context):
     proxy = click_context.obj['proxy']
 
     chariot = Chariot(keychain=keychain, proxy=proxy)
+
+    if not click_context.obj.get('explicit_account') and sys.stdin.isatty():
+        prompt_account_selection(chariot)
+
     click_context.obj = chariot

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 import praetorian_cli.handlers.add
@@ -14,7 +16,7 @@ import praetorian_cli.handlers.search
 import praetorian_cli.handlers.test
 import praetorian_cli.handlers.unlink
 import praetorian_cli.handlers.update
-from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.chariot import chariot, prompt_account_selection
 from praetorian_cli.handlers.configure import configure
 from praetorian_cli.sdk.keychain import Keychain
 
@@ -30,7 +32,7 @@ def main(click_context, profile, account, debug, proxy):
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
-    click_context.obj = {'keychain': Keychain(profile, account), 'proxy': proxy}
+    click_context.obj = {'keychain': Keychain(profile, account), 'proxy': proxy, 'explicit_account': account is not None}
     praetorian_cli.handlers.script.load_dynamic_commands()
 
 
@@ -51,7 +53,12 @@ def guard_main(click_context, profile, account, debug, proxy):
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
-    click_context.obj = Chariot(Keychain(profile, account), proxy=proxy)
+    sdk = Chariot(Keychain(profile, account), proxy=proxy)
+
+    if account is None and sys.stdin.isatty():
+        prompt_account_selection(sdk)
+
+    click_context.obj = sdk
     praetorian_cli.handlers.script.load_dynamic_commands()
 
 


### PR DESCRIPTION
## Summary
- When `--account` is not provided, the CLI now prompts users to select from their authorized accounts interactively
- Skipped for non-interactive usage (piped/scripted) via `sys.stdin.isatty()` check
- Supports `Ctrl+C` and typing `exit` to abort cleanly

## Test plan
- [ ] Run `praetorian chariot aegis` without `--account` — should show account picker
- [ ] Run `praetorian --account foo@bar.com chariot aegis` — should skip picker
- [ ] Run `guard aegis` without `--account` — should show account picker
- [ ] Type `exit` at the prompt — should exit cleanly
- [ ] Press `Ctrl+C` at the prompt — should exit cleanly
- [ ] Pipe input (e.g. `echo | praetorian chariot aegis`) — should skip picker