### PR TITLE
feat: add multi-account support to aegis CLI

### DIFF
--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -6,6 +6,7 @@ checks each account for aegis agents to build enriched account info.
 
 import logging
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -72,9 +73,11 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
             if not agents_data:
                 return None
 
+            online_count = _count_online_agents(agents_data)
             return _build_account_info(
                 account_email,
                 len(agents_data),
+                online_count,
                 metadata,
             )
         except Exception as e:
@@ -220,7 +223,23 @@ def _calculate_status(email: str, metadata: dict) -> str:
     return date_status
 
 
-def _build_account_info(email: str, agent_count: int, metadata: dict) -> dict:
+def _count_online_agents(agents_data: list) -> int:
+    """Count agents that are online (last_seen_at within 60 seconds)."""
+    now = time.time()
+    count = 0
+    for agent in agents_data:
+        last_seen = agent.get('last_seen_at')
+        if not last_seen:
+            continue
+        # Normalize microsecond timestamps to seconds
+        if last_seen > 1000000000000:
+            last_seen = last_seen / 1000000
+        if (now - last_seen) < 60:
+            count += 1
+    return count
+
+
+def _build_account_info(email: str, agent_count: int, online_count: int, metadata: dict) -> dict:
     """Build enriched account info from email and bulk metadata."""
     display_name = metadata['display_names'].get(email, '')
     if not display_name:
@@ -235,6 +254,7 @@ def _build_account_info(email: str, agent_count: int, metadata: dict) -> dict:
         'status': status,
         'account_type': account_type,
         'agent_count': agent_count,
+        'online_count': online_count,
     }
 
 
@@ -349,7 +369,7 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
 
 
 def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tuple]:
-    """Load schedules from multiple accounts concurrently.
+    """Load schedules from multiple accounts concurrently with retry.
 
     Args:
         sdk: Chariot SDK instance
@@ -361,7 +381,7 @@ def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tupl
     base_url = sdk.keychain.base_url()
     auth_headers = dict(sdk.keychain.headers())
 
-    def _load_one(acct):
+    def _load_one(acct, attempt=1):
         email = acct['account_email']
         try:
             headers = dict(auth_headers)
@@ -373,20 +393,38 @@ def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tupl
                 timeout=30,
             )
             if resp.status_code != 200:
-                logger.debug('Schedule load for %s returned status %d', email, resp.status_code)
-                return []
+                logger.debug('Schedule load for %s returned status %d (attempt %d)', email, resp.status_code, attempt)
+                return None  # Signal failure for retry
             data = resp.json()
             schedules = data.get('capabilityschedules', [])
             return [(sched, acct) for sched in schedules]
         except Exception as e:
-            logger.debug('Schedule load failed for %s: %s', email, e)
-            return []
+            logger.debug('Schedule load failed for %s: %s (attempt %d)', email, e, attempt)
+            return None
 
     results = []
+    retry_accounts = []
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = {executor.submit(_load_one, acct): acct for acct in selected_accounts}
         for future in as_completed(futures):
-            results.extend(future.result())
+            result = future.result()
+            if result is None:
+                retry_accounts.append(futures[future])
+            else:
+                results.extend(result)
+
+    # Retry failed accounts once
+    if retry_accounts:
+        logger.debug('Retrying schedule load for %d failed account(s)', len(retry_accounts))
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {executor.submit(_load_one, acct, 2): acct for acct in retry_accounts}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    results.extend(result)
+                else:
+                    acct = futures[future]
+                    logger.warning('Schedule load failed after retry for %s', acct['account_email'])
 
     return results
 

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -51,7 +51,7 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
     metadata = _fetch_all_metadata(base_url, auth_headers)
 
     results = []
-    checked = [0]
+    checked = 0
     lock = threading.Lock()
 
     # Sentinel to distinguish "no agents" from "probe failed"
@@ -59,6 +59,7 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
 
     def _check_account(account_email):
         """Check a single account for agents. Thread-safe."""
+        nonlocal checked
         try:
             headers = dict(auth_headers)
             headers['account'] = account_email
@@ -88,9 +89,9 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
             return _PROBE_FAILED
         finally:
             with lock:
-                checked[0] += 1
+                checked += 1
                 if on_progress:
-                    on_progress(checked[0], total, account_email)
+                    on_progress(checked, total, account_email)
 
     # Run agent checks concurrently (4 threads)
     with ThreadPoolExecutor(max_workers=4) as executor:
@@ -307,11 +308,12 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
     base_url = sdk.keychain.base_url()
     auth_headers = dict(sdk.keychain.headers())
     total = len(selected_accounts)
-    checked = [0]
+    checked = 0
     failed_accounts = []
     lock = threading.Lock()
 
     def _load_one(acct, attempt=1, track_progress=True):
+        nonlocal checked
         email = acct['account_email']
         try:
             headers = dict(auth_headers)
@@ -331,9 +333,9 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
         finally:
             if track_progress:
                 with lock:
-                    checked[0] += 1
+                    checked += 1
                     if on_progress:
-                        on_progress(checked[0], total, acct.get('display_name', email))
+                        on_progress(checked, total, acct.get('display_name', email))
 
     results = []
     retry_accounts = []

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -54,6 +54,9 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
     checked = [0]
     lock = threading.Lock()
 
+    # Sentinel to distinguish "no agents" from "probe failed"
+    _PROBE_FAILED = object()
+
     def _check_account(account_email):
         """Check a single account for agents. Thread-safe."""
         try:
@@ -67,11 +70,11 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
             )
             if resp.status_code != 200:
                 logger.debug('Agent check for %s returned status %d', account_email, resp.status_code)
-                return None
+                return _PROBE_FAILED
 
             agents_data = resp.json()
             if not agents_data:
-                return None
+                return None  # Genuinely empty — no agents
 
             online_count = _count_online_agents(agents_data)
             return _build_account_info(
@@ -82,7 +85,7 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
             )
         except Exception as e:
             logger.debug('Agent check failed for %s: %s', account_email, e)
-            return None
+            return _PROBE_FAILED
         finally:
             with lock:
                 checked[0] += 1
@@ -94,8 +97,9 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
         futures = {executor.submit(_check_account, email): email for email in sorted_accounts}
         for future in as_completed(futures):
             result = future.result()
-            if result:
-                results.append(result)
+            if result is _PROBE_FAILED or result is None:
+                continue  # Failed probe or genuinely empty
+            results.append(result)
 
     results.sort(key=lambda r: r['account_email'])
     return results
@@ -307,7 +311,7 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
     failed_accounts = []
     lock = threading.Lock()
 
-    def _load_one(acct, attempt=1):
+    def _load_one(acct, attempt=1, track_progress=True):
         email = acct['account_email']
         try:
             headers = dict(auth_headers)
@@ -325,10 +329,11 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
             logger.debug('Agent load failed for %s: %s (attempt %d)', email, e, attempt)
             return None
         finally:
-            with lock:
-                checked[0] += 1
-                if on_progress:
-                    on_progress(checked[0], total, acct.get('display_name', email))
+            if track_progress:
+                with lock:
+                    checked[0] += 1
+                    if on_progress:
+                        on_progress(checked[0], total, acct.get('display_name', email))
 
     results = []
     retry_accounts = []
@@ -341,11 +346,11 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
             else:
                 results.extend(result)
 
-    # Retry failed accounts once
+    # Retry failed accounts once (don't double-count progress)
     if retry_accounts:
         logger.debug('Retrying %d failed account(s)', len(retry_accounts))
         with ThreadPoolExecutor(max_workers=4) as executor:
-            futures = {executor.submit(_load_one, acct, 2): acct for acct in retry_accounts}
+            futures = {executor.submit(_load_one, acct, 2, False): acct for acct in retry_accounts}
             for future in as_completed(futures):
                 result = future.result()
                 if result is None:
@@ -368,7 +373,7 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
     return results, failed_accounts
 
 
-def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tuple]:
+def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> tuple:
     """Load schedules from multiple accounts concurrently with retry.
 
     Args:
@@ -376,10 +381,14 @@ def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tupl
         selected_accounts: List of account info dicts from discover_aegis_accounts
 
     Returns:
-        List of (schedule_dict, account_info) tuples.
+        Tuple of (schedule_tuples, failed_account_names) where schedule_tuples
+        is a list of (schedule_dict, account_info) tuples and failed_account_names
+        is a list of display names for accounts that failed after retry.
     """
     base_url = sdk.keychain.base_url()
     auth_headers = dict(sdk.keychain.headers())
+    failed_accounts = []
+    lock = threading.Lock()
 
     def _load_one(acct, attempt=1):
         email = acct['account_email']
@@ -424,9 +433,13 @@ def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tupl
                     results.extend(result)
                 else:
                     acct = futures[future]
-                    logger.warning('Schedule load failed after retry for %s', acct['account_email'])
+                    with lock:
+                        failed_accounts.append(acct.get('display_name', acct['account_email']))
 
-    return results
+    if failed_accounts:
+        logger.warning('Failed to load schedules for: %s', ', '.join(failed_accounts))
+
+    return results, failed_accounts
 
 
 def truncate_email(email: str, max_len: int = 16) -> str:

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional
 
 import requests
 
+from praetorian_cli.sdk.model.aegis import Agent
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,18 +123,21 @@ def _fetch_all_metadata(base_url: str, auth_headers: dict) -> dict:
     }
 
     def _get(params):
-        try:
-            resp = requests.get(
-                f'{base_url}/my',
-                headers=auth_headers,
-                params=params,
-                timeout=30,
-            )
-            if resp.status_code == 200:
-                return _flatten_response(resp.json())
-            logger.debug('Metadata fetch for %s returned status %d', params.get('key'), resp.status_code)
-        except Exception as e:
-            logger.debug('Metadata fetch failed for %s: %s', params.get('key'), e)
+        for attempt in range(2):
+            try:
+                resp = requests.get(
+                    f'{base_url}/my',
+                    headers=auth_headers,
+                    params=params,
+                    timeout=30,
+                )
+                if resp.status_code == 200:
+                    return _flatten_response(resp.json())
+                logger.debug('Metadata fetch for %s returned status %d (attempt %d)', params.get('key'), resp.status_code, attempt + 1)
+            except Exception as e:
+                logger.debug('Metadata fetch failed for %s: %s (attempt %d)', params.get('key'), e, attempt + 1)
+            if attempt == 0:
+                time.sleep(1)
         return []
 
     # Fetch all configurations: customer_type + subscription
@@ -279,17 +284,6 @@ def _friendly_name_from_email(email: str) -> str:
     return name.title() if name else email
 
 
-def _expand_status_code(code: str) -> str:
-    """Expand single-letter status codes to full names."""
-    mapping = {
-        'A': 'ACTIVE',
-        'C': 'COMPLETED',
-        'P': 'PAUSED',
-        'F': 'FROZEN',
-    }
-    return mapping.get(code, code.upper() if code else 'UNKNOWN')
-
-
 def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=None) -> List[tuple]:
     """Load agents from multiple accounts concurrently with retry.
 
@@ -303,8 +297,6 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
         a list of (Agent, account_info) tuples and failed_account_names is
         a list of display names for accounts that failed after retry.
     """
