### PR TITLE
fix: handle capability target field being a list in completer

### DIFF
--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -43,7 +43,10 @@ class CapabilityCompleter(Completer):
         for cap in self.capabilities:
             name = cap.get('name', '')
             name_lower = name.lower()
-            target = cap.get('target', 'asset').lower()
+            target = cap.get('target', 'asset')
+            if isinstance(target, list):
+                target = target[0] if target else 'asset'
+            target = str(target).lower()
             description = cap.get('description', '') or ''
             parsed = _parse_capability_name(name)
             category = parsed.get('category', '')


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'list' object has no attribute 'lower'` in the capability completer
- Some capabilities return `target` as a list instead of a string — extract the first element before calling `.lower()`

## Test plan
- [ ] Open aegis TUI, select an agent, and use the capability picker (job or schedule command)
- [ ] Verify no crash when capabilities with list-type `target` fields are present