### PR TITLE
fix: add timeout to PyPI upgrade check to prevent CLI hang

### DIFF
--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -29,7 +29,7 @@ def upgrade_check(func):
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
         try:
-            response = requests.get('https://pypi.org/pypi/praetorian-cli/json')
+            response = requests.get('https://pypi.org/pypi/praetorian-cli/json', timeout=3)
             pypi = sorted([Version(v) for v in list(response.json()['releases'].keys())])[-1]
             local = Version(version('praetorian-cli'))
             if pypi > local:


### PR DESCRIPTION
## Summary
- The `upgrade_check` decorator makes an HTTP request to PyPI after every
  command to check for newer versions. This request had no timeout, causing
  the CLI to hang indefinitely when PyPI is slow or unreachable.
- Adds a 3-second timeout to the request.