-    from praetorian_cli.sdk.entities.aegis import Agent
-
     base_url = sdk.keychain.base_url()
     auth_headers = dict(sdk.keychain.headers())
     total = len(selected_accounts)

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -1,0 +1,365 @@
+"""Account discovery with aegis agent filtering.
+
+Fetches account metadata in bulk via allTenants API calls, then concurrently
+checks each account for aegis agents to build enriched account info.
+"""
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
+    """Discover accounts that have aegis agents registered.
+
+    Fetches metadata (type, status, display name) in bulk, then concurrently
+    checks each authorized account for agents.
+
+    Args:
+        sdk: Chariot SDK instance
+        on_progress: Optional callback(checked: int, total: int, email: str)
+
+    Returns a list of dicts with keys:
+        account_email, display_name, status, account_type, agent_count
+    """
+    accounts, _ = sdk.accounts.list()
+    current = sdk.accounts.current_principal()
+
+    # Get unique authorized account emails (accounts we can assume into)
+    authorized = set()
+    for acct in accounts:
+        name = acct.get('name', '')
+        if name and name != current:
+            authorized.add(name)
+
+    sorted_accounts = sorted(authorized)
+    total = len(sorted_accounts)
+
+    # Pre-compute shared values
+    base_url = sdk.keychain.base_url()
+    auth_headers = dict(sdk.keychain.headers())
+
+    # Fetch all metadata in bulk (3 calls instead of N*2 per-account calls)
+    metadata = _fetch_all_metadata(base_url, auth_headers)
+
+    results = []
+    checked = [0]
+    lock = threading.Lock()
+
+    def _check_account(account_email):
+        """Check a single account for agents. Thread-safe."""
+        try:
+            headers = dict(auth_headers)
+            headers['account'] = account_email
+
+            resp = requests.get(
+                f'{base_url}/agent/enhanced',
+                headers=headers,
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                logger.debug('Agent check for %s returned status %d', account_email, resp.status_code)
+                return None
+
+            agents_data = resp.json()
+            if not agents_data:
+                return None
+
+            return _build_account_info(
+                account_email,
+                len(agents_data),
+                metadata,
+            )
+        except Exception as e:
+            logger.debug('Agent check failed for %s: %s', account_email, e)
+            return None
+        finally:
+            with lock:
+                checked[0] += 1
+                if on_progress:
+                    on_progress(checked[0], total, account_email)
+
+    # Run agent checks concurrently (4 threads)
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(_check_account, email): email for email in sorted_accounts}
+        for future in as_completed(futures):
+            result = future.result()
+            if result:
+                results.append(result)
+
+    results.sort(key=lambda r: r['account_email'])
+    return results
+
+
+def _fetch_all_metadata(base_url: str, auth_headers: dict) -> dict:
+    """Fetch customer type, subscription, frozen, and display name for all tenants.
+
+    Makes 2 bulk API calls with allTenants=true:
+      1. #configuration# — customer_type and subscription (dates for status calc)
+      2. #setting# — frozen flag and display-name
+    """
+    result = {
+        'types': {},
+        'subscriptions': {},
+        'frozen': {},
+        'display_names': {},
+    }
+
+    def _get(params):
+        try:
+            resp = requests.get(
+                f'{base_url}/my',
+                headers=auth_headers,
+                params=params,
+                timeout=30,
+            )
+            if resp.status_code == 200:
+                return _flatten_response(resp.json())
+            logger.debug('Metadata fetch for %s returned status %d', params.get('key'), resp.status_code)
+        except Exception as e:
+            logger.debug('Metadata fetch failed for %s: %s', params.get('key'), e)
+        return []
+
+    # Fetch all configurations: customer_type + subscription
+    for item in _get({'key': '#configuration#', 'allTenants': 'true'}):
+        email = _extract_email(item)
+        if not email:
+            continue
+        name = item.get('name', '')
+        if name == 'customer_type' and item.get('value'):
+            result['types'][email] = item['value']
+        elif name == 'subscription' and item.get('value'):
+            val = item['value']
+            if isinstance(val, dict):
+                result['subscriptions'][email] = val
+
+    # Fetch all settings: frozen + display-name
+    for item in _get({'key': '#setting#', 'allTenants': 'true'}):
+        email = _extract_email(item)
+        if not email:
+            continue
+        name = item.get('name', '')
+        if name == 'frozen':
+            result['frozen'][email] = (item.get('value') == 'true')
+        elif name == 'display-name' and item.get('value'):
+            result['display_names'][email] = item['value']
+
+    return result
+
+
+def _extract_email(item: dict) -> Optional[str]:
+    """Extract the tenant email from an allTenants API response item."""
+    email = item.get('username')
+    if email:
+        return email
+    # Fallback: parse from key like #configuration#customer_type#email@example.com
+    key = item.get('key', '')
+    parts = key.split('#')
+    for part in parts:
+        if '@' in part:
+            return part
+    return None
+
+
+def _flatten_response(data) -> List[dict]:
+    """Flatten a /my API response dict into a list of record dicts.
+
+    The /my endpoint returns {"someKey": [records...], "offset": ...}.
+    """
+    if isinstance(data, list):
+        return data
+    records = []
+    for value in data.values():
+        if isinstance(value, list):
+            records.extend(value)
+        elif isinstance(value, dict):
+            records.extend(_flatten_response(value))
+    return records
+
+
+def _calculate_status(email: str, metadata: dict) -> str:
+    """Calculate account status from subscription dates and frozen flag.
+
+    Mirrors the frontend useCustomerStatus logic.
+    """
+    is_frozen = metadata['frozen'].get(email, False)
+    subscription = metadata['subscriptions'].get(email, {})
+    customer_type = metadata['types'].get(email, '')
+    start_str = subscription.get('startDate')
+    end_str = subscription.get('endDate')
+
+    if not start_str or not end_str:
+        date_status = 'Setup'
+    else:
+        try:
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            start = datetime.fromisoformat(start_str.replace('Z', '+00:00')).replace(tzinfo=None)
+            end = datetime.fromisoformat(end_str.replace('Z', '+00:00')).replace(tzinfo=None)
+
+            if today > end and customer_type in ('PILOT', 'ENGAGEMENT'):
+                date_status = 'Completed'
+            elif today < start:
+                days_until = (start - today).days
+                date_status = 'Upcoming' if days_until <= 30 else 'Setup'
+            else:
+                date_status = 'Active'
+        except (ValueError, TypeError):
+            date_status = 'Active'
+
+    if date_status == 'Completed':
+        return 'Completed'
+    if is_frozen:
+        return 'Paused'
+    return date_status
+
+
+def _build_account_info(email: str, agent_count: int, metadata: dict) -> dict:
+    """Build enriched account info from email and bulk metadata."""
+    display_name = metadata['display_names'].get(email, '')
+    if not display_name:
+        display_name = _friendly_name_from_email(email)
+
+    status = _calculate_status(email, metadata)
+    account_type = metadata['types'].get(email, 'UNKNOWN')
+
+    return {
+        'account_email': email,
+        'display_name': display_name,
+        'status': status,
+        'account_type': account_type,
+        'agent_count': agent_count,
+    }
+
+
+def _friendly_name_from_email(email: str) -> str:
+    """Derive a friendly display name from an email address.
+
+    Handles chariot+name@praetorian.com pattern by extracting 'name'
+    and converting underscores/hyphens to spaces with title case.
+    """
+    local = email.split('@')[0] if '@' in email else email
+    # Strip chariot+ prefix
+    if local.startswith('chariot+'):
+        local = local[len('chariot+'):]
+    # Strip common suffixes like -v7n, dvl0.qtn005--clibuu etc.
+    # Clean up separators
+    name = local.replace('_', ' ').replace('-', ' ')
+    return name.title() if name else email
+
+
+def _expand_status_code(code: str) -> str:
+    """Expand single-letter status codes to full names."""
+    mapping = {
+        'A': 'ACTIVE',
+        'C': 'COMPLETED',
+        'P': 'PAUSED',
+        'F': 'FROZEN',
+    }
+    return mapping.get(code, code.upper() if code else 'UNKNOWN')
+
+
+def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=None) -> List[tuple]:
+    """Load agents from multiple accounts concurrently.
+
+    Args:
+        sdk: Chariot SDK instance
+        selected_accounts: List of account info dicts from discover_aegis_accounts
+        on_progress: Optional callback(checked: int, total: int, display_name: str)
+
+    Returns:
+        List of (Agent, account_info) tuples.
+    """
+    from praetorian_cli.sdk.entities.aegis import Agent
+
+    base_url = sdk.keychain.base_url()
+    auth_headers = dict(sdk.keychain.headers())
+    total = len(selected_accounts)
+    checked = [0]
+    lock = threading.Lock()
+
+    def _load_one(acct):
+        email = acct['account_email']
+        try:
+            headers = dict(auth_headers)
+            headers['account'] = email
+            resp = requests.get(
+                f'{base_url}/agent/enhanced',
+                headers=headers,
+                timeout=30,
+            )
+            if resp.status_code == 200:
+                return [(Agent.from_dict(d), acct) for d in resp.json()]
+            logger.debug('Agent load for %s returned status %d', email, resp.status_code)
+            return []
+        except Exception as e:
+            logger.debug('Agent load failed for %s: %s', email, e)
+            return []
+        finally:
+            with lock:
+                checked[0] += 1
+                if on_progress:
+                    on_progress(checked[0], total, acct.get('display_name', email))
+
+    results = []
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(_load_one, acct): acct for acct in selected_accounts}
+        for future in as_completed(futures):
+            results.extend(future.result())
+
+    return results
+
+
+def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tuple]:
+    """Load schedules from multiple accounts concurrently.
+
+    Args:
+        sdk: Chariot SDK instance
+        selected_accounts: List of account info dicts from discover_aegis_accounts
+
+    Returns:
+        List of (schedule_dict, account_info) tuples.
+    """
+    base_url = sdk.keychain.base_url()
+    auth_headers = dict(sdk.keychain.headers())
+
+    def _load_one(acct):
+        email = acct['account_email']
+        try:
+            headers = dict(auth_headers)
+            headers['account'] = email
+            resp = requests.get(
+                f'{base_url}/my',
+                headers=headers,
+                params={'key': '#capability_schedule#'},
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                logger.debug('Schedule load for %s returned status %d', email, resp.status_code)
+                return []
+            data = resp.json()
+            schedules = data.get('capabilityschedules', [])
+            return [(sched, acct) for sched in schedules]
+        except Exception as e:
+            logger.debug('Schedule load failed for %s: %s', email, e)
+            return []
+
+    results = []
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(_load_one, acct): acct for acct in selected_accounts}
+        for future in as_completed(futures):
+            results.extend(future.result())
+
+    return results
+
+
+def truncate_email(email: str, max_len: int = 16) -> str:
+    """Truncate email to max_len characters with '...' suffix if needed."""
+    if len(email) <= max_len:
+        return email
+    return email[:max_len - 3] + '...'

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -265,7 +265,7 @@ def _expand_status_code(code: str) -> str:
 
 
 def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=None) -> List[tuple]:
-    """Load agents from multiple accounts concurrently.
+    """Load agents from multiple accounts concurrently with retry.
 
     Args:
         sdk: Chariot SDK instance
@@ -273,7 +273,9 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
         on_progress: Optional callback(checked: int, total: int, display_name: str)
 
     Returns:
-        List of (Agent, account_info) tuples.
+        Tuple of (agent_tuples, failed_account_names) where agent_tuples is
+        a list of (Agent, account_info) tuples and failed_account_names is
+        a list of display names for accounts that failed after retry.
     """
     from praetorian_cli.sdk.entities.aegis import Agent
 
@@ -281,9 +283,10 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
     auth_headers = dict(sdk.keychain.headers())
     total = len(selected_accounts)
     checked = [0]
+    failed_accounts = []
     lock = threading.Lock()
 
-    def _load_one(acct):
+    def _load_one(acct, attempt=1):
         email = acct['account_email']
         try:
             headers = dict(auth_headers)
@@ -295,11 +298,11 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
             )
             if resp.status_code == 200:
                 return [(Agent.from_dict(d), acct) for d in resp.json()]
-            logger.debug('Agent load for %s returned status %d', email, resp.status_code)
-            return []
+            logger.debug('Agent load for %s returned status %d (attempt %d)', email, resp.status_code, attempt)
+            return None  # Signal failure (distinct from empty account)
         except Exception as e:
-            logger.debug('Agent load failed for %s: %s', email, e)
-            return []
+            logger.debug('Agent load failed for %s: %s (attempt %d)', email, e, attempt)
+            return None
         finally:
             with lock:
                 checked[0] += 1
@@ -307,12 +310,41 @@ def load_agents_for_accounts(sdk, selected_accounts: List[dict], on_progress=Non
                     on_progress(checked[0], total, acct.get('display_name', email))
 
     results = []
+    retry_accounts = []
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = {executor.submit(_load_one, acct): acct for acct in selected_accounts}
         for future in as_completed(futures):
-            results.extend(future.result())
+            result = future.result()
+            if result is None:
+                retry_accounts.append(futures[future])
+            else:
+                results.extend(result)
 
-    return results
+    # Retry failed accounts once
+    if retry_accounts:
+        logger.debug('Retrying %d failed account(s)', len(retry_accounts))
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = {executor.submit(_load_one, acct, 2): acct for acct in retry_accounts}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is None:
+                    acct = futures[future]
+                    with lock:
+                        failed_accounts.append(acct.get('display_name', acct['account_email']))
+                else:
+                    results.extend(result)
+
+    if failed_accounts:
+        logger.warning('Failed to load agents for: %s', ', '.join(failed_accounts))
+
+    # Sort deterministically by account name then hostname to avoid
+    # non-deterministic ordering from concurrent thread completion.
+    results.sort(key=lambda t: (
+        t[1].get('display_name', '').lower(),
+        t[0].hostname.lower() if t[0].hostname else '',
+    ))
+
+    return results, failed_accounts
 
 
 def load_schedules_for_accounts(sdk, selected_accounts: List[dict]) -> List[tuple]:

--- a/praetorian_cli/sdk/entities/account_discovery.py
+++ b/praetorian_cli/sdk/entities/account_discovery.py
@@ -29,7 +29,7 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
         account_email, display_name, status, account_type, agent_count
     """
     accounts, _ = sdk.accounts.list()
-    current = sdk.accounts.current_principal()
+    current = sdk.accounts.login_principal()
 
     # Get unique authorized account emails (accounts we can assume into)
     authorized = set()
@@ -44,6 +44,7 @@ def discover_aegis_accounts(sdk, on_progress=None) -> List[dict]:
     # Pre-compute shared values
     base_url = sdk.keychain.base_url()
     auth_headers = dict(sdk.keychain.headers())
+    auth_headers.pop('account', None)  # Ensure tenant-agnostic bulk fetch
 
     # Fetch all metadata in bulk (3 calls instead of N*2 per-account calls)
     metadata = _fetch_all_metadata(base_url, auth_headers)

