### PR TITLE
feat: replace CONTAINS filters with fulltext search via Node.Search

### DIFF
--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -103,7 +103,7 @@ class Risks:
         """
         List risks with optional filtering and pagination.
 
-        :param contains_filter: Fulltext search term to apply to risks. Uses Lucene-indexed fulltext search across risk fields.
+        :param contains_filter: Filter to apply to the risk key. Ensure the risk's key contains the filter.
         :type contains_filter: str
         :param offset: The offset of the page you want to retrieve results. If not supplied, retrieves from the first page
         :type offset: str or None

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -1,5 +1,5 @@
 from praetorian_cli.sdk.model.globals import Kind
-from praetorian_cli.sdk.model.query import Relationship, Node, Query, risk_of_key, ASSET_NODE, PORT_NODE, Filter, WEBPAGE_NODE
+from praetorian_cli.sdk.model.query import Relationship, Node, Query, risk_of_key, ASSET_NODE, PORT_NODE, WEBPAGE_NODE
 
 
 class Risks:
@@ -103,7 +103,7 @@ class Risks:
         """
         List risks with optional filtering and pagination.
 
-        :param contains_filter: Filter to apply to the risk key. Ensure the risk's key contains the filter.
+        :param contains_filter: Fulltext search term to apply to risks. Uses Lucene-indexed fulltext search across risk fields.
         :type contains_filter: str
         :param offset: The offset of the page you want to retrieve results. If not supplied, retrieves from the first page
         :type offset: str or None
@@ -112,15 +112,10 @@ class Risks:
         :return: A tuple containing (list of matching risks, next page offset)
         :rtype: tuple
         """
-        filters = []
-        if contains_filter:
-            contains_filter_filter = Filter(field=Filter.Field.KEY, operator=Filter.Operator.CONTAINS, value=contains_filter)
-            filters.append(contains_filter_filter)
-
         query = Query(
             Node(
                 labels=[Node.Label.RISK],
-                filters=filters
+                search=contains_filter if contains_filter else None
             )
         )
 

--- a/praetorian_cli/sdk/entities/webpage.py
+++ b/praetorian_cli/sdk/entities/webpage.py
@@ -122,10 +122,8 @@ class Webpage:
             parentFilter = Filter(field=Filter.Field.KEY, operator=Filter.Operator.EQUAL, value=parent_key)
             relationship = Relationship(label=Relationship.Label.HAS_WEBPAGE, target=Node(labels=[Node.Label.WEBAPPLICATION], filters=[parentFilter]))
             relationships.append(relationship)
-        if filter:
-            urlFilter = Filter(field=Filter.Field.KEY, operator=Filter.Operator.CONTAINS, value=filter)
-            filters.append(urlFilter)
-        node = Node(labels=[Node.Label.WEBPAGE], filters=filters, relationships=relationships)
+        node = Node(labels=[Node.Label.WEBPAGE], filters=filters, relationships=relationships,
+                    search=filter if filter else None)
         query = Query(node=node, page=offset)
         return self.api.search.by_query(query, pages)
 

--- a/praetorian_cli/sdk/model/query.py
+++ b/praetorian_cli/sdk/model/query.py
@@ -333,10 +333,11 @@ class Node:
         ADISSUANCEPOLICY = 'ADIssuancePolicy'
 
     def __init__(self, labels: list[Label] = None, filters: list[Filter] = None,
-                 relationships: list[Relationship] = None):
+                 relationships: list[Relationship] = None, search: str = None):
         self.labels = labels
         self.filters = filters
         self.relationships = relationships
+        self.search = search
 
     def to_dict(self):
         ret = dict()
@@ -344,6 +345,8 @@ class Node:
             ret |= dict(labels=[x.value for x in self.labels])
         if self.filters:
             ret |= dict(filters=[x.to_dict() for x in self.filters])
+        if self.search:
+            ret |= dict(search=self.search)
         if self.relationships:
             ret |= dict(relationships=[x.to_dict() for x in self.relationships])
         return ret


### PR DESCRIPTION
## Summary

Adds support for the backend's new `Node.Search` fulltext search field (chariot#4682) to the CLI SDK, replacing `CONTAINS` filter usage with Lucene-indexed fulltext search.

## Changes

### SDK query model (`praetorian_cli/sdk/model/query.py`)
- Added `search: str` parameter to `Node.__init__()`
- Added `search` serialization to `Node.to_dict()`

### Risks (`praetorian_cli/sdk/entities/risks.py`)
- `list()` now uses `Node(search=...)` instead of a `CONTAINS` filter on the key field
- Removed unused `Filter` import

### Webpages (`praetorian_cli/sdk/entities/webpage.py`)
- `list()` now uses `Node(search=...)` instead of a `CONTAINS` filter on the key field

### Not changed (intentional)
- **AD entities** — `ad.py` uses `CONTAINS` on the `name` field for AD objects. AD node types (ADUser, ADComputer, etc.) don't have fulltext indexes, so these remain as Cypher `CONTAINS` filters.
- **Other entities** (assets, seeds, preseeds, files, jobs, etc.) use `STARTS_WITH` / `by_key_prefix`, not `CONTAINS`, so no changes needed.