### PR TITLE
feat(aegis): fix cred-auth polling, add job status/artifacts, ingest command

### DIFF
--- a/praetorian_cli/handlers/aegis.py
+++ b/praetorian_cli/handlers/aegis.py
@@ -169,3 +169,145 @@ def info(ctx, sdk, client_id):
         return
     
     click.echo(agent.to_detailed_string())
+
+
+@aegis.command('cred-auth')
+@cli_handler
+@click.argument('client_id', required=True)
+@click.argument('credential_id', required=True)
+@click.option('--no-wait', is_flag=True, help='Submit task without waiting for completion')
+@click.option('--timeout', default=120, type=int, help='Max seconds to wait (default: 120)')
+@click.pass_context
+def cred_auth(ctx, sdk, client_id, credential_id, no_wait, timeout):
+    """Authenticate AD credentials via an Aegis agent.
+
+    Runs the linux-ad-umber-auth management capability on the specified agent
+    to validate credentials against a domain controller. Waits for the result
+    by default; use --no-wait to return immediately after submission.
+
+    CREDENTIAL_ID is the UUID of the credential stored in Guard.
+    """
+    import time as _time
+    import re
+    import sys
+
+    # Validate credential_id is a UUID
+    uuid_re = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+    if not uuid_re.match(credential_id):
+        click.echo("Error: credential_id must be a valid UUID", err=True)
+        return
+
+    try:
+        result = sdk.aegis.credential_auth(client_id, credential_id)
+        task_id = result.get('taskId', '')
+        click.echo(f"Task submitted: {task_id}")
+
+        if no_wait or not task_id:
+            return
+
+        start = _time.monotonic()
+        deadline = start + timeout
+        _FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+        frame_idx = 0
+
+        try:
+            while _time.monotonic() < deadline:
+                _time.sleep(5)
+                elapsed = int(_time.monotonic() - start)
+                frame_idx = (frame_idx + 1) % len(_FRAMES)
+
+                try:
+                    task = sdk.aegis.get_management_task(task_id)
+                except Exception:
+                    _write_status(f"{_FRAMES[frame_idx]} Waiting for agent... ({elapsed}s, retrying)")
+                    continue
+
+                current_status = task.get('status', '')
+                if current_status in ('AMT_COMPLETED', 'AMT_FAILED'):
+                    _clear_status()
+                    _print_task_result_cli(task)
+                    return
+
+                _write_status(f"{_FRAMES[frame_idx]} Running on agent... ({elapsed}s)")
+
+            _clear_status()
+            click.echo(f"Timed out after {timeout}s. Task may still be running.", err=True)
+        except KeyboardInterrupt:
+            _clear_status()
+            click.echo("\nInterrupted — task may still be running in background.")
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+
+
+def _write_status(msg):
+    """Overwrite the current line with a status message."""
+    import sys
+    sys.stderr.write(f"\r\033[K  {msg}")
+    sys.stderr.flush()
+
+
+def _clear_status():
+    """Clear the status line."""
+    import sys
+    sys.stderr.write("\r\033[K")
+    sys.stderr.flush()
+
+
+def _print_task_result_cli(task):
+    """Print the full result of a completed/failed management task."""
+    import json as _json
+
+    status = task.get('status', '')
+    is_success = status == 'AMT_COMPLETED'
+    label = '✓' if is_success else '✗'
+    click.echo(f"{label} {status}")
+
+    if task.get('errorMessage'):
+        click.echo(f"Error: {task['errorMessage']}")
+
+    cmd = task.get('commandResult') or {}
+    output_str = cmd.get('output', '')
+
+    # Try to parse output as JSON for structured display
+    output_data = None
+    if output_str:
+        try:
+            output_data = _json.loads(output_str)
+        except (_json.JSONDecodeError, TypeError):
+            pass
+
+    if output_data and isinstance(output_data, dict):
+        max_key = max((len(str(k)) for k in output_data), default=0)
+        for k, v in output_data.items():
+            click.echo(f"  {str(k):<{max_key}}  {v}")
+    else:
+        if task.get('result'):
+            click.echo(f"Result: {task['result']}")
+        if cmd:
+            click.echo(f"Success:   {cmd.get('success', 'N/A')}")
+            click.echo(f"Exit code: {cmd.get('exit_code', 'N/A')}")
+        if output_str:
+            click.echo("--- Output ---")
+            click.echo(output_str)
+
+    if cmd.get('error_output'):
+        click.echo("--- Error Output ---", err=True)
+        click.echo(cmd['error_output'], err=True)
+    if cmd.get('error_message'):
+        click.echo(f"Error: {cmd['error_message']}", err=True)
+
+
+@aegis.command('ingest')
+@cli_handler
+@click.argument('file', type=click.Path(exists=True))
+@click.option('--dry-run', is_flag=True, help='Parse and show summary without sending data')
+@click.option('--skip-files', is_flag=True, help='Skip uploading proof file items')
+@click.pass_context
+def ingest(ctx, sdk, file, dry_run, skip_files):
+    """Ingest an Aegis result file into Guard.
+
+    Reads assets, risks, and proof files from a chariot_result.json
+    and pushes them to Guard. Assets are created first, then risks
+    (linked to those assets), then proof files.
+    """
+    sdk.aegis.ingest_result(file, dry_run=dry_run, skip_files=skip_files)

--- a/praetorian_cli/handlers/aegis.py
+++ b/praetorian_cli/handlers/aegis.py
@@ -1,11 +1,10 @@
-import json
 import re
 import sys
