### PR TITLE
bugfix - normalize capability and asset names in dropdown menu to prevent crash

### DIFF
--- a/praetorian_cli/ui/aegis/commands/job.py
+++ b/praetorian_cli/ui/aegis/commands/job.py
@@ -11,6 +11,7 @@ from .job_helpers import (
     configure_parameters as _configure_parameters,
     capability_needs_credentials as _capability_needs_credentials,
     resolve_addomain_target_key,
+    _normalize_target,
 )
 
 
@@ -134,7 +135,7 @@ def run_job(menu, args):
         menu.pause()
         return
 
-    target_type = capability_info.get('target', 'asset').lower()
+    target_type = _normalize_target(capability_info.get('target', 'asset'))
 
     # Create appropriate target key
     if target_type == 'addomain':

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -12,6 +12,13 @@ from ..constants import DEFAULT_COLORS
 # Capability helpers
 # ---------------------------------------------------------------------------
 
+def _normalize_target(target):
+    """Normalize capability target field which may be a string or list."""
+    if isinstance(target, list):
+        return target[0].lower() if target else 'asset'
+    return (target or 'asset').lower()
+
+
 def _parse_capability_name(name):
     """Extract OS, category, and tool from capability name.
 
@@ -43,7 +50,7 @@ class CapabilityCompleter(Completer):
         for cap in self.capabilities:
             name = cap.get('name', '')
             name_lower = name.lower()
-            target = cap.get('target', 'asset').lower()
+            target = _normalize_target(cap.get('target', 'asset'))
             description = cap.get('description', '') or ''
             parsed = _parse_capability_name(name)
             category = parsed.get('category', '')
@@ -92,7 +99,7 @@ def interactive_capability_picker(menu, suggested=None):
         if capability_info:
             # Show the suggested capability and ask for confirmation
             desc = (capability_info.get('description', '') or '')[:60]
-            target = capability_info.get('target', 'asset')
+            target = _normalize_target(capability_info.get('target', 'asset'))
             menu.console.print(f"\n  Suggested capability:")
             menu.console.print(f"    {suggested} [{target}]")
             menu.console.print(f"    [{colors['dim']}]{desc}[/{colors['dim']}]")

--- a/praetorian_cli/ui/aegis/commands/schedule.py
+++ b/praetorian_cli/ui/aegis/commands/schedule.py
@@ -19,6 +19,7 @@ from .job_helpers import (
     configure_parameters,
     capability_needs_credentials,
     resolve_addomain_target_key,
+    _normalize_target,
 )
 
 
@@ -267,7 +268,7 @@ def add_schedule(menu):
         menu.pause()
         return
 
-    target_type = capability_info.get('target', 'asset').lower()
+    target_type = _normalize_target(capability_info.get('target', 'asset'))
     hostname = menu.selected_agent.hostname or 'Unknown'
 
     # Create target key


### PR DESCRIPTION
fixes this issue:

<img width="1702" height="1754" alt="image" src="https://github.com/user-attachments/assets/ce46c339-10a6-4cd4-8dec-120c851e42e8" />

