### PR TITLE
feat: add --tag flag to add/update risk CLI commands

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -145,7 +145,8 @@ def webhook(sdk):
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-cap', '--capability', default='', help='Capability that discoverd the risk')
 @click.option('--title', '-t', default=None, help='Human-readable title for the risk')
-def risk(sdk, name, asset, status, comment, capability, title):
+@click.option('-g', '--tag', 'tags', multiple=True, help='Tag for the risk (can be specified multiple times)')
+def risk(sdk, name, asset, status, comment, capability, title, tags):
     """ Add a risk
 
     This command adds a risk to Guard. A risk must have an associated asset.
@@ -161,8 +162,9 @@ def risk(sdk, name, asset, status, comment, capability, title):
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TI
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC
         - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TC --capability red-team
+        - guard add risk CVE-2024-23049 --asset "#asset#example.com#1.2.3.4" --status TI --tag critical --tag needs-review
     """
-    sdk.risks.add(asset, name, status, comment, capability, title)
+    sdk.risks.add(asset, name, status, comment, capability, title, tags)
 
 
 @add.command()

--- a/praetorian_cli/handlers/update.py
+++ b/praetorian_cli/handlers/update.py
@@ -38,7 +38,8 @@ def asset(chariot, key, status, surface):
 @click.option('-c', '--comment', default='', help='Comment for the risk')
 @click.option('-r', '--remove-comment', type=int, default=None, help='Remove comment at index (0, 1, ... or -1 for most recent)')
 @click.option('--title', '-t', default=None, help='Human-readable title for the risk')
-def risk(chariot, key, status, comment, remove_comment, title):
+@click.option('-g', '--tag', 'tags', multiple=True, help='Tag for the risk (can be specified multiple times)')
+def risk(chariot, key, status, comment, remove_comment, title, tags):
     """ Update the status and comment of a risk
 
     \b
@@ -51,11 +52,12 @@ def risk(chariot, key, status, comment, remove_comment, title):
         - guard update risk "#risk#www.example.com#open-ssh-port" --status RH --comment "John stopped sshd on the server"
         - guard update risk "#risk#www.example.com#CVE-2024-23049" --remove-comment 0
         - guard update risk "#risk#www.example.com#CVE-2024-23049" --remove-comment -1
+        - guard update risk "#risk#www.example.com#CVE-2024-23049" --tag resolved --tag verified
     """
     if comment and remove_comment is not None:
         raise click.UsageError("Cannot use --comment and --remove-comment together")
 
-    chariot.risks.update(key, status, comment, remove_comment, title)
+    chariot.risks.update(key, status, comment, remove_comment, title, tags)
 
 
 @update.command()

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -79,7 +79,7 @@ class Risks:
             params = params | dict(comment=comment)
         if title is not None:
             params['title'] = title
-        if tags is not None:
+        if tags:
             params['tags'] = {'tags': list(tags)}
         if remove_comment is not None:
             index = self.resolve_comment_entry_index(key, remove_comment)

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -9,7 +9,7 @@ class Risks:
     def __init__(self, api):
         self.api = api
 
-    def add(self, asset_key, name, status, comment=None, capability='', title=None):
+    def add(self, asset_key, name, status, comment=None, capability='', title=None, tags=None):
         """
         Add a risk to an existing asset.
 
@@ -25,12 +25,16 @@ class Risks:
         :type capability: str
         :param title: Optional human-readable title for the risk
         :type title: str or None
+        :param tags: Optional tags for the risk
+        :type tags: tuple or list or None
         :return: The created risk object
         :rtype: dict
         """
         body = dict(key=asset_key, name=name, status=status, comment=comment, source=capability)
         if title is not None:
             body['title'] = title
+        if tags:
+            body['tags'] = {'tags': list(tags)}
         return self.api.upsert('risk', body)['risks'][0]
 
     def get(self, key, details=False):
