### PR TITLE
feat: add bulk_add SDK methods for assets, risks, and attributes

### DIFF
--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -133,6 +133,31 @@ class Assets:
         attributes, _ = self.api.search.by_source(key, Kind.ATTRIBUTE.value)
         return attributes
 
+    def bulk_add(self, items):
+        """Add multiple assets in a single bulk operation (async).
+
+        Args:
+            items: List of dicts with keys: group, identifier,
+                   and optionally: type, status, surface, resource_type
+
+        Returns:
+            Job dict for tracking progress. Use sdk.jobs.bulk_results(job)
+            to get per-item results after completion.
+        """
+        payload_items = []
+        for item in items:
+            p = dict(
+                group=item['group'],
+                identifier=item['identifier'],
+                status=item.get('status', Asset.ACTIVE.value),
+                attackSurface=[item.get('surface', '')],
+                type=item.get('type', Kind.ASSET.value),
+            )
+            if item.get('resource_type'):
+                p['resourceType'] = item['resource_type']
+            payload_items.append(p)
+        return self.api.post('bulk/asset', dict(action='upsert', items=payload_items))
+
     def associated_risks(self, key):
         """
         Get risks associated with an asset.

--- a/praetorian_cli/sdk/entities/attributes.py
+++ b/praetorian_cli/sdk/entities/attributes.py
@@ -58,6 +58,21 @@ class Attributes:
         """
         return self.api.delete_by_key('attribute', key)
 
+    def bulk_add(self, items):
+        """Add multiple attributes in a single bulk operation (async).
+
+        Args:
+            items: List of dicts with keys: source_key, name, value
+
+        Returns:
+            Job dict for tracking progress.
+        """
+        payload_items = [
+            dict(key=i['source_key'], name=i['name'], value=i['value'])
+            for i in items
+        ]
+        return self.api.post('bulk/attribute', dict(action='upsert', items=payload_items))
+
     def list(self, prefix_filter='', source_key=None, offset=None, pages=100000) -> tuple:
         """
         List attributes with optional filtering.

--- a/praetorian_cli/sdk/entities/jobs.py
+++ b/praetorian_cli/sdk/entities/jobs.py
@@ -350,7 +350,13 @@ class Jobs:
         """
         start = time.time()
         while time.time() - start < timeout:
-            job = self.api.search.by_exact_key(job_key)
+            try:
+                job = self.api.search.by_exact_key(job_key)
+            except Exception:
+                # Transient errors (504, 503, etc.) during polling are expected
+                # when the backend is under load. Retry on next poll cycle.
+                time.sleep(poll_interval)
+                continue
             if job:
                 if self.is_passed(job) or self.is_failed(job):
                     return job

--- a/praetorian_cli/sdk/entities/jobs.py
+++ b/praetorian_cli/sdk/entities/jobs.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 
 class Jobs:
@@ -315,6 +316,46 @@ class Jobs:
             - Other statuses (JQ, JR, JF) will return False
         """
         return job and job['status'] and job['status'].startswith('JP')
+
+    def bulk_results(self, job):
+        """Download and parse per-item results for a completed bulk upsert job.
+
+        Args:
+            job: Job dict (must have 'config' with 'results_s3_key')
+
+        Returns:
+            Dict with 'summary' and 'results' keys, or None if job not complete.
+        """
+        if not self.is_passed(job) and not self.is_failed(job):
+            return None
+        results_key = job.get('config', {}).get('results_s3_key')
+        if not results_key:
+            return None
+        content = self.api.files.get_utf8(results_key)
+        return json.loads(content)
+
+    def wait(self, job_key, poll_interval=5, timeout=3600):
+        """Poll until a job completes or times out.
+
+        Args:
+            job_key: The job key to poll
+            poll_interval: Seconds between polls (default 5)
+            timeout: Max seconds to wait (default 3600)
+
+        Returns:
+            Final job dict
+
+        Raises:
+            TimeoutError: If job doesn't complete within timeout
+        """
+        start = time.time()
+        while time.time() - start < timeout:
+            job = self.api.search.by_exact_key(job_key)
+            if job:
+                if self.is_passed(job) or self.is_failed(job):
+                    return job
+            time.sleep(poll_interval)
+        raise TimeoutError(f"Job {job_key} did not complete within {timeout}s")
 
     def system_job_key(self, source, id):
         """

--- a/praetorian_cli/sdk/entities/risks.py
+++ b/praetorian_cli/sdk/entities/risks.py
@@ -146,6 +146,30 @@ class Risks:
         attributes, _ = self.api.search.by_source(key, Kind.ATTRIBUTE.value)
         return attributes
 
