### PR TITLE
feat: add --retest/--no-retest option to report export

### DIFF
--- a/praetorian_cli/handlers/export.py
+++ b/praetorian_cli/handlers/export.py
@@ -25,6 +25,8 @@ def export():
 @click.option('--end-date', default='', help='Engagement end date (ISO format)')
 @click.option('--report-date', default='', help='Report date (ISO format). Default: today')
 @click.option('--draft/--no-draft', default=False, help='Add DRAFT watermark')
+@click.option('--retest/--no-retest', default=False,
+              help='Include retest status badges and sections')
 @click.option('--version', 'report_version', default='1.0', help='Report version string')
 @click.option('--format', 'export_format', type=click.Choice(['pdf', 'zip']),
               default='pdf', help='Export format')
@@ -45,7 +47,7 @@ def export():
 @click.option('--no-download', is_flag=True, default=False,
               help='Skip downloading the file; just print the job result')
 def report(chariot, title, client_name, status_filter, risk_keys,
-           target, start_date, end_date, report_date, draft,
+           target, start_date, end_date, report_date, draft, retest,
            report_version, export_format, group_by, shared,
            executive_summary, narratives, appendix, output,
            timeout, no_download):
@@ -80,6 +82,7 @@ def report(chariot, title, client_name, status_filter, risk_keys,
         end_date=end_date,
         report_date=report_date,
         draft=draft,
+        retest=retest,
         version=report_version,
         export_format=export_format,
         group_by=group_by,

--- a/praetorian_cli/sdk/entities/reports.py
+++ b/praetorian_cli/sdk/entities/reports.py
@@ -35,7 +35,8 @@ class Reports:
     def build_export_body(self, title, client_name, customer_email,
                           status_filter=('O', 'T'), risk_keys=(),
                           target='', start_date='', end_date='',
-                          report_date='', draft=False, version='1.0',
+                          report_date='', draft=False, retest=False,
+                          version='1.0',
                           export_format='pdf', group_by='attack_surface',
                           shared_output=False, executive_summary_path='',
                           narratives_path='', appendix_path=''):
@@ -62,6 +63,8 @@ class Reports:
         :type report_date: str
         :param draft: Whether to add DRAFT watermark
         :type draft: bool
+        :param retest: Whether to include retest status badges and sections
+        :type retest: bool
         :param version: Report version string
         :type version: str
         :param export_format: Output format ('pdf' or 'zip')
@@ -89,6 +92,7 @@ class Reports:
                 'client_name': client_name,
                 'report_date': report_date,
                 'draft': draft,
+                'retest': retest,
                 'version': version,
             },
             'shared_output': shared_output,

--- a/praetorian_cli/sdk/test/test_report.py
+++ b/praetorian_cli/sdk/test/test_report.py
@@ -52,6 +52,7 @@ class TestBuildExportBody:
         assert body['group_by'] == 'attack_surface'
         assert body['shared_output'] is False
         assert body['config']['draft'] is False
+        assert body['config']['retest'] is False
         assert body['config']['version'] == '1.0'
         assert 'risk_keys' not in body
         assert 'target' not in body['config']
@@ -85,6 +86,7 @@ class TestBuildExportBody:
             end_date='2026-03-01',
             report_date='2026-03-15',
             draft=True,
+            retest=True,
             version='2.0',
             export_format='zip',
             group_by='tag',
@@ -99,6 +101,7 @@ class TestBuildExportBody:
         assert body['config']['start_date'] == '2026-01-01'
         assert body['config']['end_date'] == '2026-03-01'
         assert body['config']['draft'] is True
+        assert body['config']['retest'] is True
         assert body['config']['version'] == '2.0'
         assert body['export_format'] == 'zip'
         assert body['group_by'] == 'tag'


### PR DESCRIPTION
## Summary
- Add `--retest/--no-retest` CLI flag to `guard report export` (default off)
- Wire `retest` boolean through SDK `export_report()` into `config.retest` in the report body
- Add unit test coverage for default and explicit retest values

## Related PRs
- praetorian-inc/guard#5011 — adds `retest` field to backend `ReportConfig` (merged)

## Test plan
- [x] Unit tests verify `config.retest` is `False` by default
- [x] Unit tests verify `config.retest` is `True` when `retest=True` is passed