@@ -49,7 +53,7 @@ class Risks:
             risk['affected_assets'] = self.affected_assets(key)
         return risk
 
-    def update(self, key, status=None, comment=None, remove_comment=None, title=None):
+    def update(self, key, status=None, comment=None, remove_comment=None, title=None, tags=None):
         """
         Update a risk's status and/or comment, or remove a comment.
 
@@ -63,6 +67,8 @@ class Risks:
         :type remove_comment: int or None
         :param title: Optional human-readable title for the risk
         :type title: str or None
+        :param tags: Optional tags for the risk
+        :type tags: tuple or list or None
         :return: API response containing update results
         :rtype: dict
         """
@@ -73,6 +79,8 @@ class Risks:
             params = params | dict(comment=comment)
         if title is not None:
             params['title'] = title
+        if tags is not None:
+            params['tags'] = {'tags': list(tags)}
         if remove_comment is not None:
             index = self.resolve_comment_entry_index(key, remove_comment)
             params = params | dict(remove=index)

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -90,5 +90,19 @@ class TestRisk:
         risk = self.sdk.risks.get(risk_key)
         assert risk['title'] == title
 
+    def test_add_risk_with_tags(self):
+        tags = ('critical', 'needs-review')
+        r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, tags=tags)
+        risk = self.sdk.risks.get(r['key'])
+        assert risk['tags']['tags'] == list(tags)
+
+    def test_update_risk_with_tags(self):
+        r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value)
+        risk_key = r['key']
+        tags = ('resolved', 'verified')
+        self.sdk.risks.update(risk_key, tags=tags)
+        risk = self.sdk.risks.get(risk_key)
+        assert risk['tags']['tags'] == list(tags)
+
     def teardown_class(self):
         clean_test_entities(self.sdk, self)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -87,7 +87,8 @@ class TestZCli:
         o = make_test_values(lambda: None)
         self.verify(f'add asset -n {o.asset_name} -d {o.asset_dns}')
 
-        self.verify(f'add risk {o.risk_name} -a "{o.asset_key}" -s {AddRisk.TRIAGE_HIGH.value}')
+        self.verify(f'add risk {o.risk_name} -a "{o.asset_key}" -s {AddRisk.TRIAGE_HIGH.value} -g critical -g needs-review')
+        self.verify(f'get risk "{o.risk_key}"', ['"tags"', '"critical"', '"needs-review"'])
 
         self.verify('list risks -p all', [o.risk_key])
         self.verify(f'list risks -f "{o.asset_dns}"', [o.risk_key])
@@ -101,6 +102,9 @@ class TestZCli:
 
         self.verify(f'update risk "{o.risk_key}" -s {Risk.OPEN_LOW.value}')
         self.verify(f'get risk "{o.risk_key}"', [o.risk_key, f'"status": "{Risk.OPEN_LOW.value}"'])
+
+        self.verify(f'update risk "{o.risk_key}" -g resolved -g verified')
+        self.verify(f'get risk "{o.risk_key}"', ['"tags"', '"resolved"', '"verified"'])
 
         self.verify(f'delete risk "{o.risk_key}" -s {Risk.DELETED_OTHER_LOW.value}')
         self.verify(f'get risk "{o.risk_key}"', [


### PR DESCRIPTION
## Summary
- Adds `-g`/`--tag` flag (`multiple=True`) to `add risk` and `update risk` CLI commands
- Passes tags through to `sdk.risks.add()` and `sdk.risks.update()` as `{'tags': {'tags': [...]}}` in the request body
- Adds coherence and CLI tests for the new flag

Closes PS-589

## Test plan
- [ ] `guard add risk --help` shows `--tag` flag
- [ ] `guard update risk --help` shows `--tag` flag
- [ ] `pytest -m coherence -k test_add_risk_with_tags`
- [ ] `pytest -m coherence -k test_update_risk_with_tags`
- [ ] `pytest -m cli -k test_risk_cli`