### PR TITLE
fix: resolve webhook and test failures from recent SDK changes

### DIFF
--- a/praetorian_cli/sdk/entities/webhook.py
+++ b/praetorian_cli/sdk/entities/webhook.py
@@ -48,7 +48,7 @@ class Webhook:
             ```
         """
         pin = str(uuid4())
-        self.api.link_account('hook', pin)
+        self.api.link_account('hook', role='readonly', value=pin)
         return self.webhook_url(pin)
 
     def get_url(self):

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -94,7 +94,7 @@ class TestRisk:
         tags = ('critical', 'needs-review')
         r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, tags=tags)
         risk = self.sdk.risks.get(r['key'])
-        assert risk['tags']['tags'] == list(tags)
+        assert risk['tags'] == list(tags)
 
     def test_update_risk_with_tags(self):
         r = self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value)
@@ -102,7 +102,7 @@ class TestRisk:
         tags = ('resolved', 'verified')
         self.sdk.risks.update(risk_key, tags=tags)
         risk = self.sdk.risks.get(risk_key)
-        assert risk['tags']['tags'] == list(tags)
+        assert risk['tags'] == list(tags)
 
     def teardown_class(self):
         clean_test_entities(self.sdk, self)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -119,26 +119,26 @@ class TestZCli:
         The substring checks in test_risk_cli cannot detect this structural issue.
         """
         o = make_test_values(lambda: None)
-        self.verify(f'add asset -n {o.asset_name} -d {o.asset_dns}')
+        self.verify(f'add asset -i {o.asset_name} -g {o.asset_dns}')
 
         # Verify add risk with tags produces correct structure
         self.verify(f'add risk {o.risk_name} -a "{o.asset_key}" -s {AddRisk.TRIAGE_HIGH.value} -g phase_web -g needs-triage',
                     ignore_stdout=True)
         risk = self.run_json(f'get risk "{o.risk_key}"')
-        assert isinstance(risk['tags']['tags'], list), \
-            f'Expected tags.tags to be a list, got {type(risk["tags"]["tags"])}: {risk["tags"]}'
-        assert all(isinstance(t, str) for t in risk['tags']['tags']), \
-            f'Expected all tags to be strings, got: {risk["tags"]["tags"]}'
-        assert set(risk['tags']['tags']) == {'phase_web', 'needs-triage'}
+        assert isinstance(risk['tags'], list), \
+            f'Expected tags to be a list, got {type(risk["tags"])}: {risk["tags"]}'
+        assert all(isinstance(t, str) for t in risk['tags']), \
+            f'Expected all tags to be strings, got: {risk["tags"]}'
+        assert set(risk['tags']) == {'phase_web', 'needs-triage'}
 
         # Verify update risk with tags produces correct structure
         self.verify(f'update risk "{o.risk_key}" -g resolved -g verified', ignore_stdout=True)
         risk = self.run_json(f'get risk "{o.risk_key}"')
-        assert isinstance(risk['tags']['tags'], list), \
-            f'Expected tags.tags to be a list after update, got {type(risk["tags"]["tags"])}: {risk["tags"]}'
-        assert all(isinstance(t, str) for t in risk['tags']['tags']), \
-            f'Expected all tags to be strings after update, got: {risk["tags"]["tags"]}'
-        assert set(risk['tags']['tags']) == {'resolved', 'verified'}
+        assert isinstance(risk['tags'], list), \
+            f'Expected tags to be a list after update, got {type(risk["tags"])}: {risk["tags"]}'
+        assert all(isinstance(t, str) for t in risk['tags']), \
+            f'Expected all tags to be strings after update, got: {risk["tags"]}'
+        assert set(risk['tags']) == {'resolved', 'verified'}
 
         clean_test_entities(self.sdk, o)
 


### PR DESCRIPTION
## Summary
- **Webhook 400 error**: `webhook.upsert()` called `link_account('hook', pin)` without the `role` parameter now required by the backend after #185. Passed `role='readonly'` since webhook integrations only need read access.
- **Risk tag assertions**: Tests asserted `risk['tags']['tags']` but the backend now returns a flat `risk['tags']` list after the flatten fix in #184.
- **CLI flag mismatch**: `test_z_cli` used stale `-n`/`-d` flags for `add asset` instead of the current `-i`/`-g` flags.

### Errors fixed
| Test | Error | Root cause |
|------|-------|------------|
| `test_create_webhook` | `[400] invalid role: must be admin, analyst, or readonly` | Missing `role` param in `link_account` call |
| `test_add_asset` / `test_add_risk` | `MissingSchema: Invalid URL 'None'` | Webhook URL was `None` because creation failed |
| `test_webhook_cli` | `AssertionError: stdout empty` | Same 400 error via CLI path |
| `test_add_risk_with_tags` / `test_update_risk_with_tags` | `KeyError: 'tags'` | Nested `tags.tags` no longer exists |
| `test_risk_tag_cli` | `AssertionError` | Same tags structure + stale CLI flags |

## Test plan
- [ ] Run `guard test` and confirm all 281 tests pass
- [ ] Verify webhook creation returns a valid URL
- [ ] Verify risk tag assertions match the flat list structure