### PR TITLE
feat: require role when linking a collaborator account

### DIFF
--- a/praetorian_cli/handlers/link.py
+++ b/praetorian_cli/handlers/link.py
@@ -13,7 +13,10 @@ def link():
 @link.command()
 @cli_handler
 @click.argument('username')
-def account(chariot, username):
+@click.option('--role', '-r', required=True,
+              type=click.Choice(['admin', 'analyst', 'readonly'], case_sensitive=False),
+              help='Role to assign to the collaborator.')
+def account(chariot, username, role):
     """ Add a collaborator account to your account
 
     This allows them to assume access into your account
@@ -21,15 +24,14 @@ def account(chariot, username):
 
     \b
     Arguments:
-        - NAME: their email address
-
-
+        - USERNAME: their email address
 
     \b
     Example usages:
-        - guard link account john@praetorian.com
+        - guard link account john@praetorian.com --role admin
+        - guard link account analyst@example.com -r readonly
     """
-    chariot.accounts.add_collaborator(username)
+    chariot.accounts.add_collaborator(username, role=role)
 
 
 @link.command('webpage-source')

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -183,8 +183,11 @@ class Chariot:
     def upsert(self, type: str, body: dict, params: dict = {}) -> dict:
         return self.put(type, body, params)
 
-    def link_account(self, username: str, value: str = '', config: dict = {}) -> dict:
-        resp = self.chariot_request('POST', self.url(f'/account/{username}'), json=dict(config=config, value=value))
+    def link_account(self, username: str, role: str = '', value: str = '', config: dict = {}) -> dict:
+        body = dict(config=config, value=value)
+        if role:
+            body['role'] = role
+        resp = self.chariot_request('POST', self.url(f'/account/{username}'), json=body)
         process_failure(resp)
         return resp.json()
 

--- a/praetorian_cli/sdk/entities/accounts.py
+++ b/praetorian_cli/sdk/entities/accounts.py
@@ -43,16 +43,18 @@ class Accounts:
 
         return results, next_offset
 
-    def add_collaborator(self, collaborator_email):
+    def add_collaborator(self, collaborator_email, role=''):
         """
         Add a collaborator to the account of the current principal.
 
         :param collaborator_email: Email address of the collaborator to add
         :type collaborator_email: str
+        :param role: Role to assign to the collaborator (admin, analyst, or readonly)
+        :type role: str
         :return: The created account entity with member information
         :rtype: dict
         """
-        return self.api.link_account(collaborator_email)
+        return self.api.link_account(collaborator_email, role=role)
 
     def delete_collaborator(self, collaborator_email):
         """

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -209,7 +209,7 @@ class TestZCli:
     def test_account_cli(self):
         o = make_test_values(lambda: None)
 
-        self.verify(f'link account {o.email}')
+        self.verify(f'link account {o.email} --role admin')
         self.verify(f'list accounts', [o.email])
         self.verify(f'list accounts -d', [o.email, '"key"'])
         self.verify(f'list accounts -f {o.email}', [o.email])


### PR DESCRIPTION
## Summary

Adds a required `--role` / `-r` option to the `guard link account` CLI command so callers must specify one of `admin`, `analyst`, or `readonly` when linking a collaborator.

## Changes

- **`handlers/link.py`** — added `--role/-r` as a required `click.Choice` option (`admin`, `analyst`, `readonly`)
- **`sdk/entities/accounts.py`** — `add_collaborator()` now accepts and forwards a `role` parameter
- **`sdk/chariot.py`** — `link_account()` includes `role` in the `POST /account/{member}` request body
- **`sdk/test/test_z_cli.py`** — updated CLI test to pass `--role admin`

## Usage

```bash
guard link account john@example.com --role admin
guard link account analyst@example.com -r readonly
```

## Related

Aligns the CLI with the RBAC role enforcement added to the backend `POST /account/{member}` endpoint in chariot.