+    def bulk_add(self, items):
+        """Add multiple risks in a single bulk operation (async).
+
+        Args:
+            items: List of dicts with keys: asset_key, name, status,
+                   and optionally: comment, capability, title, tags
+
+        Returns:
+            Job dict for tracking progress.
+        """
+        payload_items = []
+        for item in items:
+            p = dict(key=item['asset_key'], name=item['name'], status=item['status'])
+            if item.get('comment'):
+                p['comment'] = item['comment']
+            if item.get('capability'):
+                p['source'] = item['capability']
+            if item.get('title'):
+                p['title'] = item['title']
+            if item.get('tags'):
+                p['tags'] = list(item['tags'])
+            payload_items.append(p)
+        return self.api.post('bulk/risk', dict(action='upsert', items=payload_items))
+
     def affected_assets(self, key):
         """
         Get all assets affected by a risk.

--- a/praetorian_cli/sdk/test/test_bulk.py
+++ b/praetorian_cli/sdk/test/test_bulk.py
@@ -1,0 +1,315 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from praetorian_cli.sdk.model.globals import Asset, Kind
+from praetorian_cli.sdk.entities.assets import Assets
+from praetorian_cli.sdk.entities.risks import Risks
+from praetorian_cli.sdk.entities.attributes import Attributes
+from praetorian_cli.sdk.entities.jobs import Jobs
+
+
+class TestAssetsBulkAdd:
+
+    def setup_method(self):
+        self.api = MagicMock()
+        self.assets = Assets(self.api)
+
+    def test_bulk_add_minimal(self):
+        """bulk_add with only required fields uses correct defaults."""
+        items = [dict(group='example.com', identifier='1.2.3.4')]
+        self.api.post.return_value = {'job': 'j1'}
+
+        result = self.assets.bulk_add(items)
+
+        self.api.post.assert_called_once_with('bulk/asset', dict(
+            action='upsert',
+            items=[dict(
+                group='example.com',
+                identifier='1.2.3.4',
+                status=Asset.ACTIVE.value,
+                attackSurface=[''],
+                type=Kind.ASSET.value,
+            )]
+        ))
+        assert result == {'job': 'j1'}
+
+    def test_bulk_add_with_all_optional_fields(self):
+        """bulk_add passes through all optional fields correctly."""
+        items = [dict(
+            group='example.com',
+            identifier='1.2.3.4',
+            type=Kind.ADDOMAIN.value,
+            status=Asset.FROZEN.value,
+            surface='internal',
+            resource_type='AWS::EC2::Instance',
+        )]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.assets.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        payload_items = call_args[0][1]['items']
+        assert len(payload_items) == 1
+        item = payload_items[0]
+        assert item['group'] == 'example.com'
+        assert item['identifier'] == '1.2.3.4'
+        assert item['type'] == Kind.ADDOMAIN.value
+        assert item['status'] == Asset.FROZEN.value
+        assert item['attackSurface'] == ['internal']
+        assert item['resourceType'] == 'AWS::EC2::Instance'
+
+    def test_bulk_add_multiple_items(self):
+        """bulk_add handles multiple items in a single call."""
+        items = [
+            dict(group='a.com', identifier='1.1.1.1'),
+            dict(group='b.com', identifier='2.2.2.2'),
+        ]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.assets.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        payload_items = call_args[0][1]['items']
+        assert len(payload_items) == 2
+
+    def test_bulk_add_without_resource_type_omits_key(self):
+        """When resource_type is not provided, resourceType key is absent from payload."""
+        items = [dict(group='example.com', identifier='1.2.3.4')]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.assets.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        item = call_args[0][1]['items'][0]
+        assert 'resourceType' not in item
+
+
+class TestRisksBulkAdd:
+
+    def setup_method(self):
+        self.api = MagicMock()
+        self.risks = Risks(self.api)
+
+    def test_bulk_add_minimal(self):
+        """bulk_add with only required fields."""
+        items = [dict(asset_key='#asset#a.com#1.1.1.1', name='vuln-1', status='TH')]
+        self.api.post.return_value = {'job': 'j1'}
+
+        result = self.risks.bulk_add(items)
+
+        self.api.post.assert_called_once_with('bulk/risk', dict(
+            action='upsert',
+            items=[dict(key='#asset#a.com#1.1.1.1', name='vuln-1', status='TH')]
+        ))
+        assert result == {'job': 'j1'}
+
+    def test_bulk_add_with_all_optional_fields(self):
+        """bulk_add passes through comment, capability, title, tags."""
+        items = [dict(
+            asset_key='#asset#a.com#1.1.1.1',
+            name='vuln-1',
+            status='TH',
+            comment='found during scan',
+            capability='nuclei',
+            title='SQL Injection',
+            tags=['critical', 'web'],
+        )]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.risks.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        item = call_args[0][1]['items'][0]
+        assert item['comment'] == 'found during scan'
+        assert item['source'] == 'nuclei'
+        assert item['title'] == 'SQL Injection'
+        assert item['tags'] == ['critical', 'web']
+
+    def test_bulk_add_omits_absent_optional_fields(self):
+        """When optional fields are not provided, their keys are absent."""
+        items = [dict(asset_key='#asset#a.com#1.1.1.1', name='vuln-1', status='TH')]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.risks.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        item = call_args[0][1]['items'][0]
+        assert 'comment' not in item
+        assert 'source' not in item
+        assert 'title' not in item
+        assert 'tags' not in item
+
+    def test_bulk_add_tags_converted_to_list(self):
+        """Tags tuple is converted to a list."""
+        items = [dict(
+            asset_key='#asset#a.com#1.1.1.1',
+            name='vuln-1',
+            status='TH',
+            tags=('a', 'b'),
+        )]
+        self.api.post.return_value = {'job': 'j1'}
+
+        self.risks.bulk_add(items)
+
+        call_args = self.api.post.call_args
+        item = call_args[0][1]['items'][0]
+        assert item['tags'] == ['a', 'b']
+        assert isinstance(item['tags'], list)
+
+
+class TestAttributesBulkAdd:
+
+    def setup_method(self):
+        self.api = MagicMock()
+        self.attributes = Attributes(self.api)
+
+    def test_bulk_add(self):
+        """bulk_add constructs the correct payload."""
+        items = [
+            dict(source_key='#asset#a.com#1.1.1.1', name='port', value='443'),
+            dict(source_key='#asset#b.com#2.2.2.2', name='proto', value='https'),
+        ]
+        self.api.post.return_value = {'job': 'j1'}
+
+        result = self.attributes.bulk_add(items)
+
+        self.api.post.assert_called_once_with('bulk/attribute', dict(
+            action='upsert',
+            items=[
+                dict(key='#asset#a.com#1.1.1.1', name='port', value='443'),
+                dict(key='#asset#b.com#2.2.2.2', name='proto', value='https'),
+            ]
+        ))
+        assert result == {'job': 'j1'}
+
+
+class TestJobsBulkResults:
+
+    def setup_method(self):
+        self.api = MagicMock()
+        self.jobs = Jobs(self.api)
+
+    def test_bulk_results_passed_job(self):
+        """bulk_results downloads and parses results for a passed job."""
+        job = {
+            'status': 'JP',
+            'config': {'results_s3_key': 'results/bulk-123.json'},
+        }
+        expected = {'summary': {'total': 1}, 'results': [{'key': '#asset#a.com#1.1.1.1'}]}
+        self.api.files.get_utf8.return_value = json.dumps(expected)
+
+        result = self.jobs.bulk_results(job)
+
+        self.api.files.get_utf8.assert_called_once_with('results/bulk-123.json')
+        assert result == expected
+
+    def test_bulk_results_failed_job(self):
+        """bulk_results works for failed jobs too (they can have results)."""
+        job = {
+            'status': 'JF',
+            'config': {'results_s3_key': 'results/bulk-456.json'},
+        }
+        expected = {'summary': {'total': 0, 'errors': 1}, 'results': []}
+        self.api.files.get_utf8.return_value = json.dumps(expected)
+
+        result = self.jobs.bulk_results(job)
+
+        assert result == expected
+
+    def test_bulk_results_incomplete_job_returns_none(self):
+        """bulk_results returns None for jobs that are still running."""
+        job = {'status': 'JR', 'config': {'results_s3_key': 'results/bulk-789.json'}}
+
+        result = self.jobs.bulk_results(job)
+
+        assert result is None
+        self.api.files.get_utf8.assert_not_called()
+
+    def test_bulk_results_no_results_key_returns_none(self):
+        """bulk_results returns None when config has no results_s3_key."""
+        job = {'status': 'JP', 'config': {}}
+
+        result = self.jobs.bulk_results(job)
+
+        assert result is None
+
+    def test_bulk_results_no_config_returns_none(self):
+        """bulk_results returns None when job has no config."""
+        job = {'status': 'JP'}
+
+        result = self.jobs.bulk_results(job)
+
+        assert result is None
+
+
+class TestJobsWait:
+
+    def setup_method(self):
+        self.api = MagicMock()
+        self.jobs = Jobs(self.api)
+
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_wait_returns_on_passed(self, mock_time, mock_sleep):
+        """wait returns immediately when job is passed."""
+        mock_time.side_effect = [0, 1]  # start, first check
+        completed_job = {'status': 'JP', 'key': '#job#test'}
+        self.api.search.by_exact_key.return_value = completed_job
+
+        result = self.jobs.wait('#job#test')
+
+        assert result == completed_job
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_wait_returns_on_failed(self, mock_time, mock_sleep):
+        """wait returns when job transitions to failed."""
+        mock_time.side_effect = [0, 1]
+        failed_job = {'status': 'JF', 'key': '#job#test'}
+        self.api.search.by_exact_key.return_value = failed_job
+
+        result = self.jobs.wait('#job#test')
+
+        assert result == failed_job
+
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_wait_polls_until_complete(self, mock_time, mock_sleep):
+        """wait polls multiple times until job completes."""
+        mock_time.side_effect = [0, 1, 6, 11]
+        running_job = {'status': 'JR', 'key': '#job#test'}
+        passed_job = {'status': 'JP', 'key': '#job#test'}
+        self.api.search.by_exact_key.side_effect = [running_job, running_job, passed_job]
+
+        result = self.jobs.wait('#job#test', poll_interval=5)
+
+        assert result == passed_job
+        assert self.api.search.by_exact_key.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_wait_timeout(self, mock_time, mock_sleep):
+        """wait raises TimeoutError when timeout is exceeded."""
+        # First call is start time=0, subsequent calls exceed timeout
+        mock_time.side_effect = [0, 1, 100, 200]
+        running_job = {'status': 'JR', 'key': '#job#test'}
+        self.api.search.by_exact_key.return_value = running_job
+
+        with pytest.raises(TimeoutError, match='did not complete within 10s'):
+            self.jobs.wait('#job#test', poll_interval=1, timeout=10)
+
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_wait_handles_none_result(self, mock_time, mock_sleep):
+        """wait continues polling when by_exact_key returns None."""
+        mock_time.side_effect = [0, 1, 6, 11]
+        passed_job = {'status': 'JP', 'key': '#job#test'}
+        self.api.search.by_exact_key.side_effect = [None, None, passed_job]
+
+        result = self.jobs.wait('#job#test', poll_interval=5)
+
+        assert result == passed_job
+        assert self.api.search.by_exact_key.call_count == 3

--- a/scripts/test_bulk_upsert.py
+++ b/scripts/test_bulk_upsert.py
@@ -1,12 +1,4 @@
-#!/usr/bin/env -S uv run --script
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "praetorian-cli",
-# ]
-# [tool.uv]
-# find-links = [".."]
-# ///
+#!/usr/bin/env python3
 
 """
 End-to-end test script for bulk upsert SDK methods.