--- a/praetorian_cli/sdk/test/ui/test_account_discovery.py
+++ b/praetorian_cli/sdk/test/ui/test_account_discovery.py
@@ -1,0 +1,358 @@
+"""Tests for account discovery with aegis agent filtering."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_sdk(accounts, agents_by_account=None):
+    """Build a mock SDK that returns given accounts and per-account agents."""
+    sdk = MagicMock()
+
+    sdk.accounts.list.return_value = (accounts, None)
+    sdk.accounts.current_principal.return_value = 'operator@praetorian.com'
+    sdk.accounts.login_principal.return_value = 'operator@praetorian.com'
+
+    agents_by_account = agents_by_account or {}
+
+    # For concurrent discovery: keychain.base_url() and keychain.headers()
+    sdk.keychain.base_url.return_value = 'https://api.example.com'
+    sdk.keychain.headers.return_value = {'Authorization': 'Bearer test-token'}
+
+    # Wire assume_role/unassume_role for load_agents/load_schedules (sequential paths)
+    sdk.keychain.account = None
+
+    def mock_assume_role(email):
+        sdk.keychain.account = email
+    sdk.accounts.assume_role.side_effect = mock_assume_role
+
+    def mock_unassume_role():
+        sdk.keychain.account = None
+    sdk.accounts.unassume_role.side_effect = mock_unassume_role
+
+    def mock_aegis_list():
+        current_account = sdk.keychain.account
+        agents = agents_by_account.get(current_account, [])
+        return (agents, None)
+
+    sdk.aegis.list.side_effect = mock_aegis_list
+    return sdk
+
+
+def _make_agent(hostname='host1'):
+    """Create a minimal mock Agent."""
+    agent = MagicMock()
+    agent.hostname = hostname
+    agent.client_id = f'C.{hostname}'
+    return agent
+
+
+def _account(name, member='operator@praetorian.com', config=None):
+    """Create an account dict matching Chariot entity shape."""
+    return {
+        'name': name,
+        'member': member,
+        'key': f'#account#{name}#{member}',
+        'status': 'A',
+        'dns': name,
+        'config': config or {},
+    }
+
+
+def _mock_requests_get(agents_by_account, metadata=None):
+    """Create a mock for requests.get that simulates API endpoints.
+
+    metadata keys: types, subscriptions, frozen, display_names
+    Each maps email -> value for allTenants bulk responses.
+    """
+    metadata = metadata or {}
+    types = metadata.get('types', {})
+    subscriptions = metadata.get('subscriptions', {})
+    frozen = metadata.get('frozen', {})
+    display_names = metadata.get('display_names', {})
+
+    def mock_get(url, headers=None, params=None, timeout=None):
+        account_email = (headers or {}).get('account', '')
+        resp = MagicMock()
+        params = params or {}
+
+        if '/agent/enhanced' in url:
+            agents = agents_by_account.get(account_email, [])
+            agent_dicts = [{'hostname': a.hostname, 'client_id': a.client_id} for a in agents]
+            resp.status_code = 200
+            resp.json.return_value = agent_dicts
+        elif '/my' in url and params.get('allTenants') == 'true':
+            key = params.get('key', '')
+            records = []
+            if '#configuration#' in key:
+                # Configurations: customer_type + subscription
+                for email, ctype in types.items():
+                    records.append({'username': email, 'name': 'customer_type', 'value': ctype})
+                for email, sub in subscriptions.items():
+                    records.append({'username': email, 'name': 'subscription', 'value': sub})
+            elif '#setting#' in key:
+                # Settings: frozen + display-name
+                for email, is_frozen in frozen.items():
+                    records.append({'username': email, 'name': 'frozen', 'value': 'true' if is_frozen else 'false'})
+                for email, dname in display_names.items():
+                    records.append({'username': email, 'name': 'display-name', 'value': dname})
+            resp.status_code = 200
+            resp.json.return_value = {'configurations': records}
+        else:
+            resp.status_code = 404
+            resp.json.return_value = {}
+
+        return resp
+    return mock_get
+
+
+class TestDiscoverAegisAccounts:
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_returns_only_accounts_with_agents(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [
+            _account('acme@praetorian.com'),
+            _account('empty@praetorian.com'),
+        ]
+        agents_map = {
+            'acme@praetorian.com': [_make_agent('server1')],
+            'empty@praetorian.com': [],  # no agents
+        }
+        metadata = {
+            'types': {'acme@praetorian.com': 'MANAGED', 'empty@praetorian.com': 'PILOT'},
+            'display_names': {'acme@praetorian.com': 'Acme Corp', 'empty@praetorian.com': 'Empty Inc'},
+        }
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
+        result = discover_aegis_accounts(sdk)
+
+        assert len(result) == 1
+        assert result[0]['account_email'] == 'acme@praetorian.com'
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_account_metadata_extraction(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [_account('client@praetorian.com')]
+        agents_map = {'client@praetorian.com': [_make_agent()]}
+        metadata = {
+            'types': {'client@praetorian.com': 'MANAGED'},
+            'display_names': {'client@praetorian.com': 'Cushman & Wakefield'},
+            'subscriptions': {'client@praetorian.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+        }
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
+        result = discover_aegis_accounts(sdk)
+
+        assert result[0]['display_name'] == 'Cushman & Wakefield'
+        assert result[0]['status'] == 'Active'
+        assert result[0]['account_type'] == 'MANAGED'
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_fallback_display_name_to_email(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [_account('noname@praetorian.com')]
+        agents_map = {'noname@praetorian.com': [_make_agent()]}
+        # No metadata — fallback to email-derived name
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, {})
+        result = discover_aegis_accounts(sdk)
+
+        assert result[0]['display_name'] == 'Noname'
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_concurrent_checks_all_accounts(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [_account('a@praetorian.com'), _account('b@praetorian.com')]
+        agents_map = {
+            'a@praetorian.com': [_make_agent()],
+            'b@praetorian.com': [],
+        }
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, {})
+        discover_aegis_accounts(sdk)
+
+        # Should have made bulk metadata calls + per-account agent checks
+        assert mock_requests.get.call_count >= 2
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_frozen_account_shows_paused(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [_account('frozen@praetorian.com')]
+        agents_map = {'frozen@praetorian.com': [_make_agent()]}
+        metadata = {
+            'types': {'frozen@praetorian.com': 'MANAGED'},
+            'subscriptions': {'frozen@praetorian.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'frozen': {'frozen@praetorian.com': True},
+        }
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
+        result = discover_aegis_accounts(sdk)
+
+        assert result[0]['status'] == 'Paused'
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_expired_pilot_shows_completed(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        accounts = [_account('pilot@praetorian.com')]
+        agents_map = {'pilot@praetorian.com': [_make_agent()]}
+        metadata = {
+            'types': {'pilot@praetorian.com': 'PILOT'},
+            'subscriptions': {'pilot@praetorian.com': {'startDate': '2023-01-01', 'endDate': '2023-06-30'}},
+        }
+        sdk = _make_sdk(accounts, agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
+        result = discover_aegis_accounts(sdk)
+
+        assert result[0]['status'] == 'Completed'
+
+
+class TestCalculateStatus:
+    def test_active_subscription(self):
+        from praetorian_cli.sdk.entities.account_discovery import _calculate_status
+        metadata = {
+            'types': {'a@b.com': 'MANAGED'},
+            'subscriptions': {'a@b.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'frozen': {},
+        }
+        assert _calculate_status('a@b.com', metadata) == 'Active'
+
+    def test_no_subscription_is_setup(self):
+        from praetorian_cli.sdk.entities.account_discovery import _calculate_status
+        metadata = {'types': {}, 'subscriptions': {}, 'frozen': {}}
+        assert _calculate_status('a@b.com', metadata) == 'Setup'
+
+    def test_frozen_overrides_active(self):
+        from praetorian_cli.sdk.entities.account_discovery import _calculate_status
+        metadata = {
+            'types': {'a@b.com': 'MANAGED'},
+            'subscriptions': {'a@b.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'frozen': {'a@b.com': True},
+        }
+        assert _calculate_status('a@b.com', metadata) == 'Paused'
+
+    def test_completed_not_overridden_by_frozen(self):
+        from praetorian_cli.sdk.entities.account_discovery import _calculate_status
+        metadata = {
+            'types': {'a@b.com': 'PILOT'},
+            'subscriptions': {'a@b.com': {'startDate': '2023-01-01', 'endDate': '2023-06-30'}},
+            'frozen': {'a@b.com': True},
+        }
+        assert _calculate_status('a@b.com', metadata) == 'Completed'
+
+
+class TestLoadAgentsForAccounts:
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_loads_agents_from_multiple_accounts(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import load_agents_for_accounts
+
+        agents_map = {
+            'acme@praetorian.com': [_make_agent('srv1'), _make_agent('srv2')],
+            'beta@praetorian.com': [_make_agent('srv3')],
+        }
+        sdk = _make_sdk([], agents_map)
+        mock_requests.get.side_effect = _mock_requests_get(agents_map, {})
+
+        selected = [
+            {'account_email': 'acme@praetorian.com', 'display_name': 'Acme', 'status': 'Active'},
+            {'account_email': 'beta@praetorian.com', 'display_name': 'Beta', 'status': 'Completed'},
+        ]
+        result = load_agents_for_accounts(sdk, selected)
+
+        assert len(result) == 3
+        # Results come from concurrent threads, sort for stable assertions
+        by_acct = sorted(result, key=lambda r: r[1]['display_name'])
+        assert by_acct[0][1]['display_name'] == 'Acme'
+        assert by_acct[2][1]['display_name'] == 'Beta'
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.requests')
+    def test_loads_schedules_from_multiple_accounts(self, mock_requests):
+        from praetorian_cli.sdk.entities.account_discovery import load_schedules_for_accounts
+
+        schedules_by_account = {
+            'acme@praetorian.com': [{'scheduleId': 's1', 'capabilityName': 'scan'}],
+            'beta@praetorian.com': [{'scheduleId': 's2', 'capabilityName': 'enum'}],
+        }
+
+        def mock_get(url, headers=None, params=None, timeout=None):
+            account_email = (headers or {}).get('account', '')
+            resp = MagicMock()
+            if '/my' in url and params and params.get('key') == '#capability_schedule#':
+                schedules = schedules_by_account.get(account_email, [])
+                resp.status_code = 200
+                resp.json.return_value = {'capabilityschedules': schedules}
+            else:
+                resp.status_code = 404
+                resp.json.return_value = {}
+            return resp
+
+        sdk = _make_sdk([])
+        mock_requests.get.side_effect = mock_get
+
+        selected = [
+            {'account_email': 'acme@praetorian.com', 'display_name': 'Acme', 'status': 'Active'},
+            {'account_email': 'beta@praetorian.com', 'display_name': 'Beta', 'status': 'Completed'},
+        ]
+        result = load_schedules_for_accounts(sdk, selected)
+
+        assert len(result) == 2
+        sched_ids = {r[0]['scheduleId'] for r in result}
+        assert sched_ids == {'s1', 's2'}
+
+
+class TestTruncateEmail:
+    def test_short_email_unchanged(self):
+        from praetorian_cli.sdk.entities.account_discovery import truncate_email
+        assert truncate_email('short@p.com', 16) == 'short@p.com'
+
+    def test_long_email_truncated(self):
+        from praetorian_cli.sdk.entities.account_discovery import truncate_email
+        result = truncate_email('chariot+cushwake@praetorian.com', 16)
+        assert len(result) == 16
+        assert result.endswith('...')
+
+
+class TestFriendlyNameFromEmail:
+    def test_chariot_plus_pattern(self):
+        from praetorian_cli.sdk.entities.account_discovery import _friendly_name_from_email
+        assert _friendly_name_from_email('chariot+cushwake@praetorian.com') == 'Cushwake'
+
+    def test_chariot_plus_underscores(self):
+        from praetorian_cli.sdk.entities.account_discovery import _friendly_name_from_email
+        result = _friendly_name_from_email('chariot+american_family_insurance@praetorian.com')
+        assert result == 'American Family Insurance'
+
+    def test_plain_email(self):
+        from praetorian_cli.sdk.entities.account_discovery import _friendly_name_from_email
+        assert _friendly_name_from_email('noname@praetorian.com') == 'Noname'
+
+
+class TestFlattenResponse:
+    def test_flattens_dict_of_lists(self):
+        from praetorian_cli.sdk.entities.account_discovery import _flatten_response
+        data = {'settings': [{'name': 'a'}, {'name': 'b'}], 'offset': []}
+        result = _flatten_response(data)
+        assert len(result) == 2
+        assert result[0]['name'] == 'a'
+
+    def test_passes_through_list(self):
+        from praetorian_cli.sdk.entities.account_discovery import _flatten_response
+        data = [{'name': 'a'}]
+        assert _flatten_response(data) == data
+
+
+class TestExtractEmail:
+    def test_from_username(self):
+        from praetorian_cli.sdk.entities.account_discovery import _extract_email
+        assert _extract_email({'username': 'foo@bar.com'}) == 'foo@bar.com'
+
+    def test_from_key(self):
+        from praetorian_cli.sdk.entities.account_discovery import _extract_email
+        assert _extract_email({'key': '#configuration#customer_type#foo@bar.com'}) == 'foo@bar.com'
+
+    def test_none_when_missing(self):
+        from praetorian_cli.sdk.entities.account_discovery import _extract_email
+        assert _extract_email({'key': '#configuration#customer_type'}) is None

--- a/praetorian_cli/sdk/test/ui/test_account_discovery.py
+++ b/praetorian_cli/sdk/test/ui/test_account_discovery.py
@@ -173,8 +173,13 @@ class TestDiscoverAegisAccounts:
         mock_requests.get.side_effect = _mock_requests_get(agents_map, {})
         discover_aegis_accounts(sdk)
 
-        # Should have made bulk metadata calls + per-account agent checks
-        assert mock_requests.get.call_count >= 2
+        # Verify per-account agent checks were made with correct account headers
+        checked_accounts = {
+            call.kwargs.get('headers', {}).get('account')
+            for call in mock_requests.get.call_args_list
+            if '/agent/enhanced' in call.args[0]
+        }
+        assert checked_accounts == {'a@praetorian.com', 'b@praetorian.com'}
 
     @patch('praetorian_cli.sdk.entities.account_discovery.requests')
     def test_frozen_account_shows_paused(self, mock_requests):

--- a/praetorian_cli/sdk/test/ui/test_account_discovery.py
+++ b/praetorian_cli/sdk/test/ui/test_account_discovery.py
@@ -260,13 +260,13 @@ class TestLoadAgentsForAccounts:
             {'account_email': 'acme@praetorian.com', 'display_name': 'Acme', 'status': 'Active'},
             {'account_email': 'beta@praetorian.com', 'display_name': 'Beta', 'status': 'Completed'},
         ]
-        result = load_agents_for_accounts(sdk, selected)
+        result, failed = load_agents_for_accounts(sdk, selected)
 
         assert len(result) == 3
-        # Results come from concurrent threads, sort for stable assertions
-        by_acct = sorted(result, key=lambda r: r[1]['display_name'])
-        assert by_acct[0][1]['display_name'] == 'Acme'
-        assert by_acct[2][1]['display_name'] == 'Beta'
+        assert failed == []
+        # Results are now sorted deterministically by account name, hostname
+        assert result[0][1]['display_name'] == 'Acme'
+        assert result[2][1]['display_name'] == 'Beta'
 
     @patch('praetorian_cli.sdk.entities.account_discovery.requests')
     def test_loads_schedules_from_multiple_accounts(self, mock_requests):

--- a/praetorian_cli/sdk/test/ui/test_account_discovery.py
+++ b/praetorian_cli/sdk/test/ui/test_account_discovery.py
@@ -1,6 +1,25 @@
 """Tests for account discovery with aegis agent filtering."""
 import pytest
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
+
+
+def _active_subscription():
+    """Build a subscription window that is always active relative to now."""
+    today = datetime.now().date()
+    return {
+        'startDate': (today - timedelta(days=30)).isoformat(),
+        'endDate': (today + timedelta(days=365)).isoformat(),
+    }
+
+
+def _expired_subscription():
+    """Build a subscription window that is always expired relative to now."""
+    today = datetime.now().date()
+    return {
+        'startDate': (today - timedelta(days=365)).isoformat(),
+        'endDate': (today - timedelta(days=30)).isoformat(),
+    }
 
 
 def _make_sdk(accounts, agents_by_account=None):
@@ -137,7 +156,7 @@ class TestDiscoverAegisAccounts:
         metadata = {
             'types': {'client@praetorian.com': 'MANAGED'},
             'display_names': {'client@praetorian.com': 'Cushman & Wakefield'},
-            'subscriptions': {'client@praetorian.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'subscriptions': {'client@praetorian.com': _active_subscription()},
         }
         sdk = _make_sdk(accounts, agents_map)
         mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
@@ -189,7 +208,7 @@ class TestDiscoverAegisAccounts:
         agents_map = {'frozen@praetorian.com': [_make_agent()]}
         metadata = {
             'types': {'frozen@praetorian.com': 'MANAGED'},
-            'subscriptions': {'frozen@praetorian.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'subscriptions': {'frozen@praetorian.com': _active_subscription()},
             'frozen': {'frozen@praetorian.com': True},
         }
         sdk = _make_sdk(accounts, agents_map)
@@ -206,7 +225,7 @@ class TestDiscoverAegisAccounts:
         agents_map = {'pilot@praetorian.com': [_make_agent()]}
         metadata = {
             'types': {'pilot@praetorian.com': 'PILOT'},
-            'subscriptions': {'pilot@praetorian.com': {'startDate': '2023-01-01', 'endDate': '2023-06-30'}},
+            'subscriptions': {'pilot@praetorian.com': _expired_subscription()},
         }
         sdk = _make_sdk(accounts, agents_map)
         mock_requests.get.side_effect = _mock_requests_get(agents_map, metadata)
@@ -220,7 +239,7 @@ class TestCalculateStatus:
         from praetorian_cli.sdk.entities.account_discovery import _calculate_status
         metadata = {
             'types': {'a@b.com': 'MANAGED'},
-            'subscriptions': {'a@b.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'subscriptions': {'a@b.com': _active_subscription()},
             'frozen': {},
         }
         assert _calculate_status('a@b.com', metadata) == 'Active'
@@ -234,7 +253,7 @@ class TestCalculateStatus:
         from praetorian_cli.sdk.entities.account_discovery import _calculate_status
         metadata = {
             'types': {'a@b.com': 'MANAGED'},
-            'subscriptions': {'a@b.com': {'startDate': '2024-01-01', 'endDate': '2027-12-31'}},
+            'subscriptions': {'a@b.com': _active_subscription()},
             'frozen': {'a@b.com': True},
         }
         assert _calculate_status('a@b.com', metadata) == 'Paused'
@@ -243,7 +262,7 @@ class TestCalculateStatus:
         from praetorian_cli.sdk.entities.account_discovery import _calculate_status
         metadata = {
             'types': {'a@b.com': 'PILOT'},
-            'subscriptions': {'a@b.com': {'startDate': '2023-01-01', 'endDate': '2023-06-30'}},
+            'subscriptions': {'a@b.com': _expired_subscription()},
             'frozen': {'a@b.com': True},
         }
         assert _calculate_status('a@b.com', metadata) == 'Completed'
@@ -301,9 +320,10 @@ class TestLoadAgentsForAccounts:
             {'account_email': 'acme@praetorian.com', 'display_name': 'Acme', 'status': 'Active'},
             {'account_email': 'beta@praetorian.com', 'display_name': 'Beta', 'status': 'Completed'},
         ]
-        result = load_schedules_for_accounts(sdk, selected)
+        result, failed = load_schedules_for_accounts(sdk, selected)
 
         assert len(result) == 2
+        assert failed == []
         sched_ids = {r[0]['scheduleId'] for r in result}
         assert sched_ids == {'s1', 's2'}
 

--- a/praetorian_cli/sdk/test/ui/test_account_selector.py
+++ b/praetorian_cli/sdk/test/ui/test_account_selector.py
@@ -106,16 +106,29 @@ class TestAccountSelector:
 
 
 class TestNoAccountDetection:
-    def test_keychain_account_none_triggers_multi_account(self):
+    @patch('praetorian_cli.sdk.entities.account_discovery.discover_aegis_accounts', return_value=[])
+    def test_keychain_account_none_triggers_multi_account(self, mock_discover):
+        from praetorian_cli.ui.aegis.menu import run_aegis_menu
+
         sdk = MagicMock()
         sdk.keychain.account = None
-        sdk.is_praetorian_user.return_value = True
 
-        assert sdk.keychain.account is None
-        assert sdk.is_praetorian_user()
+        run_aegis_menu(sdk)
 
-    def test_keychain_account_set_skips_multi_account(self):
+        mock_discover.assert_called_once()
+
+    @patch('praetorian_cli.sdk.entities.account_discovery.discover_aegis_accounts')
+    def test_keychain_account_set_skips_multi_account(self, mock_discover):
+        from praetorian_cli.ui.aegis.menu import run_aegis_menu
+
         sdk = MagicMock()
         sdk.keychain.account = 'client@praetorian.com'
 
-        assert sdk.keychain.account is not None
+        with patch('praetorian_cli.ui.aegis.menu.AegisMenu') as mock_menu_cls:
+            mock_menu_instance = MagicMock()
+            mock_menu_cls.return_value = mock_menu_instance
+            run_aegis_menu(sdk)
+
+        mock_discover.assert_not_called()
+        mock_menu_cls.assert_called_once_with(sdk)
+        mock_menu_instance.run.assert_called_once()

--- a/praetorian_cli/sdk/test/ui/test_account_selector.py
+++ b/praetorian_cli/sdk/test/ui/test_account_selector.py
@@ -1,0 +1,121 @@
+"""Tests for the multi-account selection UI."""
+import pytest
+from unittest.mock import MagicMock, patch
+from io import StringIO
+from rich.console import Console
+
+
+def _make_account_info(email, name='Test Corp', status='ACTIVE', acct_type='MANAGED', agent_count=3):
+    return {
+        'account_email': email,
+        'display_name': name,
+        'status': status,
+        'account_type': acct_type,
+        'agent_count': agent_count,
+    }
+
+
+class TestAccountSelector:
+    def test_render_table_has_correct_columns(self):
+        from praetorian_cli.ui.aegis.account_selector import AccountSelector
+        from praetorian_cli.ui.aegis.theme import AEGIS_COLORS
+
+        accounts = [
+            _make_account_info('acme@p.com', 'Acme Corp', 'ACTIVE', 'MANAGED'),
+            _make_account_info('beta@p.com', 'Beta Inc', 'COMPLETED', 'PILOT'),
+        ]
+        selector = AccountSelector(accounts, AEGIS_COLORS)
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+        table = selector.build_table()
+        console.print(table)
+        text = output.getvalue()
+
+        assert 'ACCOUNT' in text
+        assert 'ADDRESS' in text
+        assert 'STATUS' in text
+        assert 'TYPE' in text
+        assert 'AGENTS' in text
+
+    def test_special_rows_present(self):
+        from praetorian_cli.ui.aegis.account_selector import AccountSelector
+        from praetorian_cli.ui.aegis.theme import AEGIS_COLORS
+
+        accounts = [
+            _make_account_info('acme@p.com', 'Acme Corp', 'ACTIVE', 'MANAGED'),
+        ]
+        selector = AccountSelector(accounts, AEGIS_COLORS)
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+        table = selector.build_table()
+        console.print(table)
+        text = output.getvalue()
+
+        assert 'Select all active' in text
+        assert 'Select all' in text
+
+    def test_toggle_account(self):
+        from praetorian_cli.ui.aegis.account_selector import AccountSelector, SPECIAL_ROW_COUNT
+        from praetorian_cli.ui.aegis.theme import AEGIS_COLORS
+
+        accounts = [
+            _make_account_info('acme@p.com'),
+            _make_account_info('beta@p.com'),
+        ]
+        selector = AccountSelector(accounts, AEGIS_COLORS)
+
+        assert len(selector.selected_indices) == 0
+
+        # Toggle first real account (row index = SPECIAL_ROW_COUNT + 0)
+        selector.toggle(SPECIAL_ROW_COUNT)
+        assert 0 in selector.selected_indices
+
+        selector.toggle(SPECIAL_ROW_COUNT)
+        assert 0 not in selector.selected_indices
+
+    def test_select_all_active(self):
+        from praetorian_cli.ui.aegis.account_selector import AccountSelector
+        from praetorian_cli.ui.aegis.theme import AEGIS_COLORS
+
+        accounts = [
+            _make_account_info('acme@p.com', status='ACTIVE'),
+            _make_account_info('beta@p.com', status='COMPLETED'),
+            _make_account_info('gamma@p.com', status='ACTIVE'),
+        ]
+        selector = AccountSelector(accounts, AEGIS_COLORS)
+        selector.select_all_active()
+
+        selected = selector.get_selected_accounts()
+        assert len(selected) == 2
+        emails = {a['account_email'] for a in selected}
+        assert emails == {'acme@p.com', 'gamma@p.com'}
+
+    def test_select_all(self):
+        from praetorian_cli.ui.aegis.account_selector import AccountSelector
+        from praetorian_cli.ui.aegis.theme import AEGIS_COLORS
+
+        accounts = [
+            _make_account_info('acme@p.com', status='ACTIVE'),
+            _make_account_info('beta@p.com', status='COMPLETED'),
+        ]
+        selector = AccountSelector(accounts, AEGIS_COLORS)
+        selector.select_all()
+
+        selected = selector.get_selected_accounts()
+        assert len(selected) == 2
+
+
+class TestNoAccountDetection:
+    def test_keychain_account_none_triggers_multi_account(self):
+        sdk = MagicMock()
+        sdk.keychain.account = None
+        sdk.is_praetorian_user.return_value = True
+
+        assert sdk.keychain.account is None
+        assert sdk.is_praetorian_user()
+
+    def test_keychain_account_set_skips_multi_account(self):
+        sdk = MagicMock()
+        sdk.keychain.account = 'client@praetorian.com'
+
+        assert sdk.keychain.account is not None

--- a/praetorian_cli/sdk/test/ui/test_account_selector.py
+++ b/praetorian_cli/sdk/test/ui/test_account_selector.py
@@ -35,7 +35,8 @@ class TestAccountSelector:
         assert 'ADDRESS' in text
         assert 'STATUS' in text
         assert 'TYPE' in text
-        assert 'AGENTS' in text
+        assert 'ONLINE' in text
+        assert 'ALL' in text
 
     def test_special_rows_present(self):
         from praetorian_cli.ui.aegis.account_selector import AccountSelector

--- a/praetorian_cli/sdk/test/ui/test_aegis_list.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_list.py
@@ -31,6 +31,6 @@ def test_list_loads_when_empty():
 def test_list_with_all_flag():
     menu = Menu(agents=[object()])
     handle_list(menu, ['--all'])
-    assert menu.loaded is False
+    assert menu.loaded is True  # always reloads for fresh last_seen_at
     assert menu.show_args == [True]
     assert menu.paused is True

--- a/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
+++ b/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
@@ -117,7 +117,7 @@ class TestMultiAccountScheduleTable:
         menu.console = Console(file=output, force_terminal=True, width=200, theme=AEGIS_RICH_THEME)
 
         with patch('praetorian_cli.ui.aegis.commands.schedule.load_schedules_for_accounts') as mock_load:
-            mock_load.return_value = [
+            mock_load.return_value = ([
                 ({
                     'scheduleId': 's1',
                     'capabilityName': 'windows-smb-snaffler',
@@ -127,7 +127,7 @@ class TestMultiAccountScheduleTable:
                     'nextExecution': '',
                     'clientId': 'C.srv1',
                 }, menu.selected_accounts[0]),
-            ]
+            ], [])
             list_schedules(menu)
 
         text = output.getvalue()

--- a/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
+++ b/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
@@ -1,0 +1,135 @@
+"""Tests for multi-account agent and schedule table rendering."""
+import pytest
+from unittest.mock import MagicMock, patch
+from io import StringIO
+from rich.console import Console
+from praetorian_cli.ui.aegis.theme import AEGIS_RICH_THEME, AEGIS_COLORS
+
+
+def _make_agent(hostname='host1', client_id=None, is_online=True, has_tunnel=True, last_seen=None):
+    agent = MagicMock()
+    agent.hostname = hostname
+    agent.client_id = client_id or f'C.{hostname}'
+    agent.os = 'linux'
+    agent.os_version = '22.04'
+    agent.is_online = is_online
+    agent.has_tunnel = has_tunnel
+    agent.last_seen_at = last_seen or 1709000000
+    agent.network_interfaces = []
+    agent.health_check = MagicMock()
+    agent.health_check.cloudflared_status = MagicMock()
+    agent.health_check.cloudflared_status.hostname = 'tunnel.example.com' if has_tunnel else None
+    return agent
+
+
+def _make_account_info(email, name='Test Corp', status='ACTIVE'):
+    return {
+        'account_email': email,
+        'display_name': name,
+        'status': status,
+        'account_type': 'MANAGED',
+        'agent_count': 1,
+    }
+
+
+class TestMultiAccountAgentLoading:
+    def test_load_agents_multi_account_mode(self):
+        """In multi-account mode, load_agents should aggregate across accounts."""
+        from praetorian_cli.ui.aegis.menu import AegisMenu
+
+        sdk = MagicMock()
+        sdk.keychain.account = None
+        sdk.get_current_user.return_value = ('op@p.com', 'op')
+
+        menu = AegisMenu(sdk)
+        menu.multi_account_mode = True
+        menu.selected_accounts = [
+            _make_account_info('acme@p.com', 'Acme', 'ACTIVE'),
+            _make_account_info('beta@p.com', 'Beta', 'COMPLETED'),
+        ]
+
+        agent1 = _make_agent('srv1')
+        agent2 = _make_agent('srv2')
+        agent3 = _make_agent('srv3')
+
+        with patch('praetorian_cli.ui.aegis.menu.load_agents_for_accounts') as mock_load:
+            mock_load.return_value = [
+                (agent1, menu.selected_accounts[0]),
+                (agent2, menu.selected_accounts[0]),
+                (agent3, menu.selected_accounts[1]),
+            ]
+            menu.load_agents()
+
+        assert len(menu.agents) == 3
+        assert len(menu.agent_account_map) == 3
+        assert menu.agent_account_map[agent1.client_id]['status'] == 'ACTIVE'
+        assert menu.agent_account_map[agent3.client_id]['status'] == 'COMPLETED'
+
+
+class TestMultiAccountAgentTable:
+    def test_agent_table_has_account_columns(self):
+        """In multi-account mode, agent table should show ACCOUNT and ACCT STATUS columns."""
+        from praetorian_cli.ui.aegis.menu import AegisMenu
+
+        sdk = MagicMock()
+        sdk.keychain.account = None
+        sdk.get_current_user.return_value = ('op@p.com', 'op')
+
+        menu = AegisMenu(sdk)
+        menu.multi_account_mode = True
+        menu.selected_accounts = [
+            _make_account_info('chariot+cushwake@praetorian.com', 'Cushman & Wakefield', 'ACTIVE'),
+        ]
+
+        agent = _make_agent('dc01.internal')
+        menu.agents = [agent]
+        menu.displayed_agents = [agent]
+        menu.agent_account_map = {
+            agent.client_id: menu.selected_accounts[0],
+        }
+
+        output = StringIO()
+        menu.console = Console(file=output, force_terminal=True, width=150, theme=AEGIS_RICH_THEME)
+        menu.show_agents_list()
+        text = output.getvalue()
+
+        assert 'ACCOUNT' in text
+        assert 'ACCT STATUS' in text
+        assert 'dc01.internal' in text
+        # Display name truncated to 19 chars: "Cushman & Wakefie..."
+        assert 'Cushman & Wakefie' in text
+
+
+class TestMultiAccountScheduleTable:
+    def test_schedule_table_has_account_columns(self):
+        """In multi-account mode, schedule table should show account columns."""
+        from praetorian_cli.ui.aegis.commands.schedule import list_schedules
+
+        menu = MagicMock()
+        menu.multi_account_mode = True
+        menu.colors = AEGIS_COLORS
+        menu.selected_accounts = [
+            _make_account_info('acme@praetorian.com', 'Acme', 'ACTIVE'),
+        ]
+        menu.agent_lookup = {}
+
+        output = StringIO()
+        menu.console = Console(file=output, force_terminal=True, width=200, theme=AEGIS_RICH_THEME)
+
+        with patch('praetorian_cli.ui.aegis.commands.schedule.load_schedules_for_accounts') as mock_load:
+            mock_load.return_value = [
+                ({
+                    'scheduleId': 's1',
+                    'capabilityName': 'windows-smb-snaffler',
+                    'targetKey': '#asset#srv1#srv1',
+                    'status': 'active',
+                    'weeklySchedule': {},
+                    'nextExecution': '',
+                    'clientId': 'C.srv1',
+                }, menu.selected_accounts[0]),
+            ]
+            list_schedules(menu)
+
+        text = output.getvalue()
+        assert 'ACCOUNT' in text
+        assert 'ACCT STATUS' in text

--- a/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
+++ b/praetorian_cli/sdk/test/ui/test_multi_account_tables.py
@@ -53,11 +53,11 @@ class TestMultiAccountAgentLoading:
         agent3 = _make_agent('srv3')
 
         with patch('praetorian_cli.ui.aegis.menu.load_agents_for_accounts') as mock_load:
-            mock_load.return_value = [
+            mock_load.return_value = ([
                 (agent1, menu.selected_accounts[0]),
                 (agent2, menu.selected_accounts[0]),
                 (agent3, menu.selected_accounts[1]),
-            ]
+            ], [])
             menu.load_agents()
 
         assert len(menu.agents) == 3

--- a/praetorian_cli/ui/aegis/account_selector.py
+++ b/praetorian_cli/ui/aegis/account_selector.py
@@ -217,6 +217,9 @@ def run_account_selector(accounts: List[dict], colors: dict, console) -> List[di
         result_holder.clear()
         event.app.exit()
 
+    # Header lines before table rows (blank line + title + instructions + blank)
+    _HEADER_LINES = 4
+
     def _get_display_text():
         """Render the selector as ANSI text for prompt_toolkit."""
         output = StringIO()
@@ -233,10 +236,19 @@ def run_account_selector(accounts: List[dict], colors: dict, console) -> List[di
         render_console.print(table)
         render_console.print()
         selected_count = len(selector.selected_indices)
-        render_console.print(f"  [{colors['dim']}]{selected_count} account(s) selected — press ENTER to continue[/{colors['dim']}]")
+        if selected_count > 0:
+            render_console.print(f"  [{colors['dim']}]{selected_count} account(s) selected — press ENTER to continue[/{colors['dim']}]")
+        else:
+            render_console.print(f"  [{colors['dim']}]Select at least one account to continue[/{colors['dim']}]")
         return ANSI(output.getvalue())
 
-    layout = Layout(Window(content=FormattedTextControl(_get_display_text)))
+    def _get_cursor_position():
+        """Return cursor position so prompt_toolkit scrolls to the active row."""
+        from prompt_toolkit.data_structures import Point
+        # header lines + table header row + cursor row
+        return Point(x=0, y=_HEADER_LINES + 1 + selector.cursor)
+
+    layout = Layout(Window(content=FormattedTextControl(_get_display_text, get_cursor_position=_get_cursor_position)))
     app = Application(layout=layout, key_bindings=kb, full_screen=True)
     app.run()
 

--- a/praetorian_cli/ui/aegis/account_selector.py
+++ b/praetorian_cli/ui/aegis/account_selector.py
@@ -4,7 +4,6 @@ Renders a Rich table with checkbox column, account status, name, address, and ty
 First two rows are special: "Select all active" and "Select all regardless of status".
 """
 