-import time
 
 import click
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.sdk.entities.aegis import parse_task_result
 
 
 _UUID_RE = re.compile(
@@ -209,91 +208,63 @@ def cred_auth(ctx, sdk, client_id, credential_id, no_wait, timeout):
         if no_wait or not task_id:
             return
 
-        start = time.monotonic()
-        deadline = start + timeout
         _FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
         frame_idx = 0
 
+        def _on_status(elapsed, message, retrying):
+            nonlocal frame_idx
+            frame_idx = (frame_idx + 1) % len(_FRAMES)
+            suffix = f" ({elapsed}s, retrying)" if retrying else f" ({elapsed}s)"
+            sys.stderr.write(f"\r\033[K  {_FRAMES[frame_idx]} {message}{suffix}")
+            sys.stderr.flush()
+
         try:
-            while time.monotonic() < deadline:
-                time.sleep(5)
-                elapsed = int(time.monotonic() - start)
-                frame_idx = (frame_idx + 1) % len(_FRAMES)
+            task = sdk.aegis.poll_management_task(
+                task_id, timeout=timeout, on_status=_on_status,
+            )
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
 
-                try:
-                    task = sdk.aegis.get_management_task(task_id)
-                except Exception:
-                    _write_status(f"{_FRAMES[frame_idx]} Waiting for agent... ({elapsed}s, retrying)")
-                    continue
-
-                current_status = task.get('status', '')
-                if current_status in ('AMT_COMPLETED', 'AMT_FAILED'):
-                    _clear_status()
-                    _print_task_result_cli(task)
-                    return
-
-                _write_status(f"{_FRAMES[frame_idx]} Running on agent... ({elapsed}s)")
-
-            _clear_status()
-            click.echo(f"Timed out after {timeout}s. Task may still be running.", err=True)
+            if task:
+                _print_task_result_cli(task)
+            else:
+                click.echo(f"Timed out after {timeout}s. Task may still be running.", err=True)
         except KeyboardInterrupt:
-            _clear_status()
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
             click.echo("\nInterrupted — task may still be running in background.")
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
 
 
-def _write_status(msg):
-    """Overwrite the current line with a status message."""
-    sys.stderr.write(f"\r\033[K  {msg}")
-    sys.stderr.flush()
-
-
-def _clear_status():
-    """Clear the status line."""
-    sys.stderr.write("\r\033[K")
-    sys.stderr.flush()
-
-
 def _print_task_result_cli(task):
-    """Print the full result of a completed/failed management task."""
-    status = task.get('status', '')
-    is_success = status == 'AMT_COMPLETED'
-    label = '✓' if is_success else '✗'
-    click.echo(f"{label} {status}")
+    """Display a completed management task result on the CLI."""
+    r = parse_task_result(task)
+    label = '✓' if r['is_success'] else '✗'
+    click.echo(f"{label} {r['status']}")
 
-    if task.get('errorMessage'):
-        click.echo(f"Error: {task['errorMessage']}")
+    if r['error_message']:
+        click.echo(f"Error: {r['error_message']}")
 
-    cmd = task.get('commandResult') or {}
-    output_str = cmd.get('output', '')
-
-    output_data = None
-    if output_str:
-        try:
-            output_data = json.loads(output_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    if output_data and isinstance(output_data, dict):
-        max_key = max((len(str(k)) for k in output_data), default=0)
-        for k, v in output_data.items():
+    if r['output_data']:
+        max_key = max((len(str(k)) for k in r['output_data']), default=0)
+        for k, v in r['output_data'].items():
             click.echo(f"  {str(k):<{max_key}}  {v}")
     else:
-        if task.get('result'):
-            click.echo(f"Result: {task['result']}")
-        if cmd:
-            click.echo(f"Success:   {cmd.get('success', 'N/A')}")
-            click.echo(f"Exit code: {cmd.get('exit_code', 'N/A')}")
-        if output_str:
+        if r['result']:
+            click.echo(f"Result: {r['result']}")
+        if r['success'] is not None or r['exit_code'] is not None:
+            click.echo(f"Success:   {r['success'] or 'N/A'}")
+            click.echo(f"Exit code: {r['exit_code'] or 'N/A'}")
+        if r['output_raw']:
             click.echo("--- Output ---")
-            click.echo(output_str)
+            click.echo(r['output_raw'])
 
-    if cmd.get('error_output'):
+    if r['error_output']:
         click.echo("--- Error Output ---", err=True)
-        click.echo(cmd['error_output'], err=True)
-    if cmd.get('error_message'):
-        click.echo(f"Error: {cmd['error_message']}", err=True)
+        click.echo(r['error_output'], err=True)
+    if r['command_error']:
+        click.echo(f"Error: {r['command_error']}", err=True)
 
 
 @aegis.command('ingest')

--- a/praetorian_cli/handlers/aegis.py
+++ b/praetorian_cli/handlers/aegis.py
@@ -1,6 +1,16 @@
+import json
+import re
+import sys
+import time
+
 import click
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
+
+
+_UUID_RE = re.compile(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+)
 
 
 @chariot.group(invoke_without_command=True)
@@ -187,13 +197,7 @@ def cred_auth(ctx, sdk, client_id, credential_id, no_wait, timeout):
 
     CREDENTIAL_ID is the UUID of the credential stored in Guard.
     """
-    import time as _time
-    import re
-    import sys
-
-    # Validate credential_id is a UUID
-    uuid_re = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
-    if not uuid_re.match(credential_id):
+    if not _UUID_RE.match(credential_id):
         click.echo("Error: credential_id must be a valid UUID", err=True)
         return
 
@@ -205,15 +209,15 @@ def cred_auth(ctx, sdk, client_id, credential_id, no_wait, timeout):
         if no_wait or not task_id:
             return
 
-        start = _time.monotonic()
+        start = time.monotonic()
         deadline = start + timeout
         _FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
         frame_idx = 0
 
         try:
-            while _time.monotonic() < deadline:
-                _time.sleep(5)
-                elapsed = int(_time.monotonic() - start)
+            while time.monotonic() < deadline:
+                time.sleep(5)
+                elapsed = int(time.monotonic() - start)
                 frame_idx = (frame_idx + 1) % len(_FRAMES)
 
                 try:
@@ -241,22 +245,18 @@ def cred_auth(ctx, sdk, client_id, credential_id, no_wait, timeout):
 
 def _write_status(msg):
     """Overwrite the current line with a status message."""
-    import sys
     sys.stderr.write(f"\r\033[K  {msg}")
     sys.stderr.flush()
 
 
 def _clear_status():
     """Clear the status line."""
-    import sys
     sys.stderr.write("\r\033[K")
     sys.stderr.flush()
 
 
 def _print_task_result_cli(task):
     """Print the full result of a completed/failed management task."""
-    import json as _json
-
     status = task.get('status', '')
     is_success = status == 'AMT_COMPLETED'
     label = '✓' if is_success else '✗'
@@ -268,12 +268,11 @@ def _print_task_result_cli(task):
     cmd = task.get('commandResult') or {}
     output_str = cmd.get('output', '')
 
-    # Try to parse output as JSON for structured display
     output_data = None
     if output_str:
         try:
-            output_data = _json.loads(output_str)
-        except (_json.JSONDecodeError, TypeError):
+            output_data = json.loads(output_str)
+        except (json.JSONDecodeError, TypeError):
             pass
 
     if output_data and isinstance(output_data, dict):
@@ -310,4 +309,4 @@ def ingest(ctx, sdk, file, dry_run, skip_files):
     and pushes them to Guard. Assets are created first, then risks
     (linked to those assets), then proof files.
     """
-    sdk.aegis.ingest_result(file, dry_run=dry_run, skip_files=skip_files)
+    sdk.aegis.ingest_result(file, dry_run=dry_run, skip_files=skip_files, on_progress=click.echo)

--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -9,6 +9,42 @@ from praetorian_cli.sdk.model.aegis import Agent
 from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
 
 
+TASK_TERMINAL_STATUSES = ('AMT_COMPLETED', 'AMT_FAILED')
+
+
+def parse_task_result(task: dict) -> dict:
+    """Parse a management task response into a display-friendly structure.
+
+    Returns a dict with:
+        status, is_success, error_message, result,
+        output_data (parsed JSON dict or None), output_raw,
+        success, exit_code, error_output, command_error
+    """
+    status = task.get('status', '')
+    cmd = task.get('commandResult') or {}
+    output_str = cmd.get('output', '')
+
+    output_data = None
+    if output_str:
+        try:
+            output_data = json.loads(output_str)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return {
+        'status': status,
+        'is_success': status == 'AMT_COMPLETED',
+        'error_message': task.get('errorMessage'),
+        'result': task.get('result'),
+        'output_data': output_data if isinstance(output_data, dict) else None,
+        'output_raw': output_str,
+        'success': cmd.get('success'),
+        'exit_code': cmd.get('exit_code'),
+        'error_output': cmd.get('error_output'),
+        'command_error': cmd.get('error_message'),
+    }
+
+
 def normalize_to_list(value, item_keys: List[str] = None) -> List:
     keys = item_keys or ["items", "data", "capabilities", "assets"]
     if value is None:
@@ -703,6 +739,44 @@ class Aegis:
                 if isinstance(task, dict) and task.get('key') == task_key:
                     return task
         raise Exception(f'Task not found: {task_key}')
+
+    def poll_management_task(
+        self,
+        task_key: str,
+        timeout: int = 120,
+        interval: int = 5,
+        on_status: Optional[Callable[[int, str, bool], None]] = None,
+    ) -> Optional[dict]:
+        """Poll a management task until it reaches a terminal status.
+
+        :param task_key: The task key to poll
+        :param timeout: Max seconds to wait
+        :param interval: Seconds between polls
+        :param on_status: Optional callback(elapsed, message, retrying) called each iteration
+        :return: The completed/failed task dict, or None on timeout
+        """
+        start = time.monotonic()
+        deadline = start + timeout
+
+        while time.monotonic() < deadline:
+            time.sleep(interval)
+            elapsed = int(time.monotonic() - start)
+
+            try:
+                task = self.get_management_task(task_key)
+            except Exception:
+                if on_status:
+                    on_status(elapsed, 'Waiting for agent...', True)
+                continue
+
+            status = task.get('status', '')
+            if status in TASK_TERMINAL_STATUSES:
+                return task
+
+            if on_status:
+                on_status(elapsed, 'Running on agent...', False)
+
+        return None
 
     def format_agents_list(self, details: bool = False, filter_text: str = None):
         """

--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -1,11 +1,9 @@
-from typing import List, Optional
+from typing import Callable, List, Optional
 import json
 import shlex
 import shutil
 import subprocess
 import time
-
-import click
 
 from praetorian_cli.sdk.model.aegis import Agent
 from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
@@ -543,7 +541,8 @@ class Aegis:
             'status': status,
         }
     
-    def ingest_result(self, filepath, dry_run=False, skip_files=False):
+    def ingest_result(self, filepath, dry_run=False, skip_files=False,
+                      on_progress: Optional[Callable[[str], None]] = None):
         """Ingest a chariot_result.json file into Guard.
 
         Parses assets, risks, and proof files from the result file and
@@ -553,7 +552,10 @@ class Aegis:
         :param filepath: Path to the chariot_result.json file
         :param dry_run: If True, parse and show summary without sending data
         :param skip_files: If True, skip uploading proof file items
+        :param on_progress: Optional callback for progress messages
         """
+        log = on_progress or (lambda msg: None)
+
         with open(filepath) as f:
             data = json.load(f)
 
@@ -561,7 +563,6 @@ class Aegis:
         if items is None:
             raise Exception(f"No 'items' key found in {filepath}")
 
-        # Classify items: anything not risk/file is treated as an asset
         assets = []
         risks = []
         files = []
@@ -575,16 +576,16 @@ class Aegis:
             else:
                 assets.append(item)
 
-        click.echo(f"Parsed {len(items)} items: {len(assets)} assets, {len(risks)} risks, {len(files)} files")
+        log(f"Parsed {len(items)} items: {len(assets)} assets, {len(risks)} risks, {len(files)} files")
 
         if dry_run:
-            click.echo("Dry run — no data sent")
+            log("Dry run — no data sent")
             return
 
         errors = []
 
         # Phase 1: Assets
-        click.echo(f"\nIngesting {len(assets)} assets...")
+        log(f"\nIngesting {len(assets)} assets...")
         for i, item in enumerate(assets, 1):
             try:
                 body = self._transform_asset(item)
@@ -592,11 +593,11 @@ class Aegis:
             except Exception as e:
                 errors.append(f"Asset {item.get('key', '?')}: {e}")
             if i % 100 == 0:
-                click.echo(f"  {i}/{len(assets)} assets processed")
-        click.echo(f"  {len(assets)}/{len(assets)} assets done")
+                log(f"  {i}/{len(assets)} assets processed")
+        log(f"  {len(assets)}/{len(assets)} assets done")
 
         # Phase 2: Risks
-        click.echo(f"\nIngesting {len(risks)} risks...")
+        log(f"\nIngesting {len(risks)} risks...")
         for i, item in enumerate(risks, 1):
             try:
                 target = item.get('_target', {})
@@ -611,12 +612,12 @@ class Aegis:
             except Exception as e:
                 errors.append(f"Risk {item.get('name', '?')}: {e}")
             if i % 100 == 0:
-                click.echo(f"  {i}/{len(risks)} risks processed")
-        click.echo(f"  {len(risks)}/{len(risks)} risks done")
+                log(f"  {i}/{len(risks)} risks processed")
+        log(f"  {len(risks)}/{len(risks)} risks done")
 
         # Phase 3: Files
         if not skip_files and files:
-            click.echo(f"\nUploading {len(files)} files...")
+            log(f"\nUploading {len(files)} files...")
             for i, item in enumerate(files, 1):
                 try:
                     name = item.get('name', '')
@@ -628,19 +629,19 @@ class Aegis:
                 except Exception as e:
                     errors.append(f"File {item.get('name', '?')}: {e}")
                 if i % 100 == 0:
-                    click.echo(f"  {i}/{len(files)} files processed")
-            click.echo(f"  {len(files)}/{len(files)} files done")
+                    log(f"  {i}/{len(files)} files processed")
+            log(f"  {len(files)}/{len(files)} files done")
         elif skip_files and files:
-            click.echo(f"\nSkipped {len(files)} files (--skip-files)")
+            log(f"\nSkipped {len(files)} files (--skip-files)")
 
         # Summary
         total = len(assets) + len(risks) + (len(files) if not skip_files else 0)
         success = total - len(errors)
-        click.echo(f"\nComplete: {success}/{total} items ingested")
+        log(f"\nComplete: {success}/{total} items ingested")
         if errors:
-            click.echo(f"\n{len(errors)} errors:")
+            log(f"\n{len(errors)} errors:")
             for err in errors:
-                click.echo(f"  - {err}")
+                log(f"  - {err}")
             raise SystemExit(1)
 
     @staticmethod

--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -1,8 +1,12 @@
 from typing import List, Optional
+import json
 import shlex
 import shutil
 import subprocess
 import time
+
+import click
+
 from praetorian_cli.sdk.model.aegis import Agent
 from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
 
@@ -539,6 +543,166 @@ class Aegis:
             'status': status,
         }
     
+    def ingest_result(self, filepath, dry_run=False, skip_files=False):
+        """Ingest a chariot_result.json file into Guard.
+
+        Parses assets, risks, and proof files from the result file and
+        pushes them to Guard in order: assets first, then risks (linked
+        to those assets), then proof files.
+
+        :param filepath: Path to the chariot_result.json file
+        :param dry_run: If True, parse and show summary without sending data
+        :param skip_files: If True, skip uploading proof file items
+        """
+        with open(filepath) as f:
+            data = json.load(f)
+
+        items = data.get('items')
+        if items is None:
+            raise Exception(f"No 'items' key found in {filepath}")
+
+        # Classify items: anything not risk/file is treated as an asset
+        assets = []
+        risks = []
+        files = []
+
+        for item in items:
+            item_type = item.get('_type', '')
+            if item_type == 'risk':
+                risks.append(item)
+            elif item_type == 'file':
+                files.append(item)
+            else:
+                assets.append(item)
+
+        click.echo(f"Parsed {len(items)} items: {len(assets)} assets, {len(risks)} risks, {len(files)} files")
+
+        if dry_run:
+            click.echo("Dry run — no data sent")
+            return
+
+        errors = []
+
+        # Phase 1: Assets
+        click.echo(f"\nIngesting {len(assets)} assets...")
+        for i, item in enumerate(assets, 1):
+            try:
+                body = self._transform_asset(item)
+                self.api.upsert('asset', body)
+            except Exception as e:
+                errors.append(f"Asset {item.get('key', '?')}: {e}")
+            if i % 100 == 0:
+                click.echo(f"  {i}/{len(assets)} assets processed")
+        click.echo(f"  {len(assets)}/{len(assets)} assets done")
+
+        # Phase 2: Risks
+        click.echo(f"\nIngesting {len(risks)} risks...")
+        for i, item in enumerate(risks, 1):
+            try:
+                target = item.get('_target', {})
+                target_key = target.get('key', '')
+                if not target_key:
+                    errors.append(f"Risk {item.get('name', '?')}: missing _target.key")
+                    continue
+                name = item.get('name', '')
+                status = item.get('status', '')
+                source = item.get('source', '')
+                self.api.risks.add(target_key, name, status, capability=source)
+            except Exception as e:
+                errors.append(f"Risk {item.get('name', '?')}: {e}")
+            if i % 100 == 0:
+                click.echo(f"  {i}/{len(risks)} risks processed")
+        click.echo(f"  {len(risks)}/{len(risks)} risks done")
+
+        # Phase 3: Files
+        if not skip_files and files:
+            click.echo(f"\nUploading {len(files)} files...")
+            for i, item in enumerate(files, 1):
+                try:
+                    name = item.get('name', '')
+                    content = item.get('bytes', '')
+                    if not name:
+                        errors.append("File item missing 'name'")
+                        continue
+                    self.api._upload(name, content.encode('utf-8'))
+                except Exception as e:
+                    errors.append(f"File {item.get('name', '?')}: {e}")
+                if i % 100 == 0:
+                    click.echo(f"  {i}/{len(files)} files processed")
+            click.echo(f"  {len(files)}/{len(files)} files done")
+        elif skip_files and files:
+            click.echo(f"\nSkipped {len(files)} files (--skip-files)")
+
+        # Summary
+        total = len(assets) + len(risks) + (len(files) if not skip_files else 0)
+        success = total - len(errors)
+        click.echo(f"\nComplete: {success}/{total} items ingested")
+        if errors:
+            click.echo(f"\n{len(errors)} errors:")
+            for err in errors:
+                click.echo(f"  - {err}")
+            raise SystemExit(1)
+
+    @staticmethod
+    def _transform_asset(item):
+        """Transform a result item into an asset upsert body.
+
+        Copies the dict, renames _type to type, and drops all _-prefixed keys.
+        """
+        body = {}
+        for k, v in item.items():
+            if k == '_type':
+                body['type'] = v
+            elif not k.startswith('_'):
+                body[k] = v
+        return body
+
+    def credential_auth(self, client_id: str, credential_id: str) -> dict:
+        """Run credential authentication on an Aegis agent.
+
+        Invokes the linux-ad-umber-auth management capability to authenticate
+        AD credentials against a domain controller via the specified agent.
+
+        :param client_id: The Aegis agent client ID to run auth from
+        :type client_id: str
+        :param credential_id: UUID of the credential to authenticate
+        :type credential_id: str
+        :return: Task status dict with taskId, status, and message
+        :rtype: dict
+
+        **Example Usage:**
+            >>> result = sdk.aegis.credential_auth("C.abc123", "550e8400-e29b-41d4-a716-446655440000")
+            >>> print(result['status'])
+        """
+        task_request = {
+            "aegisManagementCapability": "linux-ad-umber-auth",
+            "aegisClientId": client_id,
+            "parameters": {
+                "credential_id": credential_id,
+            },
+        }
+        return self.api.post('aegis/management/tasks', task_request)
+
+    def get_management_task(self, task_key: str) -> dict:
+        """Get the status of an Aegis management task.
+
+        :param task_key: The task key returned from credential_auth or other management operations
+        :type task_key: str
+        :return: Task details including status, result, and error information
+        :rtype: dict
+
+        Note: Uses the list endpoint and filters client-side because the
+        single-task endpoint has a known issue where the DynamoDB partition
+        key overwrites the task username field, causing access-denied errors
+        under account assumption.
+        """
+        tasks = self.api.get('aegis/management/tasks', params={})
+        if isinstance(tasks, list):
+            for task in tasks:
+                if isinstance(task, dict) and task.get('key') == task_key:
+                    return task
+        raise Exception(f'Task not found: {task_key}')
+
     def format_agents_list(self, details: bool = False, filter_text: str = None):
         """
         Format agents list for display with optional filtering and details.

--- a/praetorian_cli/ui/aegis/commands/cred_auth.py
+++ b/praetorian_cli/ui/aegis/commands/cred_auth.py
@@ -1,0 +1,192 @@
+"""Aegis credential authentication command for TUI menu."""
+
+import re
+import time
+
+from rich.live import Live
+from rich.prompt import Prompt
+from rich.spinner import Spinner
+from rich.text import Text
+
+from ..constants import DEFAULT_COLORS
+from .job_helpers import select_credentials
+
+
+_UUID_RE = re.compile(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+)
+
+
+def handle_cred_auth(menu, args):
+    """Run AD credential authentication on the selected agent.
+
+    Usage:
+        cred-auth                Interactive credential picker, waits for result
+        cred-auth <uuid>         Authenticate with a specific credential UUID
+        cred-auth --no-wait      Submit task without waiting for completion
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    if not menu.selected_agent:
+        menu.console.print(f"  [{colors['error']}]No agent selected. Use 'set <id>' first.[/{colors['error']}]")
+        menu.pause()
+        return
+
+    agent = menu.selected_agent
+    no_wait = '--no-wait' in args
+    filtered_args = [a for a in args if a not in ('--no-wait', '--wait')]
+
+    # Get credential UUID — from argument or interactive picker
+    credential_id = None
+    if filtered_args:
+        candidate = filtered_args[0]
+        if _UUID_RE.match(candidate):
+            credential_id = candidate
+        else:
+            menu.console.print(f"  [{colors['error']}]Invalid credential UUID: {candidate}[/{colors['error']}]")
+            menu.pause()
+            return
+    else:
+        # Interactive: use the existing credential picker
+        credential_key, display_name = select_credentials(menu)
+        if not credential_key:
+            return
+
+        # Extract UUID from credential key: #credential#{category}#{type}#{uuid}
+        parts = credential_key.split('#')
+        # Find the UUID part (last segment that matches UUID format)
+        for part in reversed(parts):
+            if _UUID_RE.match(part):
+                credential_id = part
+                break
+
+        if not credential_id:
+            menu.console.print(f"  [{colors['error']}]Could not extract credential UUID from key: {credential_key}[/{colors['error']}]")
+            menu.pause()
+            return
+
+    # Confirm
+    menu.console.print(f"\n  [{colors['primary']}]Credential Auth[/{colors['primary']}]")
+    menu.console.print(f"  Agent:      {agent.hostname} ({agent.client_id})")
+    menu.console.print(f"  Credential: {credential_id}")
+    menu.console.print()
+
+    try:
+        confirm = Prompt.ask("  Proceed?", choices=["y", "n"], default="y")
+        if confirm.lower() != 'y':
+            menu.console.print(f"  [{colors['dim']}]Cancelled[/{colors['dim']}]")
+            return
+    except KeyboardInterrupt:
+        menu.console.print(f"\n  [{colors['dim']}]Cancelled[/{colors['dim']}]")
+        return
+
+    # Submit the management task
+    try:
+        result = menu.sdk.aegis.credential_auth(agent.client_id, credential_id)
+        task_id = result.get('taskId', '')
+        message = result.get('message', '')
+
+        menu.console.print(f"\n  [{colors['success']}]Task submitted[/{colors['success']}]")
+        if message:
+            menu.console.print(f"  {message}")
+
+    except Exception as e:
+        menu.console.print(f"  [{colors['error']}]Failed to create task: {e}[/{colors['error']}]")
+        menu.pause()
+        return
+
+    # Wait for completion by default
+    if not no_wait and task_id:
+        _poll_task(menu, task_id, colors)
+
+    menu.console.print()
+    menu.pause()
+
+
+def _print_task_result(menu, task, colors):
+    """Print the full result of a completed/failed management task."""
+    import json
+
+    status = task.get('status', '')
+    is_success = status == 'AMT_COMPLETED'
+    color = colors['success'] if is_success else colors['error']
+    label = 'Completed' if is_success else 'Failed'
+
+    menu.console.print(f"\n  [{color}]{label}[/{color}]")
+
+    if task.get('errorMessage'):
+        menu.console.print(f"  [{colors['error']}]Error: {task['errorMessage']}[/{colors['error']}]")
+
+    cmd = task.get('commandResult') or {}
+    output_str = cmd.get('output', '')
+
+    # Try to parse output as JSON for structured display
+    output_data = None
+    if output_str:
+        try:
+            output_data = json.loads(output_str)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if output_data and isinstance(output_data, dict):
+        # Structured output — display as key/value pairs
+        max_key = max((len(str(k)) for k in output_data), default=0)
+        for k, v in output_data.items():
+            menu.console.print(f"  {str(k):<{max_key}}  {v}")
+    else:
+        # Fall back to summary fields
+        if task.get('result'):
+            menu.console.print(f"  Result: {task['result']}")
+
+        if cmd:
+            menu.console.print(f"  Success:   {cmd.get('success', 'N/A')}")
+            menu.console.print(f"  Exit code: {cmd.get('exit_code', 'N/A')}")
+
+        if output_str:
+            menu.console.print(f"\n  [{colors['dim']}]--- Output ---[/{colors['dim']}]")
+            for line in output_str.splitlines():
+                menu.console.print(f"  {line}")
+
+    if cmd.get('error_output'):
+        menu.console.print(f"\n  [{colors['error']}]--- Error Output ---[/{colors['error']}]")
+        for line in cmd['error_output'].splitlines():
+            menu.console.print(f"  {line}")
+    if cmd.get('error_message'):
+        menu.console.print(f"  [{colors['error']}]Error: {cmd['error_message']}[/{colors['error']}]")
+
+
+def _poll_task(menu, task_id, colors, timeout=120):
+    """Poll a management task until it completes or times out."""
+    start = time.monotonic()
+    deadline = start + timeout
+    poll_count = 0
+
+    spinner = Spinner("dots", text=Text("  Waiting for agent to execute task...", style=colors['dim']))
+
+    try:
+        with Live(spinner, console=menu.console, refresh_per_second=10, transient=True):
+            while time.monotonic() < deadline:
+                time.sleep(5)
+                poll_count += 1
+                elapsed = int(time.monotonic() - start)
+
+                try:
+                    task = menu.sdk.aegis.get_management_task(task_id)
+                except Exception:
+                    spinner.update(text=Text(f"  Waiting for agent... ({elapsed}s, retrying)", style=colors['dim']))
+                    continue
+
+                current_status = task.get('status', '')
+
+                if current_status in ('AMT_COMPLETED', 'AMT_FAILED'):
+                    break
+
+                spinner.update(text=Text(f"  Running on agent... ({elapsed}s)", style=colors['dim']))
+            else:
+                menu.console.print(f"  [{colors['warning']}]Timed out after {timeout}s — task may still be running[/{colors['warning']}]")
+                return
+    except KeyboardInterrupt:
+        menu.console.print(f"\n  [{colors['dim']}]Interrupted — task may still be running in background[/{colors['dim']}]")
+        return
+
+    _print_task_result(menu, task, colors)

--- a/praetorian_cli/ui/aegis/commands/cred_auth.py
+++ b/praetorian_cli/ui/aegis/commands/cred_auth.py
@@ -1,13 +1,13 @@
 """Aegis credential authentication command for TUI menu."""
 
 import re
-import time
 
 from rich.live import Live
 from rich.prompt import Prompt
 from rich.spinner import Spinner
 from rich.text import Text
 
+from praetorian_cli.sdk.entities.aegis import parse_task_result
 from ..constants import DEFAULT_COLORS
 from .job_helpers import select_credentials
 
@@ -104,89 +104,57 @@ def handle_cred_auth(menu, args):
 
 
 def _print_task_result(menu, task, colors):
-    """Print the full result of a completed/failed management task."""
-    import json
-
-    status = task.get('status', '')
-    is_success = status == 'AMT_COMPLETED'
-    color = colors['success'] if is_success else colors['error']
-    label = 'Completed' if is_success else 'Failed'
+    """Display a completed management task result in the TUI."""
+    r = parse_task_result(task)
+    color = colors['success'] if r['is_success'] else colors['error']
+    label = 'Completed' if r['is_success'] else 'Failed'
 
     menu.console.print(f"\n  [{color}]{label}[/{color}]")
 
-    if task.get('errorMessage'):
-        menu.console.print(f"  [{colors['error']}]Error: {task['errorMessage']}[/{colors['error']}]")
+    if r['error_message']:
+        menu.console.print(f"  [{colors['error']}]Error: {r['error_message']}[/{colors['error']}]")
 
-    cmd = task.get('commandResult') or {}
-    output_str = cmd.get('output', '')
-
-    # Try to parse output as JSON for structured display
-    output_data = None
-    if output_str:
-        try:
-            output_data = json.loads(output_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    if output_data and isinstance(output_data, dict):
-        # Structured output — display as key/value pairs
-        max_key = max((len(str(k)) for k in output_data), default=0)
-        for k, v in output_data.items():
+    if r['output_data']:
+        max_key = max((len(str(k)) for k in r['output_data']), default=0)
+        for k, v in r['output_data'].items():
             menu.console.print(f"  {str(k):<{max_key}}  {v}")
     else:
-        # Fall back to summary fields
-        if task.get('result'):
-            menu.console.print(f"  Result: {task['result']}")
-
-        if cmd:
-            menu.console.print(f"  Success:   {cmd.get('success', 'N/A')}")
-            menu.console.print(f"  Exit code: {cmd.get('exit_code', 'N/A')}")
-
-        if output_str:
+        if r['result']:
+            menu.console.print(f"  Result: {r['result']}")
+        if r['success'] is not None or r['exit_code'] is not None:
+            menu.console.print(f"  Success:   {r['success'] or 'N/A'}")
+            menu.console.print(f"  Exit code: {r['exit_code'] or 'N/A'}")
+        if r['output_raw']:
             menu.console.print(f"\n  [{colors['dim']}]--- Output ---[/{colors['dim']}]")
-            for line in output_str.splitlines():
+            for line in r['output_raw'].splitlines():
                 menu.console.print(f"  {line}")
 
-    if cmd.get('error_output'):
+    if r['error_output']:
         menu.console.print(f"\n  [{colors['error']}]--- Error Output ---[/{colors['error']}]")
-        for line in cmd['error_output'].splitlines():
+        for line in r['error_output'].splitlines():
             menu.console.print(f"  {line}")
-    if cmd.get('error_message'):
-        menu.console.print(f"  [{colors['error']}]Error: {cmd['error_message']}[/{colors['error']}]")
+    if r['command_error']:
+        menu.console.print(f"  [{colors['error']}]Error: {r['command_error']}[/{colors['error']}]")
 
 
 def _poll_task(menu, task_id, colors, timeout=120):
     """Poll a management task until it completes or times out."""
-    start = time.monotonic()
-    deadline = start + timeout
-    poll_count = 0
-
     spinner = Spinner("dots", text=Text("  Waiting for agent to execute task...", style=colors['dim']))
+
+    def _on_status(elapsed, message, retrying):
+        suffix = f" ({elapsed}s, retrying)" if retrying else f" ({elapsed}s)"
+        spinner.update(text=Text(f"  {message}{suffix}", style=colors['dim']))
 
     try:
         with Live(spinner, console=menu.console, refresh_per_second=10, transient=True):
-            while time.monotonic() < deadline:
-                time.sleep(5)
-                poll_count += 1
-                elapsed = int(time.monotonic() - start)
-
-                try:
-                    task = menu.sdk.aegis.get_management_task(task_id)
-                except Exception:
-                    spinner.update(text=Text(f"  Waiting for agent... ({elapsed}s, retrying)", style=colors['dim']))
-                    continue
-
-                current_status = task.get('status', '')
-
-                if current_status in ('AMT_COMPLETED', 'AMT_FAILED'):
-                    break
-
-                spinner.update(text=Text(f"  Running on agent... ({elapsed}s)", style=colors['dim']))
-            else:
-                menu.console.print(f"  [{colors['warning']}]Timed out after {timeout}s — task may still be running[/{colors['warning']}]")
-                return
+            task = menu.sdk.aegis.poll_management_task(
+                task_id, timeout=timeout, on_status=_on_status,
+            )
     except KeyboardInterrupt:
         menu.console.print(f"\n  [{colors['dim']}]Interrupted — task may still be running in background[/{colors['dim']}]")
         return
 
-    _print_task_result(menu, task, colors)
+    if task:
+        _print_task_result(menu, task, colors)
+    else:
+        menu.console.print(f"  [{colors['warning']}]Timed out after {timeout}s — task may still be running[/{colors['warning']}]")

--- a/praetorian_cli/ui/aegis/commands/help.py
+++ b/praetorian_cli/ui/aegis/commands/help.py
@@ -9,7 +9,7 @@ from ..constants import DEFAULT_COLORS
 def handle_help(menu, args):
     """Show help for commands or a specific command."""
     colors = getattr(menu, 'colors', DEFAULT_COLORS)
-    if args and args[0] in ['ssh', 'cp', 'list', 'info', 'job', 'schedule', 'set', 'proxy']:
+    if args and args[0] in ['ssh', 'cp', 'list', 'info', 'job', 'schedule', 'set', 'proxy', 'cred-auth']:
         menu.console.print(f"\nHelp for '{args[0]}' command - see main help for details\n")
         menu.pause()
         return
@@ -35,12 +35,17 @@ def handle_help(menu, args):
     commands_table.add_row("job list", "List recent jobs for selected agent")
     commands_table.add_row("job capabilities [--details]", "List available capabilities")
     commands_table.add_row("job run <capability>", "Run capability on selected agent")
+    commands_table.add_row("job status [job_key]", "Check job status (defaults to last job)")
+    commands_table.add_row("job artifacts [--save]", "List/download job artifacts")
     commands_table.add_row("schedule list", "List scheduled jobs")
     commands_table.add_row("schedule add", "Create a new scheduled job")
     commands_table.add_row("schedule view <id>", "View schedule details")
     commands_table.add_row("schedule edit <id>", "Edit a schedule")
     commands_table.add_row("schedule delete <id>", "Delete a schedule")
     commands_table.add_row("schedule pause/resume <id>", "Pause or resume a schedule")
+    commands_table.add_row("cred-auth", "Authenticate AD credentials (waits for result)")
+    commands_table.add_row("cred-auth <uuid>", "Authenticate with a specific credential UUID")
+    commands_table.add_row("cred-auth --no-wait", "Submit auth task without waiting")
     commands_table.add_row("proxy <port>", "Start SOCKS proxy on localhost:<port>")
     commands_table.add_row("proxy list", "Show active proxies")
     commands_table.add_row("proxy stop <port|all>", "Stop a proxy or all proxies")
@@ -76,11 +81,15 @@ def handle_help(menu, args):
     examples_table.add_row("job list", "List recent jobs")
     examples_table.add_row("job capabilities", "List available capabilities")
     examples_table.add_row("job caps --details", "Show full capability descriptions")
-    examples_table.add_row("job run windows-enum", "Run capability on selected agent")
+    examples_table.add_row("job run linux-network-nmap", "Run capability on selected agent")
+    examples_table.add_row("job status", "Check status of last submitted job")
+    examples_table.add_row("job artifacts --save", "Download artifacts for last job")
     examples_table.add_row("schedule list", "List all scheduled jobs")
     examples_table.add_row("schedule add", "Create a new scheduled job")
     examples_table.add_row("schedule view abc123", "View schedule details")
     examples_table.add_row("schedule pause abc123", "Pause a scheduled job")
+    examples_table.add_row("cred-auth", "Pick a credential and authenticate (waits)")
+    examples_table.add_row("cred-auth --no-wait", "Submit auth without waiting for result")
     examples_table.add_row("proxy 1080", "Start SOCKS proxy on port 1080")
     examples_table.add_row("proxy list", "Show active proxies with uptime")
     examples_table.add_row("proxy stop 1080", "Stop proxy on port 1080")

--- a/praetorian_cli/ui/aegis/commands/job.py
+++ b/praetorian_cli/ui/aegis/commands/job.py
@@ -1,4 +1,5 @@
 import json
+import os
 from rich.table import Table
 from rich.box import MINIMAL
 from rich.prompt import Prompt, Confirm
@@ -8,6 +9,7 @@ from .job_helpers import (
     interactive_capability_picker as _interactive_capability_picker,
     select_domain as _select_domain,
     select_credentials as _select_credentials,
+    select_target as _select_target,
     configure_parameters as _configure_parameters,
     capability_needs_credentials as _capability_needs_credentials,
     resolve_addomain_target_key,
@@ -15,7 +17,7 @@ from .job_helpers import (
 
 
 def handle_job(menu, args):
-    """Handle job command with subcommands: list, run, capabilities."""
+    """Handle job command with subcommands: list, run, status, artifacts, capabilities."""
     if not args:
         show_job_help(menu)
         return
@@ -25,6 +27,10 @@ def handle_job(menu, args):
         list_jobs(menu)
     elif subcommand == 'run':
         run_job(menu, args[1:])
+    elif subcommand in ['status', 'check']:
+        check_job_status(menu, args[1:])
+    elif subcommand in ['artifacts', 'files', 'results']:
+        show_job_artifacts(menu, args[1:])
     elif subcommand in ['capabilities', 'caps']:
         list_capabilities(menu, args[1:])
     else:
@@ -38,15 +44,21 @@ def show_job_help(menu):
 
   job list                  List recent jobs for selected agent
   job run [capability]      Run a capability on selected agent (interactive picker)
+  job status [job_key]      Check status of a job (defaults to last submitted job)
+  job artifacts [job_key]   List and download artifacts for a job
   job capabilities          List available capabilities (alias: caps)
                            [--details] Show full descriptions
-  
+
+  Aliases: status=check, artifacts=files=results
+
   Examples:
     job list                 # List recent jobs
-    job capabilities         # List capabilities with brief descriptions
-    job caps --details       # List capabilities with full descriptions  
     job run                  # Interactive capability picker
-    job run windows-enum     # Run specific capability with confirmation
+    job run linux-network-nmap  # Run specific capability
+    job status               # Check last submitted job
+    job status #job#1.2.3.4#1.2.3.4#linux-network-nmap
+    job artifacts            # List artifacts for last job
+    job artifacts --save     # Download artifacts to current directory
 """
     menu.console.print(help_text)
     menu.pause()
@@ -154,9 +166,10 @@ def run_job(menu, args):
 
         target_display = f"domain {domain}"
     else:
-        target_key = f"#asset#{hostname}#{hostname}"
-        target_display = f"asset {hostname}"
-    
+        target_key, target_display = _select_target(menu)
+        if not target_key:
+            return  # User cancelled
+
     # Handle credentials for capabilities that need them
     credentials = []
     credential_display_name = None
@@ -201,12 +214,15 @@ def run_job(menu, args):
 
         # Add job using SDK with credential UUIDs (API retrieves values server-side)
         jobs = menu.sdk.jobs.add(target_key, [capability], config_json, credentials=credentials)
-        
+
         if jobs:
             job = jobs[0] if isinstance(jobs, list) else jobs
             job_key = job.get('key', '')
             status = job.get('status', 'unknown')
             job_id = job_key.split('#')[-1] if job_key else 'unknown'
+
+            # Store for quick access via 'job status' / 'job artifacts'
+            menu._last_job_key = job_key
 
             menu.console.print(f"\n[{colors['success']}]✓ Job queued successfully[/{colors['success']}]")
             menu.console.print(f"  Job ID: {job_id}")
@@ -216,14 +232,235 @@ def run_job(menu, args):
             menu.console.print(f"  Status: {status}")
             if credentials and credential_display_name:
                 menu.console.print(f"  Credential: {credential_display_name}")
+            menu.console.print(f"\n  [{colors['dim']}]Tip: use 'job status' to check progress, 'job artifacts' for results[/{colors['dim']}]")
         else:
             menu.console.print(f"\n[{colors['error']}]Error: No job returned from API[/{colors['error']}]")
-            
+
     except Exception as e:
         menu.console.print(f"\n[{colors['error']}]Job execution error: {e}[/{colors['error']}]")
-    
+
     menu.console.print()
     menu.pause()
+
+
+def _resolve_job_key(menu, args):
+    """Resolve job key from args or last submitted job.
+
+    Returns the job key string, or None if unavailable.
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    if args:
+        # Join args in case the key was split by shell quoting
+        return ' '.join(args).strip()
+
+    # Fall back to last submitted job
+    last_key = getattr(menu, '_last_job_key', None)
+    if last_key:
+        menu.console.print(f"  [{colors['dim']}]Using last job: {last_key}[/{colors['dim']}]")
+        return last_key
+
+    menu.console.print(f"\n  [{colors['error']}]No job key specified and no recent job available.[/{colors['error']}]")
+    menu.console.print(f"  [{colors['dim']}]Usage: job status <job_key>[/{colors['dim']}]")
+    menu.console.print(f"  [{colors['dim']}]Or run a job first with 'job run'[/{colors['dim']}]")
+    menu.pause()
+    return None
+
+
+def check_job_status(menu, args):
+    """Check the status of a specific job."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    # Strip --save or other flags from args for key resolution
+    clean_args = [a for a in args if not a.startswith('--')]
+    job_key = _resolve_job_key(menu, clean_args)
+    if not job_key:
+        return
+
+    try:
+        job = menu.sdk.jobs.get(job_key)
+
+        if not job:
+            menu.console.print(f"\n  [{colors['error']}]Job not found: {job_key}[/{colors['error']}]")
+            menu.pause()
+            return
+
+        status = job.get('status', 'unknown')
+        capabilities = job.get('capabilities', [])
+        capability = capabilities[0] if capabilities else 'unknown'
+        created = job.get('created', 0)
+        updated = job.get('updated', 0)
+        dns = job.get('dns', '')
+        config = job.get('config', {})
+
+        menu.console.print()
+        menu.console.print(f"  Job Details")
+        menu.console.print()
+
+        # Status with color
+        status_display = format_job_status(status, colors)
+        menu.console.print(f"  Status:      ", end="")
+        menu.console.print(status_display)
+        menu.console.print(f"  Raw Status:  {status}")
+        menu.console.print(f"  Capability:  {capability}")
+        menu.console.print(f"  Target:      {dns}")
+        menu.console.print(f"  Job Key:     {job_key}")
+        menu.console.print(f"  Created:     {format_timestamp(created, '%Y-%m-%d %H:%M:%S')}")
+        if updated:
+            menu.console.print(f"  Updated:     {format_timestamp(updated, '%Y-%m-%d %H:%M:%S')}")
+
+        # Show config if present (minus sensitive fields)
+        if config and isinstance(config, dict):
+            display_config = {k: v for k, v in config.items()
+                              if k.lower() not in ('password', 'secret', 'token')}
+            if display_config:
+                menu.console.print(f"\n  Configuration:")
+                for k, v in display_config.items():
+                    menu.console.print(f"    {k}: {v}")
+
+        menu.console.print()
+        menu.pause()
+
+    except Exception as e:
+        menu.console.print(f"\n  [{colors['error']}]Error checking job: {e}[/{colors['error']}]")
+        menu.pause()
+
+
+def show_job_artifacts(menu, args):
+    """List and optionally download artifacts for a job."""
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+
+    save_mode = '--save' in args or '-s' in args
+    clean_args = [a for a in args if not a.startswith('-')]
+    job_key = _resolve_job_key(menu, clean_args)
+    if not job_key:
+        return
+
+    try:
+        # First check the job exists and get its details
+        job = menu.sdk.jobs.get(job_key)
+        if not job:
+            menu.console.print(f"\n  [{colors['error']}]Job not found: {job_key}[/{colors['error']}]")
+            menu.pause()
+            return
+
+        status = job.get('status', 'unknown')
+        status_display = format_job_status(status, colors)
+        capabilities = job.get('capabilities', [])
+        capability = capabilities[0] if capabilities else 'unknown'
+        dns = job.get('dns', '')
+
+        menu.console.print()
+        menu.console.print(f"  Job: {capability} -> {dns}  ", end="")
+        menu.console.print(status_display)
+
+        if status.upper().startswith('JQ') or status.upper().startswith('JR'):
+            menu.console.print(f"\n  [{colors['warning']}]Job is still {'queued' if status.upper().startswith('JQ') else 'running'} — artifacts may not be available yet.[/{colors['warning']}]")
+
+        # Search for files related to this job
+        # Files are typically stored with patterns based on the target/capability
+        # Try multiple search patterns
+        search_prefixes = []
+
+        # Pattern: capability name in file path
+        if capability and capability != 'unknown':
+            search_prefixes.append(capability)
+        # Pattern: target DNS
+        if dns:
+            search_prefixes.append(dns)
+
+        all_files = []
+        seen_keys = set()
+
+        for prefix in search_prefixes:
+            try:
+                files, _ = menu.sdk.files.list(prefix_filter=prefix)
+                if files:
+                    for f in files:
+                        fkey = f.get('key', '')
+                        if fkey not in seen_keys:
+                            seen_keys.add(fkey)
+                            all_files.append(f)
+            except Exception:
+                pass
+
+        # Also try listing with no filter and matching on job key components
+        if not all_files:
+            try:
+                # Try a broader search using the job key parts
+                key_parts = job_key.replace('#job#', '').split('#')
+                for part in key_parts:
+                    if part and part not in search_prefixes:
+                        files, _ = menu.sdk.files.list(prefix_filter=part)
+                        if files:
+                            for f in files:
+                                fkey = f.get('key', '')
+                                if fkey not in seen_keys:
+                                    seen_keys.add(fkey)
+                                    all_files.append(f)
+            except Exception:
+                pass
+
+        if not all_files:
+            menu.console.print(f"\n  [{colors['dim']}]No artifacts found for this job.[/{colors['dim']}]")
+            if status.upper().startswith('JQ') or status.upper().startswith('JR'):
+                menu.console.print(f"  [{colors['dim']}]The job is still in progress — check again later.[/{colors['dim']}]")
+            menu.console.print()
+            menu.pause()
+            return
+
+        # Display artifacts table
+        artifacts_table = Table(
+            show_header=True,
+            header_style=f"bold {colors['primary']}",
+            border_style=colors['dim'],
+            box=MINIMAL,
+            show_lines=False,
+            padding=(0, 2),
+            pad_edge=False
+        )
+
+        artifacts_table.add_column("#", style=f"{colors['dim']}", width=4, justify="right")
+        artifacts_table.add_column("FILE", style=f"bold {colors['accent']}", no_wrap=False)
+        artifacts_table.add_column("CREATED", style=f"{colors['dim']}", width=18, justify="right")
+
+        for i, f in enumerate(all_files, 1):
+            fkey = f.get('key', '')
+            # Strip #file# prefix for display
+            display_name = fkey.replace('#file#', '') if fkey.startswith('#file#') else fkey
+            created = f.get('created', 0)
+            created_str = format_timestamp(created, '%Y-%m-%d %H:%M')
+            artifacts_table.add_row(str(i), display_name, created_str)
+
+        menu.console.print(f"\n  Artifacts ({len(all_files)} files)")
+        menu.console.print()
+        menu.console.print(artifacts_table)
+
+        if save_mode:
+            # Download all artifacts
+            download_dir = os.path.join(os.getcwd(), f"job-artifacts-{capability}")
+            menu.console.print(f"\n  [{colors['dim']}]Downloading to {download_dir}...[/{colors['dim']}]")
+            os.makedirs(download_dir, exist_ok=True)
+
+            for f in all_files:
+                fkey = f.get('key', '')
+                filepath = fkey.replace('#file#', '') if fkey.startswith('#file#') else fkey
+                try:
+                    local_path = menu.sdk.files.save(filepath, download_dir)
+                    menu.console.print(f"  [{colors['success']}]✓ {os.path.basename(local_path)}[/{colors['success']}]")
+                except Exception as e:
+                    menu.console.print(f"  [{colors['error']}]✗ {filepath}: {e}[/{colors['error']}]")
+
+            menu.console.print(f"\n  [{colors['success']}]Downloaded to {download_dir}[/{colors['success']}]")
+        else:
+            menu.console.print(f"\n  [{colors['dim']}]Use 'job artifacts --save' to download files[/{colors['dim']}]")
+
+        menu.console.print()
+        menu.pause()
+
+    except Exception as e:
+        menu.console.print(f"\n  [{colors['error']}]Error fetching artifacts: {e}[/{colors['error']}]")
+        menu.pause()
 
 
 def list_capabilities(menu, args):
@@ -282,7 +519,7 @@ def list_capabilities(menu, args):
 
 
 def complete(menu, text, tokens):
-    sub = ['list', 'run', 'capabilities', 'caps']
+    sub = ['list', 'run', 'status', 'check', 'artifacts', 'files', 'results', 'capabilities', 'caps']
     if len(tokens) <= 2:
         return [s for s in sub if s.startswith(text)]
     # Could extend to capability names later

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -322,6 +322,33 @@ def configure_parameters(menu, capability_info, has_credential=False):
     return configured
 
 
+def select_target(menu):
+    """Interactive target selection for asset-type capabilities.
+
+    Prompts the user to enter a target hostname/IP or choose the agent itself.
+    Returns (target_key, target_display) or (None, None) if cancelled.
+    """
+    colors = getattr(menu, 'colors', DEFAULT_COLORS)
+    hostname = menu.selected_agent.hostname or 'Unknown'
+
+    menu.console.print(f"\n  [{colors['dim']}]Enter target to scan (hostname, IP, or CIDR)[/{colors['dim']}]")
+    menu.console.print(f"  [{colors['dim']}]Press Enter to use the agent itself ({hostname})[/{colors['dim']}]")
+
+    try:
+        target = Prompt.ask("  Target", default=hostname)
+    except KeyboardInterrupt:
+        menu.console.print("\n  Cancelled")
+        return None, None
+
+    target = target.strip()
+    if not target:
+        target = hostname
+
+    target_key = f"#asset#{target}#{target}"
+    target_display = f"asset {target}"
+    return target_key, target_display
+
+
 def resolve_addomain_target_key(menu, domain):
     """Query the assets API to resolve an AD domain to its actual asset key (with SID).
 

--- a/praetorian_cli/ui/aegis/menu.py
+++ b/praetorian_cli/ui/aegis/menu.py
@@ -45,6 +45,7 @@ from .commands.info import handle_info as cmd_handle_info
 from .commands.job import handle_job as cmd_handle_job
 from .commands.schedule import handle_schedule as cmd_handle_schedule
 from .commands.proxy import handle_proxy as cmd_handle_proxy, stop_all_proxies
+from .commands.cred_auth import handle_cred_auth as cmd_handle_cred_auth
 
 from .commands.schedule_helpers import get_cached_schedules
 from .constants import DEFAULT_COLORS
@@ -142,8 +143,16 @@ class MenuCompleter(Completer):
                     if opt.startswith(current_word):
                         yield Completion(opt, start_position=-len(current_word))
 
+        elif cmd == 'cred-auth':
+            options = ['--no-wait']
+            if not words or (len(words) == 1 and not after_cmd.endswith(' ')):
+                prefix = words[0] if words else ''
+                for opt in options:
+                    if opt.startswith(prefix):
+                        yield Completion(opt, start_position=-len(prefix))
+
         elif cmd == 'job':
-            subcommands = ['list', 'run', 'capabilities', 'caps']
+            subcommands = ['list', 'run', 'status', 'artifacts', 'capabilities', 'caps']
             if not words or (len(words) == 1 and not after_cmd.endswith(' ')):
                 prefix = words[0].lower() if words else ''
                 for sub in subcommands:
@@ -375,7 +384,7 @@ class AegisMenu:
         self._active_proxies: dict = {}
 
         self.commands = [
-            'set', 'ssh', 'cp', 'proxy', 'info', 'list', 'job', 'schedule', 'reload', 'clear', 'help', 'quit', 'exit'
+            'set', 'ssh', 'cp', 'proxy', 'info', 'list', 'job', 'schedule', 'cred-auth', 'reload', 'clear', 'help', 'quit', 'exit'
         ]
 
     def prefetch_agent_home(self, agent=None):
@@ -477,6 +486,9 @@ class AegisMenu:
 
         elif command == 'proxy':
             cmd_handle_proxy(self, cmd_args)
+
+        elif command == 'cred-auth':
+            cmd_handle_cred_auth(self, cmd_args)
 
         else:
             self.console.print(f"\n  Unknown command: {command}")


### PR DESCRIPTION
## Summary
- **Fix cred-auth polling**: `get_management_task` now uses the list endpoint as a workaround for a backend bug where the DynamoDB partition key overwrites the task `username` field, causing 404 errors under account assumption
- **Default to waiting**: `cred-auth` now waits for the result by default; use `--no-wait` to fire-and-forget
- **Better polling UX**: Animated spinner showing elapsed time (Rich `Live` in TUI, single-line overwrite in CLI)
- **Structured output display**: Parses `commandResult.output` as JSON when possible for clean key/value display
- **Job status/artifacts**: New `job status` and `job artifacts` subcommands in TUI with `--save` support
- **Ingest command**: New `guard aegis ingest` CLI command for pushing chariot_result.json into Guard
- **Interactive target selection**: Extracted `select_target` helper for asset-type capabilities
- **Bug fixes**: Added try/except in CLI polling loop, fixed `exitCode` → `exit_code` field name mismatch

## Test plan
- [ ] Run `cred-auth` in TUI — verify it waits by default with spinner, shows structured result
- [ ] Run `cred-auth --no-wait` in TUI — verify it returns immediately after submission
- [ ] Run `guard aegis cred-auth <client_id> <cred_id>` CLI — verify wait + spinner
- [ ] Run `guard aegis cred-auth <client_id> <cred_id> --no-wait` CLI — verify fire-and-forget
- [ ] Run `job status` / `job artifacts` in TUI after submitting a job
- [ ] Run `guard aegis ingest result.json --dry-run` — verify summary without API calls
- [ ] Verify tab completion suggests `--no-wait`, `job status`, `job artifacts`