--- a/scripts/test_bulk_upsert.py
+++ b/scripts/test_bulk_upsert.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "praetorian-cli",
+# ]
+# [tool.uv]
+# find-links = [".."]
+# ///
+
+"""
+End-to-end test script for bulk upsert SDK methods.
+
+Exercises happy-path, negative, and edge-case scenarios against the bulk
+asset/risk/attribute APIs and prints per-item results.
+
+Usage:
+    uv run scripts/test_bulk_upsert.py --account user@example.com
+"""
+
+import argparse
+import json
+import sys
+import traceback
+
+from praetorian_cli.sdk.chariot import Chariot
+from praetorian_cli.sdk.keychain import Keychain
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def run_test(sdk, test_num, description, entity, items, expect_api_error=False, raw_post=None):
+    """Execute a single bulk-upsert test case and print results.
+
+    Args:
+        sdk: Chariot SDK instance.
+        test_num: Test number for display.
+        description: Human-readable test description.
+        entity: One of 'asset', 'risk', 'attribute'.
+        items: List of dicts to send to bulk_add.
+        expect_api_error: If True, expect an exception and print it.
+        raw_post: If set, a tuple (endpoint, body) to POST directly instead
+                  of calling entity.bulk_add.  Used for edge-case tests.
+    """
+    print(f"\n=== Test {test_num}: {description} ===")
+    print(f"Entity: {entity}")
+    print(f"Items submitted: {len(items)}")
+
+    try:
+        if raw_post:
+            endpoint, body = raw_post
+            job = sdk.post(endpoint, body)
+        elif entity == "asset":
+            job = sdk.assets.bulk_add(items)
+        elif entity == "risk":
+            job = sdk.risks.bulk_add(items)
+        elif entity == "attribute":
+            job = sdk.attributes.bulk_add(items)
+        else:
+            print(f"  Unknown entity type: {entity}")
+            print("---")
+            return
+    except KeyError as exc:
+        # bulk_add accesses dict keys directly; malformed items raise KeyError
+        if expect_api_error:
+            print(f"Expected client-side error (KeyError): {exc}")
+            print("---")
+            return
+        print(f"Unexpected KeyError in bulk_add: {exc}")
+        traceback.print_exc()
+        print("---")
+        return
+    except Exception as exc:
+        if expect_api_error:
+            print(f"Expected API error: {exc}")
+            print("---")
+            return
+        print(f"Unexpected error: {exc}")
+        traceback.print_exc()
+        print("---")
+        return
+
+    job_key = job.get("key", "N/A")
+    print(f"Job key: {job_key}")
+
+    if job_key == "N/A":
+        print("  No job key returned — cannot poll for results.")
+        print(f"  Raw response: {json.dumps(job, indent=2)}")
+        print("---")
+        return
+
+    # Wait for completion
+    try:
+        completed_job = sdk.jobs.wait(job_key, poll_interval=2, timeout=300)
+    except TimeoutError as exc:
+        print(f"  Timed out waiting for job: {exc}")
+        print("---")
+        return
+
+    passed = sdk.jobs.is_passed(completed_job)
+    failed = sdk.jobs.is_failed(completed_job)
+    status_label = "PASSED" if passed else ("FAILED" if failed else completed_job.get("status", "UNKNOWN"))
+    print(f"Job status: {status_label}")
+
+    # Get results
+    results = sdk.jobs.bulk_results(completed_job)
+    if results:
+        s = results.get("summary", {})
+        print("Results:")
+        print(
+            f"  Summary: total={s.get('total', '?')}, "
+            f"created={s.get('created', '?')}, "
+            f"updated={s.get('updated', '?')}, "
+            f"failed={s.get('failed', '?')}"
+        )
+        for r in results.get("results", []):
+            if r.get("status") == "failed":
+                print(f"  [FAILED]  {r.get('error', 'unknown error')}")
+                print(f"            Input: {r.get('input', 'N/A')}")
+            else:
+                print(f"  [{r.get('status', '?').upper()}] {r.get('key', 'N/A')}")
+    else:
+        print("  No structured results available.")
+        print(f"  Job config: {json.dumps(completed_job.get('config', {}), indent=2)}")
+    print("---")
+
+
+# ---------------------------------------------------------------------------
+# Test definitions
+# ---------------------------------------------------------------------------
+
+def run_all_tests(sdk):
+    # ------------------------------------------------------------------
+    # Group 1: Bulk Assets
+    # ------------------------------------------------------------------
+
+    # Test 1 — Happy path: 5 valid assets with different types
+    run_test(sdk, 1, "Bulk assets — happy path (5 valid)", "asset", [
+        {"group": "testbulk.example.com", "identifier": "10.0.0.1"},
+        {"group": "testbulk.example.com", "identifier": "10.0.0.2", "surface": "External"},
+        {"group": "testbulk.example.com", "identifier": "10.0.0.3", "type": "asset"},
+        {"group": "testbulk.example.com", "identifier": "app.testbulk.example.com"},
+        {"group": "testbulk.example.com", "identifier": "10.0.0.4", "resource_type": "webapp"},
+    ])
+
+    # Test 2 — Mixed valid + invalid (domain ownership failures)
+    run_test(sdk, 2, "Bulk assets — mixed valid + invalid (domain not owned)", "asset", [
+        {"group": "testbulk.example.com", "identifier": "10.0.0.10"},
+        {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.1"},
+        {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.2"},
+        {"group": "testbulk.example.com", "identifier": "10.0.0.11"},
+    ])
+
+    # Test 3 — All invalid / malformed items
+    # NOTE: bulk_add accesses item['group'] and item['identifier'] directly,
+    # so empty dicts / missing keys will raise KeyError client-side.
+    run_test(sdk, 3, "Bulk assets — all invalid / malformed items", "asset", [
+        {},
+        {"group": ""},
+        {"identifier": "10.0.0.99"},
+    ], expect_api_error=True)
+
+    # Test 4 — Duplicate assets in same batch
+    run_test(sdk, 4, "Bulk assets — duplicate asset in batch", "asset", [
+        {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
+        {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
+    ])
+
+    # ------------------------------------------------------------------
+    # Group 2: Bulk Risks
+    # ------------------------------------------------------------------
+
+    # Test 5 — Happy path: risks on assets created in test 1
+    run_test(sdk, 5, "Bulk risks — happy path", "risk", [
+        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "CVE-2024-0001", "status": "TI"},
+        {
+            "asset_key": "#asset#testbulk.example.com#10.0.0.2",
+            "name": "CVE-2024-0002",
+            "status": "TI",
+            "title": "Test Vulnerability",
+            "tags": ["test", "bulk"],
+        },
+    ])
+
+    # Test 6 — Risks on non-existent assets
+    run_test(sdk, 6, "Bulk risks — non-existent assets", "risk", [
+        {"asset_key": "#asset#nonexistent.example.com#99.99.99.1", "name": "CVE-2024-9901", "status": "TI"},
+        {"asset_key": "#asset#nonexistent.example.com#99.99.99.2", "name": "CVE-2024-9902", "status": "TI"},
+        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "CVE-2024-0003", "status": "TI"},
+    ])
+
+    # Test 7 — Invalid risk data
+    run_test(sdk, 7, "Bulk risks — invalid data", "risk", [
+        {"asset_key": "", "name": "CVE-2024-BAD1", "status": "TI"},
+        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "", "status": "TI"},
+        {},
+    ], expect_api_error=True)
+
+    # ------------------------------------------------------------------
+    # Group 3: Bulk Attributes
+    # ------------------------------------------------------------------
+
+    # Test 8 — Happy path: attributes on assets from test 1
+    run_test(sdk, 8, "Bulk attributes — happy path", "attribute", [
+        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "port", "value": "443"},
+        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "service", "value": "https"},
+        {"source_key": "#asset#testbulk.example.com#10.0.0.2", "name": "port", "value": "80"},
+    ])
+
+    # Test 9 — Attributes on non-existent entities
+    run_test(sdk, 9, "Bulk attributes — non-existent entities", "attribute", [
+        {"source_key": "#asset#nonexistent#99.99.99.99", "name": "port", "value": "443"},
+        {"source_key": "#risk#nonexistent#CVE-FAKE", "name": "cvss", "value": "9.8"},
+        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "test-attr", "value": "ok"},
+    ])
+
+    # Test 10 — Update existing attribute (re-add same from test 8)
+    run_test(sdk, 10, "Bulk attributes — update existing (should return updated)", "attribute", [
+        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "port", "value": "443"},
+    ])
+
+    # ------------------------------------------------------------------
+    # Group 4: Edge cases
+    # ------------------------------------------------------------------
+
+    # Test 11 — Empty items array (should get 400 from API)
+    run_test(
+        sdk, 11, "Edge case — empty items array (expect 400)", "asset", [],
+        expect_api_error=True,
+        raw_post=("bulk/asset", {"action": "upsert", "items": []}),
+    )
+
+    # Test 12 — Single item (verify bulk works with 1 item)
+    run_test(sdk, 12, "Edge case — single item bulk", "asset", [
+        {"group": "testbulk.example.com", "identifier": "10.0.0.99"},
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="End-to-end test script for bulk upsert SDK methods."
+    )
+    parser.add_argument(
+        "--account",
+        required=True,
+        help="Account email to make uploads to (e.g., user@example.com)",
+    )
+    args = parser.parse_args()
+
+    print(f"Initializing Chariot SDK for account: {args.account}")
+    keychain = Keychain(account=args.account)
+    sdk = Chariot(keychain)
+
+    print("Running bulk upsert e2e tests...")
+    print("=" * 60)
+
+    run_all_tests(sdk)
+
+    print("\n" + "=" * 60)
+    print("All tests completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_bulk_upsert.py
+++ b/scripts/test_bulk_upsert.py
@@ -23,7 +23,17 @@ from praetorian_cli.sdk.keychain import Keychain
 # Helper
 # ---------------------------------------------------------------------------
 
-def run_test(sdk, test_num, description, entity, items, expect_api_error=False, raw_post=None):
+
+def run_test(
+    sdk,
+    test_num,
+    description,
+    entity,
+    items,
+    expect_api_error=False,
+    raw_post=None,
+    only=None,
+):
     """Execute a single bulk-upsert test case and print results.
 
     Args:
@@ -35,7 +45,10 @@ def run_test(sdk, test_num, description, entity, items, expect_api_error=False, 
         expect_api_error: If True, expect an exception and print it.
         raw_post: If set, a tuple (endpoint, body) to POST directly instead
                   of calling entity.bulk_add.  Used for edge-case tests.
+        only: If set, skip this test unless test_num is in the set.
     """
+    if only and test_num not in only:
+        return
     print(f"\n=== Test {test_num}: {description} ===")
     print(f"Entity: {entity}")
     print(f"Items submitted: {len(items)}")
@@ -93,7 +106,11 @@ def run_test(sdk, test_num, description, entity, items, expect_api_error=False, 
 
     passed = sdk.jobs.is_passed(completed_job)
     failed = sdk.jobs.is_failed(completed_job)
-    status_label = "PASSED" if passed else ("FAILED" if failed else completed_job.get("status", "UNKNOWN"))
+    status_label = (
+        "PASSED"
+        if passed
+        else ("FAILED" if failed else completed_job.get("status", "UNKNOWN"))
+    )
     print(f"Job status: {status_label}")
 
     # Get results
@@ -123,95 +140,233 @@ def run_test(sdk, test_num, description, entity, items, expect_api_error=False, 
 # Test definitions
 # ---------------------------------------------------------------------------
 
-def run_all_tests(sdk):
+
+def run_all_tests(sdk, only=None):
     # ------------------------------------------------------------------
     # Group 1: Bulk Assets
     # ------------------------------------------------------------------
 
-    # Test 1 — Happy path: 5 valid assets with different types
-    run_test(sdk, 1, "Bulk assets — happy path (5 valid)", "asset", [
-        {"group": "testbulk.example.com", "identifier": "10.0.0.1"},
-        {"group": "testbulk.example.com", "identifier": "10.0.0.2", "surface": "External"},
-        {"group": "testbulk.example.com", "identifier": "10.0.0.3", "type": "asset"},
-        {"group": "testbulk.example.com", "identifier": "app.testbulk.example.com"},
-        {"group": "testbulk.example.com", "identifier": "10.0.0.4", "resource_type": "webapp"},
-    ])
+    # Test 1 — Scale test: 200 valid assets
+    run_test(
+        sdk,
+        1,
+        "Bulk assets — 200 assets scale test",
+        "asset",
+        [
+            {
+                "group": "testbulk.example.com",
+                "identifier": f"10.1.{i // 256}.{i % 256}",
+            }
+            for i in range(200)
+        ],
+        only=only,
+    )
 
     # Test 2 — Mixed valid + invalid (domain ownership failures)
-    run_test(sdk, 2, "Bulk assets — mixed valid + invalid (domain not owned)", "asset", [
-        {"group": "testbulk.example.com", "identifier": "10.0.0.10"},
-        {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.1"},
-        {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.2"},
-        {"group": "testbulk.example.com", "identifier": "10.0.0.11"},
-    ])
+    run_test(
+        sdk,
+        2,
+        "Bulk assets — mixed valid + invalid (domain not owned)",
+        "asset",
+        [
+            {"group": "testbulk.example.com", "identifier": "10.0.0.10"},
+            {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.1"},
+            {"group": "evil-domain-not-owned.com", "identifier": "6.6.6.2"},
+            {"group": "testbulk.example.com", "identifier": "10.0.0.11"},
+        ],
+        only=only,
+    )
 
     # Test 3 — All invalid / malformed items
     # NOTE: bulk_add accesses item['group'] and item['identifier'] directly,
     # so empty dicts / missing keys will raise KeyError client-side.
-    run_test(sdk, 3, "Bulk assets — all invalid / malformed items", "asset", [
-        {},
-        {"group": ""},
-        {"identifier": "10.0.0.99"},
-    ], expect_api_error=True)
+    run_test(
+        sdk,
+        3,
+        "Bulk assets — all invalid / malformed items",
+        "asset",
+        [
+            {},
+            {"group": ""},
+            {"identifier": "10.0.0.99"},
+        ],
+        expect_api_error=True,
+        only=only,
+    )
 
     # Test 4 — Duplicate assets in same batch
-    run_test(sdk, 4, "Bulk assets — duplicate asset in batch", "asset", [
-        {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
-        {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
-    ])
+    run_test(
+        sdk,
+        4,
+        "Bulk assets — duplicate asset in batch",
+        "asset",
+        [
+            {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
+            {"group": "testbulk.example.com", "identifier": "10.0.0.20"},
+        ],
+        only=only,
+    )
 
     # ------------------------------------------------------------------
     # Group 2: Bulk Risks
     # ------------------------------------------------------------------
 
-    # Test 5 — Happy path: risks on assets created in test 1
-    run_test(sdk, 5, "Bulk risks — happy path", "risk", [
-        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "CVE-2024-0001", "status": "TI"},
-        {
-            "asset_key": "#asset#testbulk.example.com#10.0.0.2",
-            "name": "CVE-2024-0002",
-            "status": "TI",
-            "title": "Test Vulnerability",
-            "tags": ["test", "bulk"],
-        },
-    ])
+    # Test 13 — Scale test: 200 risks across assets from test 1
+    run_test(
+        sdk,
+        13,
+        "Bulk risks — 200 risks scale test",
+        "risk",
+        [
+            {
+                "asset_key": f"#asset#testbulk.example.com#10.1.{i // 256}.{i % 256}",
+                "name": f"CVE-2026-{i:04d}",
+                "status": "TI",
+            }
+            for i in range(200)
+        ],
+        only=only,
+    )
 
-    # Test 6 — Risks on non-existent assets
-    run_test(sdk, 6, "Bulk risks — non-existent assets", "risk", [
-        {"asset_key": "#asset#nonexistent.example.com#99.99.99.1", "name": "CVE-2024-9901", "status": "TI"},
-        {"asset_key": "#asset#nonexistent.example.com#99.99.99.2", "name": "CVE-2024-9902", "status": "TI"},
-        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "CVE-2024-0003", "status": "TI"},
-    ])
+    # Test 5 — Happy path: risks on assets created in test 1
+    run_test(
+        sdk,
+        5,
+        "Bulk risks — happy path",
+        "risk",
+        [
+            {
+                "asset_key": "#asset#testbulk.example.com#10.1.0.0",
+                "name": "CVE-2024-0001",
+                "status": "TI",
+            },
+            {
+                "asset_key": "#asset#testbulk.example.com#10.1.0.1",
+                "name": "CVE-2024-0002",
+                "status": "TI",
+                "title": "Test Vulnerability",
+                "tags": ["test", "bulk"],
+            },
+        ],
+        only=only,
+    )
+
+    # Test 6 — Risks: mix of non-existent + valid asset from test 1
+    run_test(
+        sdk,
+        6,
+        "Bulk risks — non-existent assets",
+        "risk",
+        [
+            {
+                "asset_key": "#asset#nonexistent.example.com#99.99.99.1",
+                "name": "CVE-2024-9901",
+                "status": "TI",
+            },
+            {
+                "asset_key": "#asset#nonexistent.example.com#99.99.99.2",
+                "name": "CVE-2024-9902",
+                "status": "TI",
+            },
+            {
+                "asset_key": "#asset#testbulk.example.com#10.1.0.2",
+                "name": "CVE-2024-0003",
+                "status": "TI",
+            },
+        ],
+        only=only,
+    )
 
     # Test 7 — Invalid risk data
-    run_test(sdk, 7, "Bulk risks — invalid data", "risk", [
-        {"asset_key": "", "name": "CVE-2024-BAD1", "status": "TI"},
-        {"asset_key": "#asset#testbulk.example.com#10.0.0.1", "name": "", "status": "TI"},
-        {},
-    ], expect_api_error=True)
+    run_test(
+        sdk,
+        7,
+        "Bulk risks — invalid data",
+        "risk",
+        [
+            {"asset_key": "", "name": "CVE-2024-BAD1", "status": "TI"},
+            {
+                "asset_key": "#asset#testbulk.example.com#10.0.0.1",
+                "name": "",
+                "status": "TI",
+            },
+            {},
+        ],
+        expect_api_error=True,
+        only=only,
+    )
 
     # ------------------------------------------------------------------
     # Group 3: Bulk Attributes
     # ------------------------------------------------------------------
 
     # Test 8 — Happy path: attributes on assets from test 1
-    run_test(sdk, 8, "Bulk attributes — happy path", "attribute", [
-        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "port", "value": "443"},
-        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "service", "value": "https"},
-        {"source_key": "#asset#testbulk.example.com#10.0.0.2", "name": "port", "value": "80"},
-    ])
+    run_test(
+        sdk,
+        8,
+        "Bulk attributes — happy path",
+        "attribute",
+        [
+            {
+                "source_key": "#asset#testbulk.example.com#10.1.0.0",
+                "name": "port",
+                "value": "443",
+            },
+            {
+                "source_key": "#asset#testbulk.example.com#10.1.0.0",
+                "name": "service",
+                "value": "https",
+            },
+            {
+                "source_key": "#asset#testbulk.example.com#10.1.0.1",
+                "name": "port",
+                "value": "80",
+            },
+        ],
+        only=only,
+    )
 
-    # Test 9 — Attributes on non-existent entities
-    run_test(sdk, 9, "Bulk attributes — non-existent entities", "attribute", [
-        {"source_key": "#asset#nonexistent#99.99.99.99", "name": "port", "value": "443"},
-        {"source_key": "#risk#nonexistent#CVE-FAKE", "name": "cvss", "value": "9.8"},
-        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "test-attr", "value": "ok"},
-    ])
+    # Test 9 — Attributes: mix of non-existent + valid asset from test 1
+    run_test(
+        sdk,
+        9,
+        "Bulk attributes — non-existent entities",
+        "attribute",
+        [
+            {
+                "source_key": "#asset#nonexistent#99.99.99.99",
+                "name": "port",
+                "value": "443",
+            },
+            {
+                "source_key": "#risk#nonexistent#CVE-FAKE",
+                "name": "cvss",
+                "value": "9.8",
+            },
+            {
+                "source_key": "#asset#testbulk.example.com#10.1.0.3",
+                "name": "test-attr",
+                "value": "ok",
+            },
+        ],
+        only=only,
+    )
 
     # Test 10 — Update existing attribute (re-add same from test 8)
-    run_test(sdk, 10, "Bulk attributes — update existing (should return updated)", "attribute", [
-        {"source_key": "#asset#testbulk.example.com#10.0.0.1", "name": "port", "value": "443"},
-    ])
+    run_test(
+        sdk,
+        10,
+        "Bulk attributes — update existing (should return updated)",
+        "attribute",
+        [
+            {
+                "source_key": "#asset#testbulk.example.com#10.1.0.0",
+                "name": "port",
+                "value": "443",
+            },
+        ],
+        only=only,
+    )
 
     # ------------------------------------------------------------------
     # Group 4: Edge cases
@@ -219,20 +374,33 @@ def run_all_tests(sdk):
 
     # Test 11 — Empty items array (should get 400 from API)
     run_test(
-        sdk, 11, "Edge case — empty items array (expect 400)", "asset", [],
+        sdk,
+        11,
+        "Edge case — empty items array (expect 400)",
+        "asset",
+        [],
         expect_api_error=True,
         raw_post=("bulk/asset", {"action": "upsert", "items": []}),
+        only=only,
     )
 
     # Test 12 — Single item (verify bulk works with 1 item)
-    run_test(sdk, 12, "Edge case — single item bulk", "asset", [
-        {"group": "testbulk.example.com", "identifier": "10.0.0.99"},
-    ])
+    run_test(
+        sdk,
+        12,
+        "Edge case — single item bulk",
+        "asset",
+        [
+            {"group": "testbulk.example.com", "identifier": "10.0.0.99"},
+        ],
+        only=only,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -243,16 +411,27 @@ def main():
         required=True,
         help="Account email to make uploads to (e.g., user@example.com)",
     )
+    parser.add_argument(
+        "--test",
+        type=str,
+        default=None,
+        help="Comma-separated test numbers to run (e.g., '1' or '1,5,8'). Omit to run all.",
+    )
     args = parser.parse_args()
+
+    only = None
+    if args.test:
+        only = {int(n.strip()) for n in args.test.split(",")}
 
     print(f"Initializing Chariot SDK for account: {args.account}")
     keychain = Keychain(account=args.account)
     sdk = Chariot(keychain)
 
-    print("Running bulk upsert e2e tests...")
+    label = f"tests {args.test}" if only else "all tests"
+    print(f"Running bulk upsert e2e {label}...")
     print("=" * 60)
 
-    run_all_tests(sdk)
+    run_all_tests(sdk, only=only)
 
     print("\n" + "=" * 60)
     print("All tests completed.")


### PR DESCRIPTION
## Summary

Add SDK methods for bulk uploading assets, risks, and attributes via the new bulk upsert API.

- `sdk.assets.bulk_add(items)` — bulk create/update assets
- `sdk.risks.bulk_add(items)` — bulk create/update risks
- `sdk.attributes.bulk_add(items)` — bulk create/update attributes
- `sdk.jobs.wait(job_key)` — poll until job completes (with retry on transient 504s)
- `sdk.jobs.bulk_results(job)` — download per-item results from S3
- E2e test script (`scripts/test_bulk_upsert.py`) with `--account` and `--test` flags

### Usage
```python
job = sdk.assets.bulk_add([
    {'group': 'example.com', 'identifier': '1.2.3.4'},
    {'group': 'example.com', 'identifier': '5.6.7.8'},
])
job = sdk.jobs.wait(job['key'])
results = sdk.jobs.bulk_results(job)
for r in results['results']:
    print(f"[{r['status']}] {r.get('key', r.get('error'))}")
```

## Merge order

> **Merge praetorian-inc/guard#4984 first.** This PR calls the bulk upsert endpoint added there.

## Test plan

- [x] 19 unit tests pass (`pytest praetorian_cli/sdk/test/test_bulk.py`)
- [x] E2e test on fresh account with 200 assets + 200 risks: all 12 test cases pass
- [x] `jobs.wait()` retries on transient 504s during polling