-import os
 from typing import List, Set
 from rich.table import Table
 from rich.text import Text

--- a/praetorian_cli/ui/aegis/account_selector.py
+++ b/praetorian_cli/ui/aegis/account_selector.py
@@ -27,6 +27,7 @@ class AccountSelector:
         self.colors = colors
         self.selected_indices: Set[int] = set()  # indices into self.accounts
         self.cursor = 0  # current row in display (0-based, includes special rows)
+        self._active_indices: Set[int] = {i for i, a in enumerate(accounts) if a.get('status', '').upper() == 'ACTIVE'}
 
     def build_table(self) -> Table:
         """Build the Rich table for display."""
@@ -95,9 +96,7 @@ class AccountSelector:
         """Toggle selection for a display row. Handles special rows."""
         if display_row == ROW_SELECT_ALL_ACTIVE:
             if self._all_active_selected():
-                for i, acct in enumerate(self.accounts):
-                    if acct.get('status', '').upper() == 'ACTIVE':
-                        self.selected_indices.discard(i)
+                self.selected_indices -= self._active_indices
             else:
                 self.select_all_active()
         elif display_row == ROW_SELECT_ALL:
@@ -115,9 +114,7 @@ class AccountSelector:
 
     def select_all_active(self) -> None:
         """Select all accounts with ACTIVE status."""
-        for i, acct in enumerate(self.accounts):
-            if acct.get('status', '').upper() == 'ACTIVE':
-                self.selected_indices.add(i)
+        self.selected_indices.update(self._active_indices)
 
     def select_all(self) -> None:
         """Select all accounts regardless of status."""
@@ -132,8 +129,7 @@ class AccountSelector:
         return SPECIAL_ROW_COUNT + len(self.accounts)
 
     def _all_active_selected(self) -> bool:
-        active_indices = {i for i, a in enumerate(self.accounts) if a.get('status', '').upper() == 'ACTIVE'}
-        return bool(active_indices) and active_indices.issubset(self.selected_indices)
+        return bool(self._active_indices) and self._active_indices.issubset(self.selected_indices)
 
     def _all_selected(self) -> bool:
         return len(self.selected_indices) == len(self.accounts) and len(self.accounts) > 0

--- a/praetorian_cli/ui/aegis/account_selector.py
+++ b/praetorian_cli/ui/aegis/account_selector.py
@@ -45,7 +45,8 @@ class AccountSelector:
         table.add_column("ADDRESS", min_width=20, no_wrap=True)
         table.add_column("STATUS", width=10, no_wrap=True)
         table.add_column("TYPE", width=10, no_wrap=True)
-        table.add_column("AGENTS", width=6, justify="right", no_wrap=True)
+        table.add_column("ONLINE", width=6, justify="right", no_wrap=True)
+        table.add_column("ALL", width=6, justify="right", no_wrap=True)
 
         empty = Text("", style=self.colors['dim'])
 
@@ -55,7 +56,7 @@ class AccountSelector:
         table.add_row(
             Text(check_all, style=f"bold {self.colors['accent']}"),
             Text("Select all", style="bold white" if is_cursor_all else f"bold {self.colors['primary']}"),
-            empty, empty, empty, empty,
+            empty, empty, empty, empty, empty,
         )
 
         # Special row 2: Select all active
@@ -64,7 +65,7 @@ class AccountSelector:
         table.add_row(
             Text(check_all_active, style=f"bold {self.colors['accent']}"),
             Text("Select all active", style="bold white" if is_cursor_active else f"bold {self.colors['primary']}"),
-            empty, empty, empty, empty,
+            empty, empty, empty, empty, empty,
         )
 
         # Account rows
@@ -73,6 +74,8 @@ class AccountSelector:
             checkbox = self._checkbox_char(checked)
             is_cursor = (self.cursor == SPECIAL_ROW_COUNT + i)
             agent_count = str(acct.get('agent_count', 0))
+            online_count = acct.get('online_count', 0)
+            online_str = str(online_count)
             status = acct.get('status', 'UNKNOWN')
             acct_type = acct.get('account_type', 'UNKNOWN')
 
@@ -82,7 +85,8 @@ class AccountSelector:
                 Text(truncate_email(acct.get('account_email', ''), 19), style=self.colors['dim']),
                 Text(status, style=self._status_style(status)),
                 Text(acct_type, style=self.colors['dim']),
