### PR TITLE
feat: add guard export report command

### DIFF
--- a/praetorian_cli/handlers/export.py
+++ b/praetorian_cli/handlers/export.py
@@ -1,12 +1,9 @@
 import os
-from datetime import date
-from time import sleep, time
 
 import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import error
 
 
 @chariot.group()
@@ -70,79 +67,36 @@ def report(chariot, title, client_name, status_filter, risk_keys,
             --format zip --draft \\
             --status-filter O --status-filter T --status-filter R
     """
-    customer_email = chariot.keychain.account or chariot.keychain.username()
-    if not customer_email:
-        error('Could not determine customer email. Use --account or configure a username.')
+    customer_email = chariot.reports.customer_email()
 
-    if not report_date:
-        report_date = date.today().isoformat()
-
-    body = {
-        'status_filter': list(status_filter),
-        'config': {
-            'title': title,
-            'client_name': client_name,
-            'report_date': report_date,
-            'draft': draft,
-            'version': report_version,
-        },
-        'shared_output': shared,
-        'customer_email': customer_email,
-        'export_format': export_format,
-        'group_by': group_by,
-    }
-
-    if risk_keys:
-        body['risk_keys'] = list(risk_keys)
-    if target:
-        body['config']['target'] = target
-    if start_date:
-        body['config']['start_date'] = start_date
-    if end_date:
-        body['config']['end_date'] = end_date
-    if executive_summary:
-        body['executive_summary_path'] = executive_summary
-    if narratives:
-        body['narratives_path'] = narratives
-    if appendix:
-        body['appendix_path'] = appendix
+    body = chariot.reports.build_export_body(
+        title=title,
+        client_name=client_name,
+        customer_email=customer_email,
+        status_filter=status_filter,
+        risk_keys=risk_keys,
+        target=target,
+        start_date=start_date,
+        end_date=end_date,
+        report_date=report_date,
+        draft=draft,
+        version=report_version,
+        export_format=export_format,
+        group_by=group_by,
+        shared_output=shared,
+        executive_summary_path=executive_summary,
+        narratives_path=narratives,
+        appendix_path=appendix,
+    )
 
     click.echo(f'Starting {export_format.upper()} report generation for {customer_email}...')
-    resp = chariot.post('export/report', body)
-
-    job_key = resp.get('key')
-    if not job_key:
-        error('No job key returned from export/report endpoint.')
-
-    click.echo(f'Job queued: {job_key}')
-    click.echo(f'Polling for completion (timeout: {timeout}s)...')
-
-    start_time = time()
-    job = None
-    while time() - start_time < timeout:
-        job = chariot.jobs.get(job_key)
-        if chariot.jobs.is_failed(job):
-            message = job.get('message', 'unknown error')
-            error(f'Report generation failed: {message}')
-        if chariot.jobs.is_passed(job):
-            break
-        sleep(5)
-
-    if not job or not chariot.jobs.is_passed(job):
-        error(f'Report generation timed out after {timeout} seconds.')
-
+    job = chariot.reports.export(body, timeout=timeout)
     click.echo('Report generation complete.')
 
-    config = job.get('config', {})
-    output_path = config.get('output') or job.get('dns', '')
-
-    if not output_path:
-        error('Could not determine output file path from job.')
-
     if no_download:
-        click.echo(f'Output path: {output_path}')
+        click.echo(f'Output path: {chariot.reports.output_path(job)}')
         return
 
-    click.echo(f'Downloading {output_path}...')
-    local_path = chariot.files.save(output_path, output)
+    click.echo(f'Downloading {chariot.reports.output_path(job)}...')
+    local_path = chariot.reports.download(job, output)
     click.echo(f'Saved to {local_path}')

--- a/praetorian_cli/handlers/export.py
+++ b/praetorian_cli/handlers/export.py
@@ -1,0 +1,148 @@
+import os
+from datetime import date
+from time import sleep, time
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error
+
+
+@chariot.group()
+def export():
+    """ Export data from Guard """
+    pass
+
+
+@export.command()
+@cli_handler
+@click.option('--title', required=True, help='Report title')
+@click.option('--client-name', required=True, help='Client organization name')
+@click.option('--status-filter', multiple=True, default=('O', 'T'),
+              help='Risk status filter (repeatable). Default: O T')
+@click.option('--risk-keys', multiple=True, default=(),
+              help='Specific risk keys to include (repeatable). Default: all')
+@click.option('--target', default='', help='Target/scope (e.g., example.com)')
+@click.option('--start-date', default='', help='Engagement start date (ISO format)')
+@click.option('--end-date', default='', help='Engagement end date (ISO format)')
+@click.option('--report-date', default='', help='Report date (ISO format). Default: today')
+@click.option('--draft/--no-draft', default=False, help='Add DRAFT watermark')
+@click.option('--version', 'report_version', default='1.0', help='Report version string')
+@click.option('--format', 'export_format', type=click.Choice(['pdf', 'zip']),
+              default='pdf', help='Export format')
+@click.option('--group-by', type=click.Choice(['attack_surface', 'tag']),
+              default='attack_surface', help='Finding grouping strategy')
+@click.option('--shared/--no-shared', default=False,
+              help='Copy report to customer shared files')
+@click.option('--executive-summary', default='',
+              help='Path to executive summary .md file in Guard storage')
+@click.option('--narratives', default='',
+              help='Path to narratives .md file in Guard storage')
+@click.option('--appendix', default='',
+              help='Path to appendix .md file in Guard storage')
+@click.option('--output', '-o', default=os.getcwd(),
+              help='Local directory to save the downloaded report')
+@click.option('--timeout', default=300, type=int,
+              help='Max seconds to wait for report generation. Default: 300')
+@click.option('--no-download', is_flag=True, default=False,
+              help='Skip downloading the file; just print the job result')
+def report(chariot, title, client_name, status_filter, risk_keys,
+           target, start_date, end_date, report_date, draft,
+           report_version, export_format, group_by, shared,
+           executive_summary, narratives, appendix, output,
+           timeout, no_download):
+    """ Generate and download a PDF or ZIP report.
+
+    Requires Praetorian engineer access. Initiates report generation,
+    polls until the job completes, then downloads the file.
+
+    The customer email is derived automatically from --account (the customer
+    you are viewing) or the logged-in user's email.
+
+    \b
+    Example usages:
+        guard --account customer@acme.com export report \\
+            --title "Pentest Report" --client-name "Acme"
+
+        guard --account customer@acme.com export report \\
+            --title "Q1 Assessment" --client-name "Acme" \\
+            --format zip --draft \\
+            --status-filter O --status-filter T --status-filter R
+    """
+    customer_email = chariot.keychain.account or chariot.keychain.username()
+    if not customer_email:
+        error('Could not determine customer email. Use --account or configure a username.')
+
+    if not report_date:
+        report_date = date.today().isoformat()
+
+    body = {
+        'status_filter': list(status_filter),
+        'config': {
+            'title': title,
+            'client_name': client_name,
+            'report_date': report_date,
+            'draft': draft,
+            'version': report_version,
+        },
+        'shared_output': shared,
+        'customer_email': customer_email,
+        'export_format': export_format,
+        'group_by': group_by,
+    }
+
+    if risk_keys:
+        body['risk_keys'] = list(risk_keys)
+    if target:
+        body['config']['target'] = target
+    if start_date:
+        body['config']['start_date'] = start_date
+    if end_date:
+        body['config']['end_date'] = end_date
+    if executive_summary:
+        body['executive_summary_path'] = executive_summary
+    if narratives:
+        body['narratives_path'] = narratives
+    if appendix:
+        body['appendix_path'] = appendix
+
+    click.echo(f'Starting {export_format.upper()} report generation for {customer_email}...')
+    resp = chariot.post('export/report', body)
+
+    job_key = resp.get('key')
+    if not job_key:
+        error('No job key returned from export/report endpoint.')
+
+    click.echo(f'Job queued: {job_key}')
+    click.echo(f'Polling for completion (timeout: {timeout}s)...')
+
+    start_time = time()
+    job = None
+    while time() - start_time < timeout:
+        job = chariot.jobs.get(job_key)
+        if chariot.jobs.is_failed(job):
+            message = job.get('message', 'unknown error')
+            error(f'Report generation failed: {message}')
+        if chariot.jobs.is_passed(job):
+            break
+        sleep(5)
+
+    if not job or not chariot.jobs.is_passed(job):
+        error(f'Report generation timed out after {timeout} seconds.')
+
+    click.echo('Report generation complete.')
+
+    config = job.get('config', {})
+    output_path = config.get('output') or job.get('dns', '')
+
+    if not output_path:
+        error('Could not determine output file path from job.')
+
+    if no_download:
+        click.echo(f'Output path: {output_path}')
+        return
+
+    click.echo(f'Downloading {output_path}...')
+    local_path = chariot.files.save(output_path, output)
+    click.echo(f'Saved to {local_path}')

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -5,6 +5,7 @@ import praetorian_cli.handlers.aegis
 import praetorian_cli.handlers.agent
 import praetorian_cli.handlers.delete
 import praetorian_cli.handlers.enrich
+import praetorian_cli.handlers.export
 import praetorian_cli.handlers.get
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.link

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -15,6 +15,7 @@ from praetorian_cli.sdk.entities.integrations import Integrations
 from praetorian_cli.sdk.entities.jobs import Jobs
 from praetorian_cli.sdk.entities.keys import Keys
 from praetorian_cli.sdk.entities.preseeds import Preseeds
+from praetorian_cli.sdk.entities.reports import Reports
 from praetorian_cli.sdk.entities.risks import Risks
 from praetorian_cli.sdk.entities.scanners import Scanners
 from praetorian_cli.sdk.entities.schedules import Schedules
@@ -37,6 +38,7 @@ class Chariot:
         self.assets = Assets(self)
         self.seeds = Seeds(self)
         self.preseeds = Preseeds(self)
+        self.reports = Reports(self)
         self.risks = Risks(self)
         self.accounts = Accounts(self)
         self.integrations = Integrations(self)

--- a/praetorian_cli/sdk/entities/reports.py
+++ b/praetorian_cli/sdk/entities/reports.py
@@ -1,0 +1,194 @@
+from datetime import date
+from time import sleep, time
+
+
+class Reports:
+    """ The methods in this class are to be accessed from sdk.reports, where sdk
+    is an instance of Chariot. """
+
+    POLL_INTERVAL = 5
+    DEFAULT_TIMEOUT = 300
+
+    def __init__(self, api):
+        self.api = api
+
+    def customer_email(self):
+        """
+        Derive the customer email from the current SDK context.
+
+        Uses the --account (assumed account) if set, otherwise falls back
+        to the logged-in user's email. This mirrors the frontend logic of
+        ``friend || me``.
+
+        :return: The customer email address
+        :rtype: str
+        :raises Exception: If no customer email can be determined
+        """
+        email = self.api.keychain.account or self.api.keychain.username()
+        if not email:
+            raise Exception(
+                'Could not determine customer email. '
+                'Use --account or configure a username.'
+            )
+        return email
+
+    def build_export_body(self, title, client_name, customer_email,
+                          status_filter=('O', 'T'), risk_keys=(),
+                          target='', start_date='', end_date='',
+                          report_date='', draft=False, version='1.0',
+                          export_format='pdf', group_by='attack_surface',
+                          shared_output=False, executive_summary_path='',
+                          narratives_path='', appendix_path=''):
+        """
+        Build the request body for POST /export/report.
+
+        :param title: Report title
+        :type title: str
+        :param client_name: Client organization name
+        :type client_name: str
+        :param customer_email: Customer email address
+        :type customer_email: str
+        :param status_filter: Risk status codes to include
+        :type status_filter: tuple or list
+        :param risk_keys: Specific risk keys to include (empty for all)
+        :type risk_keys: tuple or list
+        :param target: Target/scope
+        :type target: str
+        :param start_date: Engagement start date (ISO format)
+        :type start_date: str
+        :param end_date: Engagement end date (ISO format)
+        :type end_date: str
+        :param report_date: Report date (ISO format). Defaults to today.
+        :type report_date: str
+        :param draft: Whether to add DRAFT watermark
+        :type draft: bool
+        :param version: Report version string
+        :type version: str
+        :param export_format: Output format ('pdf' or 'zip')
+        :type export_format: str
+        :param group_by: Finding grouping strategy ('attack_surface' or 'tag')
+        :type group_by: str
+        :param shared_output: Whether to copy to customer shared files
+        :type shared_output: bool
+        :param executive_summary_path: Path to executive summary .md in Guard storage
+        :type executive_summary_path: str
+        :param narratives_path: Path to narratives .md in Guard storage
+        :type narratives_path: str
+        :param appendix_path: Path to appendix .md in Guard storage
+        :type appendix_path: str
+        :return: Request body dict ready for POST /export/report
+        :rtype: dict
+        """
+        if not report_date:
+            report_date = date.today().isoformat()
+
+        body = {
+            'status_filter': list(status_filter),
+            'config': {
+                'title': title,
+                'client_name': client_name,
+                'report_date': report_date,
+                'draft': draft,
+                'version': version,
+            },
+            'shared_output': shared_output,
+            'customer_email': customer_email,
+            'export_format': export_format,
+            'group_by': group_by,
+        }
+
+        if risk_keys:
+            body['risk_keys'] = list(risk_keys)
+        if target:
+            body['config']['target'] = target
+        if start_date:
+            body['config']['start_date'] = start_date
+        if end_date:
+            body['config']['end_date'] = end_date
+        if executive_summary_path:
+            body['executive_summary_path'] = executive_summary_path
+        if narratives_path:
+            body['narratives_path'] = narratives_path
+        if appendix_path:
+            body['appendix_path'] = appendix_path
+
+        return body
+
+    def export(self, body, timeout=DEFAULT_TIMEOUT, poll_interval=POLL_INTERVAL):
+        """
+        Start a report export job, poll until completion, and return the job.
+
+        :param body: Request body from build_export_body()
+        :type body: dict
+        :param timeout: Max seconds to wait for completion
+        :type timeout: int
+        :param poll_interval: Seconds between status polls
+        :type poll_interval: int
+        :return: The completed job dict
+        :rtype: dict
+        :raises Exception: If the job fails, times out, or no job key is returned
+        """
+        resp = self.api.post('export/report', body)
+
+        job_key = resp.get('key')
+        if not job_key:
+            raise Exception('No job key returned from export/report endpoint.')
+
+        return self.poll_job(job_key, timeout, poll_interval)
+
+    def poll_job(self, job_key, timeout=DEFAULT_TIMEOUT, poll_interval=POLL_INTERVAL):
+        """
+        Poll a report generation job until it passes, fails, or times out.
+
+        :param job_key: The job key to poll
+        :type job_key: str
+        :param timeout: Max seconds to wait
+        :type timeout: int
+        :param poll_interval: Seconds between polls
+        :type poll_interval: int
+        :return: The completed job dict
+        :rtype: dict
+        :raises Exception: If the job fails or times out
+        """
+        start_time = time()
+        job = None
+        while time() - start_time < timeout:
+            job = self.api.jobs.get(job_key)
+            if self.api.jobs.is_failed(job):
+                message = job.get('message', 'unknown error')
+                raise Exception(f'Report generation failed: {message}')
+            if self.api.jobs.is_passed(job):
+                return job
+            sleep(poll_interval)
+
+        raise Exception(f'Report generation timed out after {timeout} seconds.')
+
+    def output_path(self, job):
+        """
+        Extract the output file path from a completed report job.
+
+        :param job: The completed job dict
+        :type job: dict
+        :return: The output file path in Guard storage
+        :rtype: str
+        :raises Exception: If the output path cannot be determined
+        """
+        config = job.get('config', {})
+        path = config.get('output') or job.get('dns', '')
+        if not path:
+            raise Exception('Could not determine output file path from job.')
+        return path
+
+    def download(self, job, download_directory):
+        """
+        Download the report file from a completed job to a local directory.
+
+        :param job: The completed job dict
+        :type job: dict
+        :param download_directory: Local directory to save the file
+        :type download_directory: str
+        :return: The local file path where the report was saved
+        :rtype: str
+        """
+        path = self.output_path(job)
+        return self.api.files.save(path, download_directory)

--- a/praetorian_cli/sdk/test/test_report.py
+++ b/praetorian_cli/sdk/test/test_report.py
@@ -1,0 +1,242 @@
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praetorian_cli.sdk.entities.reports import Reports
+
+
+def make_reports(account=None, username=None):
+    """Create a Reports instance with a mocked API."""
+    api = MagicMock()
+    api.keychain.account = account
+    api.keychain.username.return_value = username
+    return Reports(api), api
+
+
+class TestCustomerEmail:
+
+    def test_uses_account_when_set(self):
+        reports, _ = make_reports(account='customer@acme.com', username='engineer@praetorian.com')
+        assert reports.customer_email() == 'customer@acme.com'
+
+    def test_falls_back_to_username(self):
+        reports, _ = make_reports(account=None, username='engineer@praetorian.com')
+        assert reports.customer_email() == 'engineer@praetorian.com'
+
+    def test_raises_when_neither_set(self):
+        reports, _ = make_reports(account=None, username=None)
+        with pytest.raises(Exception, match='Could not determine customer email'):
+            reports.customer_email()
+
+    def test_prefers_account_over_username(self):
+        reports, _ = make_reports(account='customer@acme.com', username='me@praetorian.com')
+        assert reports.customer_email() == 'customer@acme.com'
+
+
+class TestBuildExportBody:
+
+    def test_minimal_body(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Test Report',
+            client_name='Acme Corp',
+            customer_email='customer@acme.com',
+        )
+
+        assert body['config']['title'] == 'Test Report'
+        assert body['config']['client_name'] == 'Acme Corp'
+        assert body['customer_email'] == 'customer@acme.com'
+        assert body['status_filter'] == ['O', 'T']
+        assert body['export_format'] == 'pdf'
+        assert body['group_by'] == 'attack_surface'
+        assert body['shared_output'] is False
+        assert body['config']['draft'] is False
+        assert body['config']['version'] == '1.0'
+        assert 'risk_keys' not in body
+        assert 'target' not in body['config']
+        assert 'executive_summary_path' not in body
+
+    def test_defaults_report_date_to_today(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Test', client_name='Test', customer_email='test@test.com',
+        )
+        assert body['config']['report_date'] == date.today().isoformat()
+
+    def test_explicit_report_date(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Test', client_name='Test', customer_email='test@test.com',
+            report_date='2026-01-15',
+        )
+        assert body['config']['report_date'] == '2026-01-15'
+
+    def test_all_optional_fields(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Full Report',
+            client_name='Acme',
+            customer_email='customer@acme.com',
+            status_filter=['O', 'T', 'R'],
+            risk_keys=['#risk#example.com#sqli', '#risk#example.com#xss'],
+            target='example.com',
+            start_date='2026-01-01',
+            end_date='2026-03-01',
+            report_date='2026-03-15',
+            draft=True,
+            version='2.0',
+            export_format='zip',
+            group_by='tag',
+            shared_output=True,
+            executive_summary_path='home/exec-summary.md',
+            narratives_path='home/narratives.md',
+            appendix_path='home/appendix.md',
+        )
+
+        assert body['risk_keys'] == ['#risk#example.com#sqli', '#risk#example.com#xss']
+        assert body['config']['target'] == 'example.com'
+        assert body['config']['start_date'] == '2026-01-01'
+        assert body['config']['end_date'] == '2026-03-01'
+        assert body['config']['draft'] is True
+        assert body['config']['version'] == '2.0'
+        assert body['export_format'] == 'zip'
+        assert body['group_by'] == 'tag'
+        assert body['shared_output'] is True
+        assert body['executive_summary_path'] == 'home/exec-summary.md'
+        assert body['narratives_path'] == 'home/narratives.md'
+        assert body['appendix_path'] == 'home/appendix.md'
+
+    def test_status_filter_converts_tuple_to_list(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Test', client_name='Test', customer_email='test@test.com',
+            status_filter=('O', 'T', 'R'),
+        )
+        assert body['status_filter'] == ['O', 'T', 'R']
+        assert isinstance(body['status_filter'], list)
+
+    def test_empty_optional_strings_excluded(self):
+        reports, _ = make_reports()
+        body = reports.build_export_body(
+            title='Test', client_name='Test', customer_email='test@test.com',
+            target='', executive_summary_path='', narratives_path='', appendix_path='',
+        )
+        assert 'target' not in body['config']
+        assert 'executive_summary_path' not in body
+        assert 'narratives_path' not in body
+        assert 'appendix_path' not in body
+
+
+class TestExport:
+
+    def test_success(self):
+        reports, api = make_reports()
+        api.post.return_value = {'key': '#job#report#123'}
+        api.jobs.get.return_value = {'status': 'JP', 'config': {'output': 'home/report.pdf'}}
+        api.jobs.is_passed.return_value = True
+        api.jobs.is_failed.return_value = False
+
+        job = reports.export({'customer_email': 'test@test.com'}, timeout=10, poll_interval=0)
+
+        api.post.assert_called_once_with('export/report', {'customer_email': 'test@test.com'})
+        assert job['config']['output'] == 'home/report.pdf'
+
+    def test_raises_on_missing_job_key(self):
+        reports, api = make_reports()
+        api.post.return_value = {}
+
+        with pytest.raises(Exception, match='No job key returned'):
+            reports.export({})
+
+    def test_raises_on_failure(self):
+        reports, api = make_reports()
+        api.post.return_value = {'key': '#job#report#123'}
+        api.jobs.get.return_value = {'status': 'JF', 'message': 'missing definitions'}
+        api.jobs.is_failed.return_value = True
+        api.jobs.is_passed.return_value = False
+
+        with pytest.raises(Exception, match='Report generation failed: missing definitions'):
+            reports.export({}, timeout=10, poll_interval=0)
+
+    @patch('praetorian_cli.sdk.entities.reports.time')
+    @patch('praetorian_cli.sdk.entities.reports.sleep')
+    def test_raises_on_timeout(self, mock_sleep, mock_time):
+        reports, api = make_reports()
+        api.post.return_value = {'key': '#job#report#123'}
+        api.jobs.get.return_value = {'status': 'JR'}
+        api.jobs.is_failed.return_value = False
+        api.jobs.is_passed.return_value = False
+
+        # Simulate time progressing past timeout
+        mock_time.side_effect = [0, 0, 100, 200, 301]
+
+        with pytest.raises(Exception, match='timed out after 300 seconds'):
+            reports.export({}, timeout=300, poll_interval=5)
+
+
+class TestPollJob:
+
+    @patch('praetorian_cli.sdk.entities.reports.sleep')
+    def test_polls_until_passed(self, mock_sleep):
+        reports, api = make_reports()
+
+        # First call: running, second call: passed
+        api.jobs.get.side_effect = [
+            {'status': 'JR'},
+            {'status': 'JP', 'config': {'output': 'home/report.pdf'}},
+        ]
+        api.jobs.is_failed.return_value = False
+        api.jobs.is_passed.side_effect = [False, True]
+
+        job = reports.poll_job('#job#123', timeout=60, poll_interval=0)
+        assert job['status'] == 'JP'
+        assert api.jobs.get.call_count == 2
+
+    @patch('praetorian_cli.sdk.entities.reports.sleep')
+    def test_raises_on_job_failure(self, mock_sleep):
+        reports, api = make_reports()
+        api.jobs.get.return_value = {'status': 'JF', 'message': 'orator crashed'}
+        api.jobs.is_failed.return_value = True
+        api.jobs.is_passed.return_value = False
+
+        with pytest.raises(Exception, match='orator crashed'):
+            reports.poll_job('#job#123', timeout=60, poll_interval=0)
+
+
+class TestOutputPath:
+
+    def test_from_config_output(self):
+        reports, _ = make_reports()
+        job = {'config': {'output': 'home/my-report-2026.pdf'}, 'dns': 'fallback.pdf'}
+        assert reports.output_path(job) == 'home/my-report-2026.pdf'
+
+    def test_falls_back_to_dns(self):
+        reports, _ = make_reports()
+        job = {'config': {}, 'dns': 'home/fallback.pdf'}
+        assert reports.output_path(job) == 'home/fallback.pdf'
+
+    def test_raises_when_no_path(self):
+        reports, _ = make_reports()
+        job = {'config': {}, 'dns': ''}
+        with pytest.raises(Exception, match='Could not determine output file path'):
+            reports.output_path(job)
+
+    def test_raises_when_no_config(self):
+        reports, _ = make_reports()
+        job = {}
+        with pytest.raises(Exception, match='Could not determine output file path'):
+            reports.output_path(job)
+
+
+class TestDownload:
+
+    def test_delegates_to_files_save(self):
+        reports, api = make_reports()
+        api.files.save.return_value = '/tmp/my-report.pdf'
+
+        job = {'config': {'output': 'home/my-report.pdf'}}
+        result = reports.download(job, '/tmp')
+
+        api.files.save.assert_called_once_with('home/my-report.pdf', '/tmp')
+        assert result == '/tmp/my-report.pdf'


### PR DESCRIPTION
## Summary
- Adds `guard export report` command that generates PDF/ZIP pentest reports via the `/export/report` API
- Customer email is auto-derived from `--account` flag or logged-in keychain user (no extra flag needed)
- Polls the async report generation job with configurable timeout (default 5 min), then downloads the result

## Usage
```bash
guard --account customer@acme.com export report \
    --title "Pentest Report" --client-name "Acme"

guard --account customer@acme.com export report \
    --title "Q1 Assessment" --client-name "Acme" \
    --format zip --draft \
    --status-filter O --status-filter T --status-filter R
```

## Options
| Flag | Description |
|------|-------------|
| `--title` (required) | Report title |
| `--client-name` (required) | Client organization name |
| `--status-filter` | Risk status filter (repeatable, default: O T) |
| `--risk-keys` | Specific risk keys (repeatable) |
| `--target` | Scope / target |
| `--start-date` / `--end-date` | Engagement dates |
| `--report-date` | Report date (default: today) |
| `--draft` / `--no-draft` | DRAFT watermark |
| `--version` | Report version string |
| `--format` | `pdf` (default) or `zip` |
| `--group-by` | `attack_surface` (default) or `tag` |
| `--shared` / `--no-shared` | Copy to customer shared files |
| `--executive-summary` | Path to exec summary .md in Guard storage |
| `--narratives` | Path to narratives .md in Guard storage |
| `--appendix` | Path to appendix .md in Guard storage |
| `-o` / `--output` | Local download directory |
| `--timeout` | Max poll seconds (default: 300) |
| `--no-download` | Print output path without downloading |

## Test plan
- [ ] `uv run guard export --help` shows the export group
- [ ] `uv run guard export report --help` shows all options
- [ ] `uv run guard export report` errors on missing required flags
- [ ] Smoke test with Praetorian credentials against a real account