-                Text(agent_count, style=self.colors['success']),
+                Text(online_str, style=self.colors['success'] if online_count > 0 else self.colors['dim']),
+                Text(agent_count, style=self.colors['dim']),
             )
 
         return table

--- a/praetorian_cli/ui/aegis/account_selector.py
+++ b/praetorian_cli/ui/aegis/account_selector.py
@@ -1,0 +1,239 @@
+"""Interactive account selection table for multi-account aegis mode.
+
+Renders a Rich table with checkbox column, account status, name, address, and type.
+First two rows are special: "Select all active" and "Select all regardless of status".
+"""
+
+import os
+from typing import List, Set
+from rich.table import Table
+from rich.text import Text
+from rich.box import MINIMAL
+
+from praetorian_cli.sdk.entities.account_discovery import truncate_email
+
+
+# Row indices for special actions
+ROW_SELECT_ALL = 0
+ROW_SELECT_ALL_ACTIVE = 1
+SPECIAL_ROW_COUNT = 2
+
+
+class AccountSelector:
+    """Manages account selection state and table rendering."""
+
+    def __init__(self, accounts: List[dict], colors: dict):
+        self.accounts = accounts
+        self.colors = colors
+        self.selected_indices: Set[int] = set()  # indices into self.accounts
+        self.cursor = 0  # current row in display (0-based, includes special rows)
+
+    def build_table(self) -> Table:
+        """Build the Rich table for display."""
+        table = Table(
+            show_header=True,
+            header_style=f"{self.colors['dim']}",
+            border_style=self.colors['dim'],
+            box=MINIMAL,
+            show_lines=False,
+            padding=(0, 2),
+            pad_edge=False,
+        )
+
+        table.add_column("", width=3, no_wrap=True)           # checkbox
+        table.add_column("ACCOUNT", min_width=20, no_wrap=False)
+        table.add_column("ADDRESS", min_width=20, no_wrap=True)
+        table.add_column("STATUS", width=10, no_wrap=True)
+        table.add_column("TYPE", width=10, no_wrap=True)
+        table.add_column("AGENTS", width=6, justify="right", no_wrap=True)
+
+        empty = Text("", style=self.colors['dim'])
+
+        # Special row 1: Select all
+        check_all = self._checkbox_char(self._all_selected())
+        is_cursor_all = (self.cursor == ROW_SELECT_ALL)
+        table.add_row(
+            Text(check_all, style=f"bold {self.colors['accent']}"),
+            Text("Select all", style="bold white" if is_cursor_all else f"bold {self.colors['primary']}"),
+            empty, empty, empty, empty,
+        )
+
+        # Special row 2: Select all active
+        check_all_active = self._checkbox_char(self._all_active_selected())
+        is_cursor_active = (self.cursor == ROW_SELECT_ALL_ACTIVE)
+        table.add_row(
+            Text(check_all_active, style=f"bold {self.colors['accent']}"),
+            Text("Select all active", style="bold white" if is_cursor_active else f"bold {self.colors['primary']}"),
+            empty, empty, empty, empty,
+        )
+
+        # Account rows
+        for i, acct in enumerate(self.accounts):
+            checked = i in self.selected_indices
+            checkbox = self._checkbox_char(checked)
+            is_cursor = (self.cursor == SPECIAL_ROW_COUNT + i)
+            agent_count = str(acct.get('agent_count', 0))
+            status = acct.get('status', 'UNKNOWN')
+            acct_type = acct.get('account_type', 'UNKNOWN')
+
+            table.add_row(
+                Text(checkbox, style=f"{self.colors['accent']}" if checked else self.colors['dim']),
+                Text(acct.get('display_name', ''), style="bold white" if is_cursor else "white"),
+                Text(truncate_email(acct.get('account_email', ''), 19), style=self.colors['dim']),
+                Text(status, style=self._status_style(status)),
+                Text(acct_type, style=self.colors['dim']),
+                Text(agent_count, style=self.colors['success']),
+            )
+
+        return table
+
+    def toggle(self, display_row: int) -> None:
+        """Toggle selection for a display row. Handles special rows."""
+        if display_row == ROW_SELECT_ALL_ACTIVE:
+            if self._all_active_selected():
+                for i, acct in enumerate(self.accounts):
+                    if acct.get('status', '').upper() == 'ACTIVE':
+                        self.selected_indices.discard(i)
+            else:
+                self.select_all_active()
+        elif display_row == ROW_SELECT_ALL:
+            if self._all_selected():
+                self.selected_indices.clear()
+            else:
+                self.select_all()
+        else:
+            account_idx = display_row - SPECIAL_ROW_COUNT
+            if 0 <= account_idx < len(self.accounts):
+                if account_idx in self.selected_indices:
+                    self.selected_indices.discard(account_idx)
+                else:
+                    self.selected_indices.add(account_idx)
+
+    def select_all_active(self) -> None:
+        """Select all accounts with ACTIVE status."""
+        for i, acct in enumerate(self.accounts):
+            if acct.get('status', '').upper() == 'ACTIVE':
+                self.selected_indices.add(i)
+
+    def select_all(self) -> None:
+        """Select all accounts regardless of status."""
+        self.selected_indices = set(range(len(self.accounts)))
+
+    def get_selected_accounts(self) -> List[dict]:
+        """Return the list of selected account info dicts."""
+        return [self.accounts[i] for i in sorted(self.selected_indices)]
+
+    def total_rows(self) -> int:
+        """Total display rows including special rows."""
+        return SPECIAL_ROW_COUNT + len(self.accounts)
+
+    def _all_active_selected(self) -> bool:
+        active_indices = {i for i, a in enumerate(self.accounts) if a.get('status', '').upper() == 'ACTIVE'}
+        return bool(active_indices) and active_indices.issubset(self.selected_indices)
+
+    def _all_selected(self) -> bool:
+        return len(self.selected_indices) == len(self.accounts) and len(self.accounts) > 0
+
+    def _checkbox_char(self, checked: bool) -> str:
+        return "[x]" if checked else "[ ]"
+
+    def _status_style(self, status: str) -> str:
+        s = status.upper()
+        if s == 'ACTIVE':
+            return self.colors['success']
+        elif s == 'COMPLETED':
+            return self.colors['dim']
+        elif s == 'PAUSED':
+            return self.colors['warning']
+        return self.colors['dim']
+
+
+def run_account_selector(accounts: List[dict], colors: dict, console) -> List[dict]:
+    """Run the interactive account selector and return selected accounts.
+
+    Renders a table with arrow key navigation and spacebar toggling.
+    Enter confirms selection. 'q' or Escape cancels (returns []).
+
+    Uses prompt_toolkit Application for keyboard input (no readchar dependency).
+
+    Args:
+        accounts: List of account info dicts from discover_aegis_accounts
+        colors: Aegis color theme dict
+        console: Rich Console instance
+
+    Returns:
+        List of selected account info dicts, or [] if cancelled.
+    """
+    from io import StringIO
+    from prompt_toolkit import Application
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+
+    if not accounts:
+        console.print("  No accounts with aegis agents found.")
+        return []
+
+    selector = AccountSelector(accounts, colors)
+    selector.cursor = 0
+    result_holder = []  # mutable container for result from key handler
+
+    kb = KeyBindings()
+
+    @kb.add('up')
+    def _(event):
+        selector.cursor = max(0, selector.cursor - 1)
+
+    @kb.add('down')
+    def _(event):
+        selector.cursor = min(selector.total_rows() - 1, selector.cursor + 1)
+
+    @kb.add(' ')
+    def _(event):
+        selector.toggle(selector.cursor)
+
+    @kb.add('enter')
+    def _(event):
+        selected = selector.get_selected_accounts()
+        if selected:
+            result_holder.clear()
+            result_holder.extend(selected)
+            event.app.exit()
+
+    @kb.add('q')
+    @kb.add('escape')
+    def _(event):
+        result_holder.clear()
+        event.app.exit()
+
+    @kb.add('c-c')
+    def _(event):
+        result_holder.clear()
+        event.app.exit()
+
+    def _get_display_text():
+        """Render the selector as ANSI text for prompt_toolkit."""
+        output = StringIO()
+        from rich.console import Console as _Console
+        from rich.theme import Theme
+        from .theme import AEGIS_RICH_THEME
+        render_console = _Console(
+            file=output, force_terminal=True,
+            width=console.width, theme=AEGIS_RICH_THEME,
+        )
+        render_console.print(f"\n[bold {colors['primary']}]Aegis Multi-Account Selection[/bold {colors['primary']}]")
+        render_console.print(f"  [{colors['dim']}]↑/↓ navigate  SPACE toggle  ENTER confirm  q quit[/{colors['dim']}]\n")
+        table = selector.build_table()
+        render_console.print(table)
+        render_console.print()
+        selected_count = len(selector.selected_indices)
+        render_console.print(f"  [{colors['dim']}]{selected_count} account(s) selected — press ENTER to continue[/{colors['dim']}]")
+        return ANSI(output.getvalue())
+
+    layout = Layout(Window(content=FormattedTextControl(_get_display_text)))
+    app = Application(layout=layout, key_bindings=kb, full_screen=True)
+    app.run()
+
+    return result_holder

--- a/praetorian_cli/ui/aegis/commands/job.py
+++ b/praetorian_cli/ui/aegis/commands/job.py
@@ -134,7 +134,8 @@ def run_job(menu, args):
         menu.pause()
         return
 
-    target_type = capability_info.get('target', 'asset').lower()
+    target_raw = capability_info.get('target', 'asset')
+    target_type = (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
 
     # Create appropriate target key
     if target_type == 'addomain':

--- a/praetorian_cli/ui/aegis/commands/job.py
+++ b/praetorian_cli/ui/aegis/commands/job.py
@@ -11,6 +11,7 @@ from .job_helpers import (
     configure_parameters as _configure_parameters,
     capability_needs_credentials as _capability_needs_credentials,
     resolve_addomain_target_key,
+    extract_target_type,
 )
 
 
@@ -134,8 +135,7 @@ def run_job(menu, args):
         menu.pause()
         return
 
-    target_raw = capability_info.get('target', 'asset')
-    target_type = (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
+    target_type = extract_target_type(capability_info)
 
     # Create appropriate target key
     if target_type == 'addomain':

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -9,6 +9,16 @@ from ..constants import DEFAULT_COLORS
 
 
 # ---------------------------------------------------------------------------
+# Target type helpers
+# ---------------------------------------------------------------------------
+
+def extract_target_type(capability_info: dict) -> str:
+    """Extract the target type from capability info, handling list or string values."""
+    target_raw = capability_info.get('target', 'asset')
+    return (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
+
+
+# ---------------------------------------------------------------------------
 # Capability helpers
 # ---------------------------------------------------------------------------
 

--- a/praetorian_cli/ui/aegis/commands/list.py
+++ b/praetorian_cli/ui/aegis/commands/list.py
@@ -2,9 +2,7 @@ def handle_list(menu, args):
     """List agents with optional offline flag."""
     show_offline = '--all' in args or '-a' in args
 
-    if not menu.agents:
-        menu.load_agents()
-
+    menu.load_agents()
     menu.show_agents_list(show_offline=show_offline)
     menu.pause()
 

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -25,17 +25,22 @@ from .job_helpers import (
 
 
 def _assume_schedule_account(menu, schedule_id):
-    """In multi-account mode, assume into the account owning this schedule."""
+    """In multi-account mode, assume into the account owning this schedule.
+
+    Returns True if the tenant switch succeeded (or not in multi-account mode).
+    Returns False if the account could not be resolved or assumption failed.
+    """
     if not getattr(menu, 'multi_account_mode', False):
         return True
     acct_info = getattr(menu, 'schedule_account_map', {}).get(schedule_id, {})
     acct_email = acct_info.get('account_email')
-    if acct_email:
-        try:
-            menu.sdk.accounts.assume_role(acct_email)
-        except Exception:
-            return False
-    return True
+    if not acct_email:
+        return False
+    try:
+        menu.sdk.accounts.assume_role(acct_email)
+        return True
+    except Exception:
+        return False
 
 
 def handle_schedule(menu, args):
@@ -98,11 +103,13 @@ def list_schedules(menu):
 
     try:
         if multi_account and getattr(menu, 'selected_accounts', None):
-            schedule_tuples = load_schedules_for_accounts(menu.sdk, menu.selected_accounts)
+            schedule_tuples, failed = load_schedules_for_accounts(menu.sdk, menu.selected_accounts)
             schedules = [s for s, _ in schedule_tuples]
             menu.schedule_account_map = {}
             for sched, acct_info in schedule_tuples:
                 menu.schedule_account_map[sched.get('scheduleId', '')] = acct_info
+            if failed:
+                menu.console.print(f"[{colors['warning']}]Failed to load schedules for: {', '.join(failed)}[/{colors['warning']}]")
         else:
             schedules, _ = menu.sdk.schedules.list()
             menu.schedule_account_map = {}
@@ -227,7 +234,10 @@ def view_schedule(menu, args):
         menu.pause()
         return
 
-    _assume_schedule_account(menu, schedule_id)
+    if not _assume_schedule_account(menu, schedule_id):
+        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+        menu.pause()
+        return
 
     try:
         # Use cached agent lookup from menu
@@ -441,7 +451,10 @@ def edit_schedule(menu, args):
         menu.pause()
         return
 
-    _assume_schedule_account(menu, schedule_id)
+    if not _assume_schedule_account(menu, schedule_id):
+        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+        menu.pause()
+        return
 
     try:
         menu.console.print(f"\n  [bold {colors['primary']}]Edit Schedule: {schedule_id[:10]}[/]")
@@ -515,7 +528,10 @@ def delete_schedule(menu, args):
         menu.pause()
         return
 
-    _assume_schedule_account(menu, schedule_id)
+    if not _assume_schedule_account(menu, schedule_id):
+        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+        menu.pause()
+        return
 
     try:
         menu.console.print(f"\n  Schedule: {schedule_id[:10]}")
@@ -552,7 +568,10 @@ def pause_schedule(menu, args):
         menu.pause()
         return
 
-    _assume_schedule_account(menu, full_id)
+    if not _assume_schedule_account(menu, full_id):
+        menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+        menu.pause()
+        return
 
     try:
         result = menu.sdk.schedules.pause(full_id)
@@ -581,7 +600,10 @@ def resume_schedule(menu, args):
         menu.pause()
         return
 
-    _assume_schedule_account(menu, full_id)
+    if not _assume_schedule_account(menu, full_id):
+        menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+        menu.pause()
+        return
 
     try:
         result = menu.sdk.schedules.resume(full_id)

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -24,6 +24,20 @@ from .job_helpers import (
 )
 
 
+def _assume_schedule_account(menu, schedule_id):
+    """In multi-account mode, assume into the account owning this schedule."""
+    if not getattr(menu, 'multi_account_mode', False):
+        return True
+    acct_info = getattr(menu, 'schedule_account_map', {}).get(schedule_id, {})
+    acct_email = acct_info.get('account_email')
+    if acct_email:
+        try:
+            menu.sdk.accounts.assume_role(acct_email)
+        except Exception:
+            return False
+    return True
+
+
 def handle_schedule(menu, args):
     """Handle schedule command with subcommands: list, view, add, edit, delete, pause, resume."""
     if not args:
@@ -86,12 +100,12 @@ def list_schedules(menu):
         if multi_account and getattr(menu, 'selected_accounts', None):
             schedule_tuples = load_schedules_for_accounts(menu.sdk, menu.selected_accounts)
             schedules = [s for s, _ in schedule_tuples]
-            schedule_account_map = {}
+            menu.schedule_account_map = {}
             for sched, acct_info in schedule_tuples:
-                schedule_account_map[sched.get('scheduleId', '')] = acct_info
+                menu.schedule_account_map[sched.get('scheduleId', '')] = acct_info
         else:
             schedules, _ = menu.sdk.schedules.list()
-            schedule_account_map = {}
+            menu.schedule_account_map = {}
 
         if not schedules:
             menu.console.print("\n  No scheduled jobs found\n")
@@ -169,7 +183,7 @@ def list_schedules(menu):
 
             row_cells = []
             if multi_account:
-                acct_info = schedule_account_map.get(schedule.get('scheduleId', ''), {})
+                acct_info = menu.schedule_account_map.get(schedule.get('scheduleId', ''), {})
                 acct_name = truncate_email(acct_info.get('display_name', ''), 19)
                 acct_status = acct_info.get('status', '')
                 acct_status_style = colors['success'] if acct_status.upper() == 'ACTIVE' else colors['dim']
@@ -201,6 +215,8 @@ def view_schedule(menu, args):
             menu.console.print(f"\n  Schedule not found: {suggested_id}")
         menu.pause()
         return
+
+    _assume_schedule_account(menu, schedule_id)
 
     try:
         # Use cached agent lookup from menu
@@ -413,6 +429,8 @@ def edit_schedule(menu, args):
         menu.pause()
         return
 
+    _assume_schedule_account(menu, schedule_id)
+
     try:
         menu.console.print(f"\n  [bold {colors['primary']}]Edit Schedule: {schedule_id[:10]}[/]")
         menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
@@ -485,6 +503,8 @@ def delete_schedule(menu, args):
         menu.pause()
         return
 
+    _assume_schedule_account(menu, schedule_id)
+
     try:
         menu.console.print(f"\n  Schedule: {schedule_id[:10]}")
         menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
@@ -520,6 +540,8 @@ def pause_schedule(menu, args):
         menu.pause()
         return
 
+    _assume_schedule_account(menu, full_id)
+
     try:
         result = menu.sdk.schedules.pause(full_id)
         invalidate_schedule_cache(menu)
@@ -546,6 +568,8 @@ def resume_schedule(menu, args):
             menu.console.print(f"\n[{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
         menu.pause()
         return
+
+    _assume_schedule_account(menu, full_id)
 
     try:
         result = menu.sdk.schedules.resume(full_id)

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -2,9 +2,11 @@
 
 from datetime import datetime, timezone
 from rich.table import Table
+from rich.text import Text
 from rich.box import MINIMAL
 from rich.prompt import Prompt, Confirm
 from ..constants import DEFAULT_COLORS
+from praetorian_cli.sdk.entities.account_discovery import load_schedules_for_accounts, truncate_email
 from .schedule_helpers import (
     DAYS, DAY_ABBREVS,
     format_target, format_days, format_status,
@@ -76,10 +78,20 @@ def show_schedule_help(menu):
 
 
 def list_schedules(menu):
-    """List all schedules for the current user."""
+    """List all schedules for the current user (or all selected accounts in multi-account mode)."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    multi_account = getattr(menu, 'multi_account_mode', False)
+
     try:
-        schedules, _ = menu.sdk.schedules.list()
+        if multi_account and getattr(menu, 'selected_accounts', None):
+            schedule_tuples = load_schedules_for_accounts(menu.sdk, menu.selected_accounts)
+            schedules = [s for s, _ in schedule_tuples]
+            schedule_account_map = {}
+            for sched, acct_info in schedule_tuples:
+                schedule_account_map[sched.get('scheduleId', '')] = acct_info
+        else:
+            schedules, _ = menu.sdk.schedules.list()
+            schedule_account_map = {}
 
         if not schedules:
             menu.console.print("\n  No scheduled jobs found\n")
@@ -101,6 +113,10 @@ def list_schedules(menu):
             padding=(0, 2),
             pad_edge=False
         )
+
+        if multi_account:
+            table.add_column("ACCOUNT", style=f"{colors['dim']}", width=19, no_wrap=True)
+            table.add_column("ACCT STATUS", width=12, no_wrap=True)
 
         table.add_column("ID", style=f"bold {colors['accent']}", width=10, no_wrap=True)
         table.add_column("CAPABILITY", style="white", min_width=20, no_wrap=True)
@@ -151,7 +167,17 @@ def list_schedules(menu):
             # Format next execution
             next_display = format_next_execution(next_exec)
 
-            table.add_row(schedule_id, capability, agent_display, target_display, days_display, status_display, next_display)
+            row_cells = []
+            if multi_account:
+                acct_info = schedule_account_map.get(schedule.get('scheduleId', ''), {})
+                acct_name = truncate_email(acct_info.get('display_name', ''), 19)
+                acct_status = acct_info.get('status', '')
+                acct_status_style = colors['success'] if acct_status.upper() == 'ACTIVE' else colors['dim']
+                row_cells.append(Text(acct_name, style=colors['dim']))
+                row_cells.append(Text(acct_status, style=acct_status_style))
+
+            row_cells.extend([schedule_id, capability, agent_display, target_display, days_display, status_display, next_display])
+            table.add_row(*row_cells)
 
         menu.console.print(table)
         menu.console.print()

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -1,6 +1,7 @@
 """Schedule command handlers for Aegis TUI."""
 
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
@@ -28,25 +29,46 @@ from .job_helpers import (
 )
 
 
-def _assume_schedule_account(menu, schedule_id):
-    """In multi-account mode, assume into the account owning this schedule.
+@contextmanager
+def _schedule_account_context(menu, schedule_id):
+    """Context manager: assume into a schedule's account, restore on exit.
 
-    Returns True if the tenant switch succeeded (or not in multi-account mode).
-    Returns False if the account could not be resolved or assumption failed.
+    Yields True if the tenant switch succeeded (or not in multi-account mode).
+    Yields False if the account could not be resolved or assumption failed.
+    Always restores the prior account context in the finally block.
     """
     if not menu.multi_account_mode:
-        return True
+        yield True
+        return
+
+    previous_account = menu.sdk.keychain.account
     acct_info = getattr(menu, 'schedule_account_map', {}).get(schedule_id, {})
     acct_email = acct_info.get('account_email')
     if not acct_email:
         logger.warning('No account email found for schedule %s', schedule_id[:10])
-        return False
+        yield False
+        return
+
     try:
         menu.sdk.accounts.assume_role(acct_email)
-        return True
     except Exception as e:
         logger.error('Failed to assume role for %s: %s', acct_email, e)
-        return False
+        yield False
+        return
+
+    try:
+        yield True
+    finally:
+        if previous_account:
+            try:
+                menu.sdk.accounts.assume_role(previous_account)
+            except Exception as e:
+                logger.error('Failed to restore account %s: %s', previous_account, e)
+        else:
+            try:
+                menu.sdk.accounts.unassume_role()
+            except Exception as e:
+                logger.error('Failed to unassume role: %s', e)
 
 
 def handle_schedule(menu, args):
@@ -240,78 +262,79 @@ def view_schedule(menu, args):
         menu.pause()
         return
 
-    if not _assume_schedule_account(menu, schedule_id):
-        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
-        menu.pause()
-        return
+    with _schedule_account_context(menu, schedule_id) as switched:
+        if not switched:
+            menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+            menu.pause()
+            return
 
-    try:
-        # Use cached agent lookup from menu
-        agent_lookup = getattr(menu, 'agent_lookup', {})
+        try:
+            # Use cached agent lookup from menu
+            agent_lookup = getattr(menu, 'agent_lookup', {})
 
-        menu.console.print()
-        menu.console.print(f"  [bold {colors['primary']}]Schedule Details[/]")
-        menu.console.print()
-        menu.console.print(f"  ID:            {schedule.get('scheduleId', 'N/A')}")
-        menu.console.print(f"  Capability:    {schedule.get('capabilityName', 'N/A')}")
-        menu.console.print(f"  Target:        {schedule.get('targetKey', 'N/A')}")
-        menu.console.print(f"  Status:        {format_status(schedule.get('status', 'unknown'), colors)}")
-
-        # Show agent information
-        client_id = schedule.get('clientId', '')
-        if not client_id:
-            config = schedule.get('config', {})
-            client_id = config.get('client_id', '')
-
-        if client_id:
-            agent_hostname = agent_lookup.get(client_id, '')
-            if agent_hostname:
-                menu.console.print(f"  Agent:         [{colors['success']}]{agent_hostname}[/{colors['success']}]")
-                menu.console.print(f"  Client ID:     [{colors['dim']}]{client_id}[/{colors['dim']}]")
-            else:
-                menu.console.print(f"  Client ID:     {client_id}")
-
-        menu.console.print()
-        menu.console.print(f"  [bold {colors['primary']}]Schedule[/]")
-        weekly = schedule.get('weeklySchedule', {})
-        for day, abbrev in zip(DAYS, DAY_ABBREVS):
-            day_sched = weekly.get(day, {})
-            if day_sched.get('enabled'):
-                time_str = day_sched.get('time', 'N/A')
-                menu.console.print(f"    {abbrev}: [{colors['success']}]✓ {time_str} UTC[/{colors['success']}]")
-            else:
-                menu.console.print(f"    {abbrev}: [{colors['dim']}]—[/{colors['dim']}]")
-
-        menu.console.print()
-        menu.console.print(f"  [bold {colors['primary']}]Dates[/]")
-        menu.console.print(f"  Start:         {format_date(schedule.get('startDate', ''))}")
-        end_date = schedule.get('endDate', '')
-        menu.console.print(f"  End:           {format_date(end_date) if end_date else 'No end date'}")
-
-        menu.console.print()
-        menu.console.print(f"  [bold {colors['primary']}]Execution[/]")
-        next_exec = schedule.get('nextExecution', '')
-        last_exec = schedule.get('lastExecution', '')
-        menu.console.print(f"  Next:          {format_datetime(next_exec) if next_exec else 'Not scheduled'}")
-        menu.console.print(f"  Last:          {format_datetime(last_exec) if last_exec else 'Never'}")
-
-        # Show config if present
-        config = schedule.get('config', {})
-        if config:
             menu.console.print()
-            menu.console.print(f"  [bold {colors['primary']}]Configuration[/]")
-            for key, value in config.items():
-                # Hide sensitive values
-                if 'password' in key.lower() or 'secret' in key.lower():
-                    value = '********'
-                menu.console.print(f"    {key}: {value}")
+            menu.console.print(f"  [bold {colors['primary']}]Schedule Details[/]")
+            menu.console.print()
+            menu.console.print(f"  ID:            {schedule.get('scheduleId', 'N/A')}")
+            menu.console.print(f"  Capability:    {schedule.get('capabilityName', 'N/A')}")
+            menu.console.print(f"  Target:        {schedule.get('targetKey', 'N/A')}")
+            menu.console.print(f"  Status:        {format_status(schedule.get('status', 'unknown'), colors)}")
 
-        menu.console.print()
-        menu.pause()
+            # Show agent information
+            client_id = schedule.get('clientId', '')
+            if not client_id:
+                config = schedule.get('config', {})
+                client_id = config.get('client_id', '')
 
-    except Exception as e:
-        menu.console.print(f"[{colors['error']}]Error viewing schedule: {e}[/{colors['error']}]")
-        menu.pause()
+            if client_id:
+                agent_hostname = agent_lookup.get(client_id, '')
+                if agent_hostname:
+                    menu.console.print(f"  Agent:         [{colors['success']}]{agent_hostname}[/{colors['success']}]")
+                    menu.console.print(f"  Client ID:     [{colors['dim']}]{client_id}[/{colors['dim']}]")
+                else:
+                    menu.console.print(f"  Client ID:     {client_id}")
+
+            menu.console.print()
+            menu.console.print(f"  [bold {colors['primary']}]Schedule[/]")
+            weekly = schedule.get('weeklySchedule', {})
+            for day, abbrev in zip(DAYS, DAY_ABBREVS):
+                day_sched = weekly.get(day, {})
+                if day_sched.get('enabled'):
+                    time_str = day_sched.get('time', 'N/A')
+                    menu.console.print(f"    {abbrev}: [{colors['success']}]✓ {time_str} UTC[/{colors['success']}]")
+                else:
+                    menu.console.print(f"    {abbrev}: [{colors['dim']}]—[/{colors['dim']}]")
+
+            menu.console.print()
+            menu.console.print(f"  [bold {colors['primary']}]Dates[/]")
+            menu.console.print(f"  Start:         {format_date(schedule.get('startDate', ''))}")
+            end_date = schedule.get('endDate', '')
+            menu.console.print(f"  End:           {format_date(end_date) if end_date else 'No end date'}")
+
+            menu.console.print()
+            menu.console.print(f"  [bold {colors['primary']}]Execution[/]")
+            next_exec = schedule.get('nextExecution', '')
+            last_exec = schedule.get('lastExecution', '')
+            menu.console.print(f"  Next:          {format_datetime(next_exec) if next_exec else 'Not scheduled'}")
+            menu.console.print(f"  Last:          {format_datetime(last_exec) if last_exec else 'Never'}")
+
+            # Show config if present
+            config = schedule.get('config', {})
+            if config:
+                menu.console.print()
+                menu.console.print(f"  [bold {colors['primary']}]Configuration[/]")
+                for key, value in config.items():
+                    # Hide sensitive values
+                    if 'password' in key.lower() or 'secret' in key.lower():
+                        value = '********'
+                    menu.console.print(f"    {key}: {value}")
+
+            menu.console.print()
+            menu.pause()
+
+        except Exception as e:
+            menu.console.print(f"[{colors['error']}]Error viewing schedule: {e}[/{colors['error']}]")
+            menu.pause()
 
 
 def add_schedule(menu):
@@ -456,67 +479,68 @@ def edit_schedule(menu, args):
         menu.pause()
         return
 
-    if not _assume_schedule_account(menu, schedule_id):
-        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
-        menu.pause()
-        return
+    with _schedule_account_context(menu, schedule_id) as switched:
+        if not switched:
+            menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+            menu.pause()
+            return
 
-    try:
-        menu.console.print(f"\n  [bold {colors['primary']}]Edit Schedule: {schedule_id[:10]}[/]")
-        menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
-        menu.console.print()
+        try:
+            menu.console.print(f"\n  [bold {colors['primary']}]Edit Schedule: {schedule_id[:10]}[/]")
+            menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
+            menu.console.print()
 
-        # Edit weekly schedule
-        if Confirm.ask("  Edit weekly schedule?"):
-            weekly_schedule = configure_weekly_schedule(menu)
-            if not weekly_schedule:
-                menu.console.print("  Schedule edit cancelled\n")
+            # Edit weekly schedule
+            if Confirm.ask("  Edit weekly schedule?"):
+                weekly_schedule = configure_weekly_schedule(menu)
+                if not weekly_schedule:
+                    menu.console.print("  Schedule edit cancelled\n")
+                    menu.pause()
+                    return
+            else:
+                weekly_schedule = None
+
+            # Edit start date
+            current_start = schedule.get('startDate', '')
+            if Confirm.ask("  Edit start date?"):
+                start_date = Prompt.ask("  Start date (RFC3339)", default=current_start)
+            else:
+                start_date = None
+
+            # Edit end date
+            current_end = schedule.get('endDate', '')
+            if Confirm.ask("  Edit end date?"):
+                end_date = Prompt.ask("  End date (RFC3339, empty to remove)", default=current_end)
+            else:
+                end_date = None
+
+            # Confirm changes
+            if weekly_schedule is None and start_date is None and end_date is None:
+                menu.console.print("  No changes made.\n")
                 menu.pause()
                 return
-        else:
-            weekly_schedule = None
 
-        # Edit start date
-        current_start = schedule.get('startDate', '')
-        if Confirm.ask("  Edit start date?"):
-            start_date = Prompt.ask("  Start date (RFC3339)", default=current_start)
-        else:
-            start_date = None
+            if not Confirm.ask("\n  Save changes?"):
+                menu.console.print("  Cancelled\n")
+                menu.pause()
+                return
 
-        # Edit end date
-        current_end = schedule.get('endDate', '')
-        if Confirm.ask("  Edit end date?"):
-            end_date = Prompt.ask("  End date (RFC3339, empty to remove)", default=current_end)
-        else:
-            end_date = None
+            result = menu.sdk.schedules.update(
+                schedule_id=schedule_id,
+                weekly_schedule=weekly_schedule,
+                start_date=start_date,
+                end_date=end_date
+            )
 
-        # Confirm changes
-        if weekly_schedule is None and start_date is None and end_date is None:
-            menu.console.print("  No changes made.\n")
-            menu.pause()
-            return
+            invalidate_schedule_cache(menu)
+            menu.console.print(f"\n[{colors['success']}]✓ Schedule updated successfully[/{colors['success']}]")
+            menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
 
-        if not Confirm.ask("\n  Save changes?"):
-            menu.console.print("  Cancelled\n")
-            menu.pause()
-            return
+        except Exception as e:
+            menu.console.print(f"\n[{colors['error']}]Error updating schedule: {e}[/{colors['error']}]")
 
-        result = menu.sdk.schedules.update(
-            schedule_id=schedule_id,
-            weekly_schedule=weekly_schedule,
-            start_date=start_date,
-            end_date=end_date
-        )
-
-        invalidate_schedule_cache(menu)
-        menu.console.print(f"\n[{colors['success']}]✓ Schedule updated successfully[/{colors['success']}]")
-        menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
-
-    except Exception as e:
-        menu.console.print(f"\n[{colors['error']}]Error updating schedule: {e}[/{colors['error']}]")
-
-    menu.console.print()
-    menu.pause()
+        menu.console.print()
+        menu.pause()
 
 
 def delete_schedule(menu, args):
@@ -533,30 +557,31 @@ def delete_schedule(menu, args):
         menu.pause()
         return
 
-    if not _assume_schedule_account(menu, schedule_id):
-        menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
-        menu.pause()
-        return
-
-    try:
-        menu.console.print(f"\n  Schedule: {schedule_id[:10]}")
-        menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
-        menu.console.print(f"  Target: {format_target(schedule.get('targetKey', ''))}")
-
-        if not Confirm.ask(f"\n  [{colors['error']}]Delete this schedule?[/{colors['error']}]"):
-            menu.console.print("  Cancelled\n")
+    with _schedule_account_context(menu, schedule_id) as switched:
+        if not switched:
+            menu.console.print(f"\n  [{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
             menu.pause()
             return
 
-        menu.sdk.schedules.delete(schedule_id)
-        invalidate_schedule_cache(menu)
-        menu.console.print(f"\n[{colors['success']}]✓ Schedule deleted successfully[/{colors['success']}]")
+        try:
+            menu.console.print(f"\n  Schedule: {schedule_id[:10]}")
+            menu.console.print(f"  Capability: {schedule.get('capabilityName', 'N/A')}")
+            menu.console.print(f"  Target: {format_target(schedule.get('targetKey', ''))}")
 
-    except Exception as e:
-        menu.console.print(f"\n[{colors['error']}]Error deleting schedule: {e}[/{colors['error']}]")
+            if not Confirm.ask(f"\n  [{colors['error']}]Delete this schedule?[/{colors['error']}]"):
+                menu.console.print("  Cancelled\n")
+                menu.pause()
+                return
 
-    menu.console.print()
-    menu.pause()
+            menu.sdk.schedules.delete(schedule_id)
+            invalidate_schedule_cache(menu)
+            menu.console.print(f"\n[{colors['success']}]✓ Schedule deleted successfully[/{colors['success']}]")
+
+        except Exception as e:
+            menu.console.print(f"\n[{colors['error']}]Error deleting schedule: {e}[/{colors['error']}]")
+
+        menu.console.print()
+        menu.pause()
 
 
 def pause_schedule(menu, args):
@@ -573,22 +598,23 @@ def pause_schedule(menu, args):
         menu.pause()
         return
 
-    if not _assume_schedule_account(menu, full_id):
-        menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+    with _schedule_account_context(menu, full_id) as switched:
+        if not switched:
+            menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+            menu.pause()
+            return
+
+        try:
+            result = menu.sdk.schedules.pause(full_id)
+            invalidate_schedule_cache(menu)
+            menu.console.print(f"\n[{colors['success']}]✓ Schedule paused[/{colors['success']}]")
+            menu.console.print(f"  Status: {result.get('status', 'paused')}")
+
+        except Exception as e:
+            menu.console.print(f"\n[{colors['error']}]Error pausing schedule: {e}[/{colors['error']}]")
+
+        menu.console.print()
         menu.pause()
-        return
-
-    try:
-        result = menu.sdk.schedules.pause(full_id)
-        invalidate_schedule_cache(menu)
-        menu.console.print(f"\n[{colors['success']}]✓ Schedule paused[/{colors['success']}]")
-        menu.console.print(f"  Status: {result.get('status', 'paused')}")
-
-    except Exception as e:
-        menu.console.print(f"\n[{colors['error']}]Error pausing schedule: {e}[/{colors['error']}]")
-
-    menu.console.print()
-    menu.pause()
 
 
 def resume_schedule(menu, args):
@@ -605,23 +631,24 @@ def resume_schedule(menu, args):
         menu.pause()
         return
 
-    if not _assume_schedule_account(menu, full_id):
-        menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+    with _schedule_account_context(menu, full_id) as switched:
+        if not switched:
+            menu.console.print(f"\n[{colors['error']}]Could not switch to schedule's account.[/{colors['error']}]")
+            menu.pause()
+            return
+
+        try:
+            result = menu.sdk.schedules.resume(full_id)
+            invalidate_schedule_cache(menu)
+            menu.console.print(f"\n[{colors['success']}]✓ Schedule resumed[/{colors['success']}]")
+            menu.console.print(f"  Status: {result.get('status', 'active')}")
+            menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
+
+        except Exception as e:
+            menu.console.print(f"\n[{colors['error']}]Error resuming schedule: {e}[/{colors['error']}]")
+
+        menu.console.print()
         menu.pause()
-        return
-
-    try:
-        result = menu.sdk.schedules.resume(full_id)
-        invalidate_schedule_cache(menu)
-        menu.console.print(f"\n[{colors['success']}]✓ Schedule resumed[/{colors['success']}]")
-        menu.console.print(f"  Status: {result.get('status', 'active')}")
-        menu.console.print(f"  Next execution: {format_datetime(result.get('nextExecution', ''))}")
-
-    except Exception as e:
-        menu.console.print(f"\n[{colors['error']}]Error resuming schedule: {e}[/{colors['error']}]")
-
-    menu.console.print()
-    menu.pause()
 
 
 def complete(menu, text, tokens):

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -21,6 +21,7 @@ from .job_helpers import (
     configure_parameters,
     capability_needs_credentials,
     resolve_addomain_target_key,
+    extract_target_type,
 )
 
 
@@ -30,7 +31,7 @@ def _assume_schedule_account(menu, schedule_id):
     Returns True if the tenant switch succeeded (or not in multi-account mode).
     Returns False if the account could not be resolved or assumption failed.
     """
-    if not getattr(menu, 'multi_account_mode', False):
+    if not menu.multi_account_mode:
         return True
     acct_info = getattr(menu, 'schedule_account_map', {}).get(schedule_id, {})
     acct_email = acct_info.get('account_email')
@@ -98,11 +99,11 @@ def show_schedule_help(menu):
 
 def list_schedules(menu):
     """List all schedules for the current user (or all selected accounts in multi-account mode)."""
-    colors = getattr(menu, 'colors', DEFAULT_COLORS)
-    multi_account = getattr(menu, 'multi_account_mode', False)
+    colors = menu.colors
+    multi_account = menu.multi_account_mode
 
     try:
-        if multi_account and getattr(menu, 'selected_accounts', None):
+        if multi_account and menu.selected_accounts:
             schedule_tuples, failed = load_schedules_for_accounts(menu.sdk, menu.selected_accounts)
             schedules = [s for s, _ in schedule_tuples]
             menu.schedule_account_map = {}
@@ -170,7 +171,7 @@ def list_schedules(menu):
                 agent_display = agent_lookup[client_id]
             elif client_id:
                 # Show shortened client_id if no hostname found
-                agent_display = client_id[:15] + '...' if len(client_id) > 15 else client_id
+                agent_display = truncate_email(client_id, 15)
             else:
                 # Try to get from config
                 config = schedule.get('config', {})
@@ -178,7 +179,7 @@ def list_schedules(menu):
                 if client_id_from_config and client_id_from_config in agent_lookup:
                     agent_display = agent_lookup[client_id_from_config]
                 elif client_id_from_config:
-                    agent_display = client_id_from_config[:15] + '...' if len(client_id_from_config) > 15 else client_id_from_config
+                    agent_display = truncate_email(client_id_from_config, 15)
                 else:
                     agent_display = '—'
 
@@ -330,8 +331,7 @@ def add_schedule(menu):
         menu.pause()
         return
 
-    target_raw = capability_info.get('target', 'asset')
-    target_type = (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
+    target_type = extract_target_type(capability_info)
     hostname = menu.selected_agent.hostname or 'Unknown'
 
     # Create target key

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -1,6 +1,9 @@
 """Schedule command handlers for Aegis TUI."""
 
+import logging
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 from rich.table import Table
 from rich.text import Text
 from rich.box import MINIMAL
@@ -36,11 +39,13 @@ def _assume_schedule_account(menu, schedule_id):
     acct_info = getattr(menu, 'schedule_account_map', {}).get(schedule_id, {})
     acct_email = acct_info.get('account_email')
     if not acct_email:
+        logger.warning('No account email found for schedule %s', schedule_id[:10])
         return False
     try:
         menu.sdk.accounts.assume_role(acct_email)
         return True
-    except Exception:
+    except Exception as e:
+        logger.error('Failed to assume role for %s: %s', acct_email, e)
         return False
 
 

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -118,6 +118,11 @@ def list_schedules(menu):
 
         # Use cached agent lookup from menu (built when agents were loaded)
         agent_lookup = getattr(menu, 'agent_lookup', {})
+        # Build OS lookup from loaded agents
+        agent_os_lookup = {}
+        for agent in getattr(menu, 'agents', []):
+            if agent.client_id:
+                agent_os_lookup[agent.client_id] = agent.os
         table = Table(
             show_header=True,
             header_style=f"bold {colors['primary']}",
@@ -135,6 +140,7 @@ def list_schedules(menu):
         table.add_column("ID", style=f"bold {colors['accent']}", width=10, no_wrap=True)
         table.add_column("CAPABILITY", style="white", min_width=20, no_wrap=True)
         table.add_column("AGENT", style=f"{colors['success']}", min_width=15, no_wrap=True)
+        table.add_column("OS", style=f"{colors['dim']}", width=3, no_wrap=True)
         table.add_column("TARGET", style=f"{colors['dim']}", min_width=15, no_wrap=True)
         table.add_column("DAYS", style="white", width=21, no_wrap=True)
         table.add_column("STATUS", width=8, justify="center", no_wrap=True)
@@ -169,6 +175,11 @@ def list_schedules(menu):
                 else:
                     agent_display = '—'
 
+            # Resolve OS from agent
+            resolved_client_id = client_id or schedule.get('config', {}).get('client_id', '')
+            agent_os = agent_os_lookup.get(resolved_client_id, '').lower()
+            os_display = 'WIN' if 'windows' in agent_os else 'NIX' if agent_os else '—'
+
             # Format target display
             target_display = format_target(target_key)
 
@@ -190,7 +201,7 @@ def list_schedules(menu):
                 row_cells.append(Text(acct_name, style=colors['dim']))
                 row_cells.append(Text(acct_status, style=acct_status_style))
 
-            row_cells.extend([schedule_id, capability, agent_display, target_display, days_display, status_display, next_display])
+            row_cells.extend([schedule_id, capability, agent_display, os_display, target_display, days_display, status_display, next_display])
             table.add_row(*row_cells)
 
         menu.console.print(table)
@@ -309,7 +320,8 @@ def add_schedule(menu):
         menu.pause()
         return
 
-    target_type = capability_info.get('target', 'asset').lower()
+    target_raw = capability_info.get('target', 'asset')
+    target_type = (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
     hostname = menu.selected_agent.hostname or 'Unknown'
 
     # Create target key

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -4,7 +4,6 @@ import logging
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
-logger = logging.getLogger(__name__)
 from rich.table import Table
 from rich.text import Text
 from rich.box import MINIMAL
@@ -27,6 +26,8 @@ from .job_helpers import (
     resolve_addomain_target_key,
     extract_target_type,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -148,16 +149,10 @@ def list_schedules(menu):
             menu.pause()
             return
 
-        # Sort by next execution time
         schedules.sort(key=lambda s: s.get('nextExecution', '') or 'zzz')
 
-        # Use cached agent lookup from menu (built when agents were loaded)
         agent_lookup = getattr(menu, 'agent_lookup', {})
-        # Build OS lookup from loaded agents
-        agent_os_lookup = {}
-        for agent in getattr(menu, 'agents', []):
-            if agent.client_id:
-                agent_os_lookup[agent.client_id] = agent.os
+        agent_os_lookup = getattr(menu, 'agent_os_lookup', {})
         table = Table(
             show_header=True,
             header_style=f"bold {colors['primary']}",
@@ -193,14 +188,11 @@ def list_schedules(menu):
             next_exec = schedule.get('nextExecution', '')
             client_id = schedule.get('clientId', '')
 
-            # Get agent hostname from lookup, fall back to client_id or config
             if client_id and client_id in agent_lookup:
                 agent_display = agent_lookup[client_id]
             elif client_id:
-                # Show shortened client_id if no hostname found
                 agent_display = truncate_email(client_id, 15)
             else:
-                # Try to get from config
                 config = schedule.get('config', {})
                 client_id_from_config = config.get('client_id', '')
                 if client_id_from_config and client_id_from_config in agent_lookup:
@@ -210,21 +202,13 @@ def list_schedules(menu):
                 else:
                     agent_display = '—'
 
-            # Resolve OS from agent
             resolved_client_id = client_id or schedule.get('config', {}).get('client_id', '')
             agent_os = agent_os_lookup.get(resolved_client_id, '').lower()
             os_display = 'WIN' if 'windows' in agent_os else 'NIX' if agent_os else '—'
 
-            # Format target display
             target_display = format_target(target_key)
-
-            # Format days display
             days_display = format_days(schedule.get('weeklySchedule', {}))
-
-            # Format status with color
             status_display = format_status(status, colors)
-
-            # Format next execution
             next_display = format_next_execution(next_exec)
 
             row_cells = []
@@ -252,13 +236,12 @@ def view_schedule(menu, args):
     """View detailed information about a schedule."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
 
-    # Use interactive picker if no ID provided, otherwise validate the provided one
     suggested_id = args[0] if args else None
     schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule view")
 
     if not schedule:
         if suggested_id:
-            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+            menu.console.print(f"\n  [{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
         menu.pause()
         return
 
@@ -469,13 +452,12 @@ def edit_schedule(menu, args):
     """Edit an existing schedule."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
 
-    # Use interactive picker if no ID provided, otherwise validate the provided one
     suggested_id = args[0] if args else None
     schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule edit")
 
     if not schedule:
         if suggested_id:
-            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+            menu.console.print(f"\n  [{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
         menu.pause()
         return
 
@@ -547,13 +529,12 @@ def delete_schedule(menu, args):
     """Delete a schedule."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
 
-    # Use interactive picker if no ID provided, otherwise validate the provided one
     suggested_id = args[0] if args else None
     schedule, schedule_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule delete")
 
     if not schedule:
         if suggested_id:
-            menu.console.print(f"\n  Schedule not found: {suggested_id}")
+            menu.console.print(f"\n  [{colors['error']}]Schedule not found: {suggested_id}[/{colors['error']}]")
         menu.pause()
         return
 
@@ -588,7 +569,6 @@ def pause_schedule(menu, args):
     """Pause a schedule."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
 
-    # Use interactive picker if no ID provided, otherwise validate the provided one
     suggested_id = args[0] if args else None
     schedule, full_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule pause")
 
@@ -621,7 +601,6 @@ def resume_schedule(menu, args):
     """Resume a paused schedule."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
 
-    # Use interactive picker if no ID provided, otherwise validate the provided one
     suggested_id = args[0] if args else None
     schedule, full_id = interactive_schedule_picker(menu, suggested_id, prompt_prefix="schedule resume")
 

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -20,7 +20,7 @@ def handle_set(menu, args):
         # In multi-account mode, assume into the agent's account so SDK
         # calls (asset search, domain lookup, etc.) target the right tenant.
         # Must succeed before we commit to the selection.
-        if getattr(menu, 'multi_account_mode', False):
+        if menu.multi_account_mode:
             # Prefer account info attached directly to agent (avoids client_id collisions)
             acct_info = getattr(selected_agent, '_account_info', None) or menu.agent_account_map.get(selected_agent.client_id, {})
             acct_email = acct_info.get('account_email') if acct_info else None

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -21,8 +21,9 @@ def handle_set(menu, args):
         # calls (asset search, domain lookup, etc.) target the right tenant.
         # Must succeed before we commit to the selection.
         if getattr(menu, 'multi_account_mode', False):
-            acct_info = menu.agent_account_map.get(selected_agent.client_id, {})
-            acct_email = acct_info.get('account_email')
+            # Prefer account info attached directly to agent (avoids client_id collisions)
+            acct_info = getattr(selected_agent, '_account_info', None) or menu.agent_account_map.get(selected_agent.client_id, {})
+            acct_email = acct_info.get('account_email') if acct_info else None
             if not acct_email:
                 menu.console.print(f"[{colors['error']}]  Could not resolve an account for {hostname}.[/{colors['error']}]")
                 menu.pause()

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -1,5 +1,8 @@
+import logging
 from ..utils import parse_agent_identifier
 from ..constants import DEFAULT_COLORS
+
+logger = logging.getLogger(__name__)
 
 
 def handle_set(menu, args):
@@ -25,12 +28,14 @@ def handle_set(menu, args):
             acct_info = getattr(selected_agent, '_account_info', None) or menu.agent_account_map.get(selected_agent.client_id, {})
             acct_email = acct_info.get('account_email') if acct_info else None
             if not acct_email:
+                logger.warning('No account email resolved for agent %s (client_id=%s)', hostname, selected_agent.client_id)
                 menu.console.print(f"[{colors['error']}]  Could not resolve an account for {hostname}.[/{colors['error']}]")
                 menu.pause()
                 return
             try:
                 menu.sdk.accounts.assume_role(acct_email)
             except Exception as e:
+                logger.error('Failed to assume role for %s: %s', acct_email, e)
                 menu.console.print(f"[{colors['error']}]  Failed to assume account {acct_email}: {e}[/{colors['error']}]")
                 menu.pause()
                 return

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -17,6 +17,18 @@ def handle_set(menu, args):
     if selected_agent:
         menu.selected_agent = selected_agent
         hostname = selected_agent.hostname
+
+        # In multi-account mode, assume into the agent's account so SDK
+        # calls (asset search, domain lookup, etc.) target the right tenant.
+        if getattr(menu, 'multi_account_mode', False):
+            acct_info = menu.agent_account_map.get(selected_agent.client_id, {})
+            acct_email = acct_info.get('account_email')
+            if acct_email:
+                try:
+                    menu.sdk.accounts.assume_role(acct_email)
+                except Exception as e:
+                    menu.console.print(f"[{colors['warning']}]  Warning: failed to assume account {acct_email}: {e}[/{colors['warning']}]")
+
         menu.console.print(f"\n  Selected: {hostname}\n")
         # Pre-fetch home directory listing so cp tab-completion is instant
         if hasattr(menu, 'prefetch_agent_home'):

--- a/praetorian_cli/ui/aegis/commands/set.py
+++ b/praetorian_cli/ui/aegis/commands/set.py
@@ -15,20 +15,26 @@ def handle_set(menu, args):
     selected_agent = parse_agent_identifier(selection, menu.displayed_agents, menu.agents)
 
     if selected_agent:
-        menu.selected_agent = selected_agent
         hostname = selected_agent.hostname
 
         # In multi-account mode, assume into the agent's account so SDK
         # calls (asset search, domain lookup, etc.) target the right tenant.
+        # Must succeed before we commit to the selection.
         if getattr(menu, 'multi_account_mode', False):
             acct_info = menu.agent_account_map.get(selected_agent.client_id, {})
             acct_email = acct_info.get('account_email')
-            if acct_email:
-                try:
-                    menu.sdk.accounts.assume_role(acct_email)
-                except Exception as e:
-                    menu.console.print(f"[{colors['warning']}]  Warning: failed to assume account {acct_email}: {e}[/{colors['warning']}]")
+            if not acct_email:
+                menu.console.print(f"[{colors['error']}]  Could not resolve an account for {hostname}.[/{colors['error']}]")
+                menu.pause()
+                return
+            try:
+                menu.sdk.accounts.assume_role(acct_email)
+            except Exception as e:
+                menu.console.print(f"[{colors['error']}]  Failed to assume account {acct_email}: {e}[/{colors['error']}]")
+                menu.pause()
+                return
 
+        menu.selected_agent = selected_agent
         menu.console.print(f"\n  Selected: {hostname}\n")
         # Pre-fetch home directory listing so cp tab-completion is instant
         if hasattr(menu, 'prefetch_agent_home'):

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -702,7 +702,10 @@ class AegisMenu:
                     self.agent_account_map = {}
                     for agent, acct_info in agent_tuples:
                         self.agents.append(agent)
-                        self.agent_account_map[agent.client_id] = acct_info
+                        # Attach account info directly to agent to avoid client_id collisions
+                        agent._account_info = acct_info
+                        if agent.client_id and agent.client_id != 'N/A':
+                            self.agent_account_map[agent.client_id] = acct_info
                 finally:
                     status.stop()
 

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -701,13 +701,16 @@ class AegisMenu:
                     self.agents = []
                     self.agent_account_map = {}
                     self.agent_lookup = {}
+                    self.agent_os_lookup = {}
                     for agent, acct_info in agent_tuples:
                         self.agents.append(agent)
                         agent._account_info = acct_info
                         if agent.client_id and agent.client_id != 'N/A':
                             self.agent_account_map[agent.client_id] = acct_info
-                        if agent.client_id and agent.hostname:
-                            self.agent_lookup[agent.client_id] = agent.hostname
+                        if agent.client_id:
+                            self.agent_os_lookup[agent.client_id] = agent.os
+                            if agent.hostname:
+                                self.agent_lookup[agent.client_id] = agent.hostname
                 finally:
                     status.stop()
 
@@ -724,9 +727,12 @@ class AegisMenu:
                     self.agent_account_map = {}
 
                 self.agent_lookup = {}
+                self.agent_os_lookup = {}
                 for agent in self.agents:
-                    if agent.client_id and agent.hostname:
-                        self.agent_lookup[agent.client_id] = agent.hostname
+                    if agent.client_id:
+                        self.agent_os_lookup[agent.client_id] = agent.os
+                        if agent.hostname:
+                            self.agent_lookup[agent.client_id] = agent.hostname
 
             if self.verbose or not self.agents:
                 agent_count = len(self.agents)
@@ -739,6 +745,7 @@ class AegisMenu:
             self.console.print(f"[{self.colors['error']}]✗ Error loading agents: {e}[/{self.colors['error']}]")
             self.agents = []
             self.agent_lookup = {}
+            self.agent_os_lookup = {}
             self.agent_account_map = {}
     
     def pause(self):

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -697,7 +697,7 @@ class AegisMenu:
                     )
 
                 try:
-                    agent_tuples = load_agents_for_accounts(self.sdk, self.selected_accounts, on_progress=_on_progress)
+                    agent_tuples, failed = load_agents_for_accounts(self.sdk, self.selected_accounts, on_progress=_on_progress)
                     self.agents = []
                     self.agent_account_map = {}
                     for agent, acct_info in agent_tuples:
@@ -705,6 +705,9 @@ class AegisMenu:
                         self.agent_account_map[agent.client_id] = acct_info
                 finally:
                     status.stop()
+
+                if failed:
+                    self.console.print(f"[{self.colors['warning']}]Failed to load agents for: {', '.join(failed)}[/{self.colors['warning']}]")
             else:
                 with self.console.status(
                     f"[{self.colors['dim']}]Loading agents...[/{self.colors['dim']}]",

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -28,8 +28,9 @@ from prompt_toolkit.history import InMemoryHistory
 
 from praetorian_cli.sdk.chariot import Chariot
 from praetorian_cli.sdk.model.aegis import Agent
+from praetorian_cli.sdk.entities.account_discovery import load_agents_for_accounts, truncate_email
 
-from .theme import AEGIS_RICH_THEME
+from .theme import AEGIS_RICH_THEME, AEGIS_COLORS
 from .utils import (
     relative_time, format_os_display,
     compute_agent_groups, get_agent_display_style
@@ -374,6 +375,11 @@ class AegisMenu:
         
         self._active_proxies: dict = {}
 
+        # Multi-account state
+        self.multi_account_mode = False
+        self.selected_accounts: list = []
+        self.agent_account_map: dict = {}  # client_id -> account_info dict
+
         self.commands = [
             'set', 'ssh', 'cp', 'proxy', 'info', 'list', 'job', 'schedule', 'reload', 'clear', 'help', 'quit', 'exit'
         ]
@@ -447,6 +453,8 @@ class AegisMenu:
             
         elif command in ['r', 'reload']:
             self.reload_agents()
+            self.show_agents_list()
+            self.pause()
             
         elif command == 'clear':
             self.clear_screen()
@@ -560,6 +568,10 @@ class AegisMenu:
             pad_edge=False
         )
         
+        if self.multi_account_mode:
+            table.add_column("ACCOUNT", style=f"{self.colors['dim']}", width=19, no_wrap=True)
+            table.add_column("ACCT STATUS", width=12, no_wrap=True)
+
         table.add_column("", style=f"{self.colors['dim']}", width=4, justify="right", no_wrap=True)
         table.add_column("HOSTNAME", style="white", min_width=25, no_wrap=False)
         table.add_column("OS", style=f"{self.colors['dim']}", width=16, no_wrap=True)
@@ -592,14 +604,24 @@ class AegisMenu:
             else:
                 last_seen = "—"
             
-            table.add_row(
+            row_cells = []
+            if self.multi_account_mode:
+                acct_info = self.agent_account_map.get(agent.client_id, {})
+                acct_name = truncate_email(acct_info.get('display_name', ''), 19)
+                acct_status = acct_info.get('status', '')
+                acct_status_style = self.colors['success'] if acct_status.upper() == 'ACTIVE' else self.colors['dim']
+                row_cells.append(Text(acct_name, style=self.colors['dim']))
+                row_cells.append(Text(acct_status, style=acct_status_style))
+
+            row_cells.extend([
                 Text(str(i), style=idx_style),
                 Text(hostname, style=hostname_style),
                 os_display,
                 status,
                 tunnel,
-                last_seen
-            )
+                last_seen,
+            ])
+            table.add_row(*row_cells)
         
         self.console.print(table)
         self.console.print()
@@ -655,21 +677,49 @@ class AegisMenu:
             return "quit"
 
     def load_agents(self) -> None:
-        """Load agents from SDK and build lookup cache"""
-        try:
-            with self.console.status(
-                f"[{self.colors['dim']}]Loading agents...[/{self.colors['dim']}]",
-                spinner="dots",
-                spinner_style=f"{self.colors['primary']}"
-            ):
-                agents, _ = self.sdk.aegis.list()
-                self.agents = agents or []
+        """Load agents from SDK and build lookup cache.
 
-                # Build agent_lookup for fast client_id -> hostname mapping
-                self.agent_lookup = {}
-                for agent in self.agents:
-                    if agent.client_id and agent.hostname:
-                        self.agent_lookup[agent.client_id] = agent.hostname
+        In multi-account mode, aggregates agents from all selected accounts
+        and maintains agent_account_map for account context display.
+        """
+        try:
+            if self.multi_account_mode and self.selected_accounts:
+                status = self.console.status(
+                    f"[{self.colors['dim']}]Loading agents...[/{self.colors['dim']}]",
+                    spinner="dots",
+                    spinner_style=f"{self.colors['primary']}"
+                )
+                status.start()
+
+                def _on_progress(checked, total, name):
+                    status.update(
+                        f"[{self.colors['dim']}]Loading agents... ({checked}/{total}) {name}[/{self.colors['dim']}]"
+                    )
+
+                try:
+                    agent_tuples = load_agents_for_accounts(self.sdk, self.selected_accounts, on_progress=_on_progress)
+                    self.agents = []
+                    self.agent_account_map = {}
+                    for agent, acct_info in agent_tuples:
+                        self.agents.append(agent)
+                        self.agent_account_map[agent.client_id] = acct_info
+                finally:
+                    status.stop()
+            else:
+                with self.console.status(
+                    f"[{self.colors['dim']}]Loading agents...[/{self.colors['dim']}]",
+                    spinner="dots",
+                    spinner_style=f"{self.colors['primary']}"
+                ):
+                    agents, _ = self.sdk.aegis.list()
+                    self.agents = agents or []
+                    self.agent_account_map = {}
+
+            # Build agent_lookup for fast client_id -> hostname mapping
+            self.agent_lookup = {}
+            for agent in self.agents:
+                if agent.client_id and agent.hostname:
+                    self.agent_lookup[agent.client_id] = agent.hostname
 
             if self.verbose or not self.agents:
                 agent_count = len(self.agents)
@@ -682,6 +732,7 @@ class AegisMenu:
             self.console.print(f"[{self.colors['error']}]✗ Error loading agents: {e}[/{self.colors['error']}]")
             self.agents = []
             self.agent_lookup = {}
+            self.agent_account_map = {}
     
     def pause(self):
         """Professional pause with styling"""
@@ -691,6 +742,42 @@ class AegisMenu:
 
 
 def run_aegis_menu(sdk: Chariot) -> None:
-    """Run the Aegis menu interface"""
-    menu = AegisMenu(sdk)
-    menu.run()
+    """Run the Aegis menu interface.
+
+    If no account is selected (sdk.keychain.account is None), shows the
+    multi-account selector first. Otherwise runs single-account mode.
+    """
+    if not sdk.keychain.account:
+        # Multi-account mode: show account selector
+        from praetorian_cli.ui.aegis.account_selector import run_account_selector
+        from praetorian_cli.sdk.entities.account_discovery import discover_aegis_accounts
+
+        console = Console(theme=AEGIS_RICH_THEME)
+
+        with console.status(
+            f"[{AEGIS_COLORS['dim']}]Discovering accounts with aegis agents...[/{AEGIS_COLORS['dim']}]",
+            spinner="dots",
+            spinner_style=AEGIS_COLORS['primary'],
+        ) as status:
+            def _on_progress(checked, total, email):
+                status.update(
+                    f"[{AEGIS_COLORS['dim']}]Checking account {checked}/{total}: {email}[/{AEGIS_COLORS['dim']}]"
+                )
+
+            accounts = discover_aegis_accounts(sdk, on_progress=_on_progress)
+        if not accounts:
+            console.print(f"[{AEGIS_COLORS['warning']}]No accounts with aegis agents found.[/{AEGIS_COLORS['warning']}]")
+            return
+
+        selected = run_account_selector(accounts, AEGIS_COLORS, console)
+        if not selected:
+            return  # User cancelled
+
+        menu = AegisMenu(sdk)
+        menu.multi_account_mode = True
+        menu.selected_accounts = selected
+        menu.run()
+    else:
+        # Single-account mode (existing behavior)
+        menu = AegisMenu(sdk)
+        menu.run()

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -700,12 +700,14 @@ class AegisMenu:
                     agent_tuples, failed = load_agents_for_accounts(self.sdk, self.selected_accounts, on_progress=_on_progress)
                     self.agents = []
                     self.agent_account_map = {}
+                    self.agent_lookup = {}
                     for agent, acct_info in agent_tuples:
                         self.agents.append(agent)
-                        # Attach account info directly to agent to avoid client_id collisions
                         agent._account_info = acct_info
                         if agent.client_id and agent.client_id != 'N/A':
                             self.agent_account_map[agent.client_id] = acct_info
+                        if agent.client_id and agent.hostname:
+                            self.agent_lookup[agent.client_id] = agent.hostname
                 finally:
                     status.stop()
 
@@ -721,11 +723,10 @@ class AegisMenu:
                     self.agents = agents or []
                     self.agent_account_map = {}
 
-            # Build agent_lookup for fast client_id -> hostname mapping
-            self.agent_lookup = {}
-            for agent in self.agents:
-                if agent.client_id and agent.hostname:
-                    self.agent_lookup[agent.client_id] = agent.hostname
+                self.agent_lookup = {}
+                for agent in self.agents:
+                    if agent.client_id and agent.hostname:
+                        self.agent_lookup[agent.client_id] = agent.hostname
 
             if self.verbose or not self.agents:
                 agent_count = len(self.agents)


### PR DESCRIPTION
## Summary
- When `chariot aegis` is run without `--account`, discovers all accounts with agents via bulk `allTenants` API calls, shows an interactive checkbox selector with STATUS/TYPE/AGENTS columns, then aggregates agents and schedules across selected accounts
- Agent and schedule tables display ACCOUNT (display name) and ACCT STATUS columns in multi-account mode
- Selecting an agent via `set` auto-assumes into the correct account so downstream commands (schedule add, job, etc.) target the right tenant
- `list` and `reload` always re-fetch agents from API to avoid stale `is_online` (60-second window)
- Thread-safe progress indicators during discovery and agent loading
- Debug logging for all swallowed exceptions in concurrent API calls

## New files
- `account_discovery.py` — Bulk metadata fetching, concurrent agent/schedule loading, status calculation
- `account_selector.py` — Interactive prompt_toolkit-based checkbox table for account selection
- `test_account_discovery.py` — 22 tests for discovery, status calc, loading, helpers
- `test_account_selector.py` — Tests for selector state management
- `test_multi_account_tables.py` — Tests for multi-account table rendering

## Test plan
- [x] 178 existing tests pass (6 pre-existing schedule ID format failures unrelated)
- [x] 27 new/modified tests pass
- [ ] Live test: `PYTHONPATH=. python3 -m praetorian_cli chariot aegis` → select accounts → verify agent table → `set` agent → `schedule add`
- [ ] Live test: `list` and `reload` show fresh online status
- [ ] Live test: single-account mode (`--account`) unchanged

Fixes ENG-2374 — adds multi-account aegis schedule management (per-account assume/restore around schedule loading)
