### PR TITLE
Feature: Job Filtering

### DIFF
--- a/praetorian_cli/handlers/list.py
+++ b/praetorian_cli/handlers/list.py
@@ -99,7 +99,12 @@ def integrations(chariot, filter, details, offset, page):
 
 @list.command()
 @list_params('group of the job asset')
-def jobs(chariot, filter, details, offset, page):
+@click.option('-c', '--capability', default=None, help='Filter by capability name (e.g., nuclei, portscan, diana-agent)')
+@click.option('-s', '--status', type=click.Choice(['JQ', 'JR', 'JP', 'JF']),
+              default=None, help='Filter by job status (JQ=queued, JR=running, JP=passed, JF=failed)')
+@click.option('-t', '--target', default=None, help='Filter by target DNS or hostname')
+@click.option('--summary', is_flag=True, default=False, help='Show job count summary by capability and status')
+def jobs(chariot, capability, status, target, summary, filter, details, offset, page):
     """
     List jobs
 
@@ -110,10 +115,24 @@ def jobs(chariot, filter, details, offset, page):
     Example usages:
         - guard list jobs
         - guard list jobs --filter www.example.com
+        - guard list jobs --capability nuclei
+        - guard list jobs --capability diana-agent --details
+        - guard list jobs --status JR
+        - guard list jobs --target api.example.com
+        - guard list jobs --summary
         - guard list jobs --details
         - guard list jobs --page all
     """
-    render_list_results(chariot.jobs.list(filter, offset, pagination_size(page)), details)
+    if summary:
+        print_json(chariot.jobs.summary(pagination_size(page)))
+    elif capability:
+        render_list_results(chariot.jobs.list_by_capability(capability, offset, pagination_size(page)), details)
+    elif status:
+        render_list_results(chariot.jobs.list_by_status(status, offset, pagination_size(page)), details)
+    elif target:
+        render_list_results(chariot.jobs.list_by_target(target, offset, pagination_size(page)), details)
+    else:
+        render_list_results(chariot.jobs.list(filter, offset, pagination_size(page)), details)
 
 
 @list.command()

--- a/praetorian_cli/sdk/entities/jobs.py
+++ b/praetorian_cli/sdk/entities/jobs.py
@@ -148,6 +148,130 @@ class Jobs:
         return self.api.search.by_key_prefix(f'#job#{prefix_filter}',
                                              offset, pages)
 
+    def list_by_status(self, status, offset=None, pages=100000) -> tuple:
+        """
+        List jobs filtered by status code.
+
+        Uses server-side filtering via DynamoDB Status GSI for efficient
+        queries without fetching all jobs.
+
+        :param status: Job status prefix to filter by
+        :type status: str
+        :param offset: The offset for pagination
+        :type offset: str or None
+        :param pages: Maximum number of pages to retrieve
+        :type pages: int
+        :return: A tuple containing (list of matching jobs, next page offset)
+        :rtype: tuple
+
+        **Status Codes:**
+            - JQ: Job is queued for execution
+            - JR: Job is currently running
+            - JP: Job completed successfully
+            - JF: Job failed during execution
+
+        **Example Usage:**
+            >>> # Find all running jobs
+            >>> running, offset = sdk.jobs.list_by_status('JR')
+
+            >>> # Find all failed jobs
+            >>> failed, offset = sdk.jobs.list_by_status('JF')
+        """
+        return self.api.search.by_term(f'status:{status}', kind='job',
+                                       offset=offset, pages=pages)
+
+    def list_by_capability(self, capability, offset=None, pages=100000) -> tuple:
+        """
+        List jobs filtered by capability/scan type.
+
+        Uses server-side filtering via DynamoDB Source GSI. The source
+        field on jobs contains 'capability_name#timestamp', so begins_with
+        matching on the capability name works correctly.
+
+        :param capability: Capability name to filter by (e.g., 'nuclei',
+            'portscan', 'diana-agent', 'julius')
+        :type capability: str
+        :param offset: The offset for pagination
+        :type offset: str or None
+        :param pages: Maximum number of pages to retrieve
+        :type pages: int
+        :return: A tuple containing (list of matching jobs, next page offset)
+        :rtype: tuple
+
+        **Example Usage:**
+            >>> # Find all nuclei scan jobs
+            >>> nuclei_jobs, offset = sdk.jobs.list_by_capability('nuclei')
+
+            >>> # Find all diana-agent jobs
+            >>> diana_jobs, offset = sdk.jobs.list_by_capability('diana-agent')
+        """
+        return self.api.search.by_term(f'source:{capability}', kind='job',
+                                       offset=offset, pages=pages)
+
+    def list_by_target(self, target, offset=None, pages=100000) -> tuple:
+        """
+        List jobs filtered by target DNS or hostname.
+
+        Uses server-side filtering via DynamoDB DNS GSI. This is a more
+        explicit alternative to list(prefix_filter=target) for finding
+        what jobs ran against a specific asset.
+
+        :param target: Target DNS name or hostname to filter by
+        :type target: str
+        :param offset: The offset for pagination
+        :type offset: str or None
+        :param pages: Maximum number of pages to retrieve
+        :type pages: int
+        :return: A tuple containing (list of matching jobs, next page offset)
+        :rtype: tuple
+
+        **Example Usage:**
+            >>> # Find all jobs that targeted a specific domain
+            >>> jobs, offset = sdk.jobs.list_by_target('api.example.com')
+        """
+        return self.list(prefix_filter=target, offset=offset, pages=pages)
+
+    def summary(self, pages=100000) -> dict:
+        """
+        Return job counts grouped by capability and status.
+
+        Fetches all jobs and aggregates counts client-side. This may be
+        slow for accounts with many jobs (e.g., 90k+).
+
+        :param pages: Maximum number of pages to retrieve
+        :type pages: int
+        :return: Dictionary with total count, counts by status, and counts
+            by capability
+        :rtype: dict
+
+        **Example Usage:**
+            >>> summary = sdk.jobs.summary()
+            >>> print(summary['total'])
+            91185
+            >>> print(summary['by_capability'])
+            {'nuclei': 4032, 'portscan': 1424, 'diana-agent': 5, ...}
+            >>> print(summary['by_status'])
+            {'JQ': 50000, 'JP': 30000, 'JR': 6, 'JF': 1000}
+        """
+        jobs, _ = self.list(pages=pages)
+        summary = {
+            'total': len(jobs),
+            'by_status': {},
+            'by_capability': {},
+        }
+        for job in jobs:
+            status = job.get('status', 'unknown')
+            status_code = status[:2] if len(status) >= 2 else status
+            summary['by_status'][status_code] = summary['by_status'].get(status_code, 0) + 1
+
+            source = job.get('source', 'unknown')
+            capability = source.split('#')[0] if '#' in source else source
+            if not capability:
+                capability = 'unknown'
+            summary['by_capability'][capability] = summary['by_capability'].get(capability, 0) + 1
+
+        return summary
+
     def is_failed(self, job):
         """
         Check if a job has failed during execution.

--- a/praetorian_cli/sdk/test/test_job.py
+++ b/praetorian_cli/sdk/test/test_job.py
@@ -52,6 +52,50 @@ class TestJob:
             self.sdk.jobs.add(result['key'], [], invalid_json)
         assert "Invalid JSON in configuration string" in str(e.value)
 
+    def test_list_by_status(self):
+        result = self.sdk.assets.add(self.asset_dns, self.asset_dns)
+        self.sdk.jobs.add(result['key'])
+
+        jobs, _ = self.sdk.jobs.list_by_status('JQ')
+        assert isinstance(jobs, list)
+        assert len(jobs) > 0
+        for job in jobs:
+            assert job['status'].startswith('JQ')
+
+    def test_list_by_capability(self):
+        result = self.sdk.assets.add(self.asset_dns, self.asset_dns)
+        self.sdk.jobs.add(result['key'], ['nuclei'])
+
+        jobs, _ = self.sdk.jobs.list_by_capability('nuclei')
+        assert isinstance(jobs, list)
+        assert len(jobs) > 0
+        for job in jobs:
+            assert job.get('source', '').startswith('nuclei')
+
+    def test_list_by_target(self):
+        result = self.sdk.assets.add(self.asset_dns, self.asset_dns)
+        self.sdk.jobs.add(result['key'])
+
+        jobs, _ = self.sdk.jobs.list_by_target(self.asset_dns)
+        assert isinstance(jobs, list)
+        assert len(jobs) > 0
+        for job in jobs:
+            assert self.asset_dns in job.get('dns', '') or self.asset_dns in job.get('key', '')
+
+    def test_summary(self):
+        result = self.sdk.assets.add(self.asset_dns, self.asset_dns)
+        self.sdk.jobs.add(result['key'])
+
+        summary = self.sdk.jobs.summary()
+        assert isinstance(summary, dict)
+        assert 'total' in summary
+        assert 'by_status' in summary
+        assert 'by_capability' in summary
+        assert summary['total'] > 0
+        assert isinstance(summary['by_status'], dict)
+        assert isinstance(summary['by_capability'], dict)
+        assert len(summary['by_status']) > 0
+
     def teardown_class(self):
         clean_test_entities(self.sdk, self)
         if self.was_frozen:

--- a/praetorian_cli/ui/console/commands/context.py
+++ b/praetorian_cli/ui/console/commands/context.py
@@ -14,11 +14,28 @@ class ContextCommands:
         if len(args) < 2:
             self.console.print('[dim]Usage: set <account|scope|mode|target> <value>[/dim]')
             return
-        key, value = args[0].lower(), ' '.join(args[1:])
+        key, value = args[0].lower(), ' '.join(args[1:]).strip().rstrip('.')
         if key == 'account':
+            # Always validate against the real account list
+            if not (hasattr(self, '_account_list') and self._account_list):
+                try:
+                    accounts_list, _ = self.sdk.accounts.list()
+                    self._account_list = [a.get('name', '') for a in (accounts_list or [])]
+                except Exception:
+                    self._account_list = []
+            if self._account_list and value not in self._account_list:
+                self.console.print(f'[error]Unknown account: {value}[/error]')
+                self.console.print(f'[dim]Run "accounts" to see the list, or "switch <#>" to select by number.[/dim]')
+                return
             self.context.account = value
             self.context.clear_conversation()
+            self.context.clear_tool()
+            # Update SDK impersonation so all API calls use this account
+            self.sdk.keychain.account = value
+            # Clear stale target lists from previous engagement
+            self._target_list = []
             self.console.print(f'[success]Account set to {value}[/success]')
+            self._show_engagement_status()
         elif key == 'scope':
             self.context.scope = value
             self.console.print(f'[success]Scope set to {value}[/success]')
@@ -55,8 +72,17 @@ class ContextCommands:
                     return
             self.context.target = value
             self.console.print(f'[success]TARGET => {value}[/success]')
+        elif key == 'verbose':
+            if value.lower() in ('on', 'true', '1', 'yes'):
+                self.context.verbose = True
+                self.console.print('[success]Verbose mode ON -- tool calls will show full details[/success]')
+            elif value.lower() in ('off', 'false', '0', 'no'):
+                self.context.verbose = False
+                self.console.print('[success]Verbose mode OFF[/success]')
+            else:
+                self.console.print('[error]Usage: set verbose on|off[/error]')
         else:
-            self.console.print(f'[dim]Unknown setting: {key}. Use: account, scope, mode, target[/dim]')
+            self.console.print(f'[dim]Unknown setting: {key}. Use: account, scope, mode, target, verbose[/dim]')
 
     def _cmd_unset(self, args):
         if not args:
@@ -81,6 +107,7 @@ class ContextCommands:
             table.add_row('Mode', self.context.mode)
             table.add_row('Tool', self.context.active_tool or '[dim]none[/dim]')
             table.add_row('Target', self.context.target or '[dim]not set[/dim]')
+            table.add_row('Verbose', 'on' if self.context.verbose else '[dim]off[/dim]')
             table.add_row('Agent', self.context.active_agent or '[dim]default[/dim]')
             table.add_row('Conversation', self.context.conversation_id[:8] + '...' if self.context.conversation_id else '[dim]none[/dim]')
             self.console.print(table)
@@ -90,6 +117,8 @@ class ContextCommands:
             self._cmd_options(args[1:])
         elif target == 'tools':
             self._cmd_run([])
+        elif target in ('calls', 'toolcalls'):
+            self._show_tool_calls()
         elif target == 'assets':
             self._cmd_assets(args[1:])
         elif target == 'risks':
@@ -196,6 +225,45 @@ class ContextCommands:
                     self.console.print(f'[dim]Not found: {key}[/dim]')
         except Exception as e:
             self.console.print(f'[error]{e}[/error]')
+
+    def _show_tool_calls(self):
+        """Show tool calls from the last Marcus interaction."""
+        tool_log = getattr(self, '_last_tool_log', None)
+        if not tool_log:
+            self.console.print('[dim]No tool calls recorded. Run "ask" or "marcus" first.[/dim]')
+            return
+
+        table = Table(title='Last Marcus Tool Calls', border_style=self.colors['primary'])
+        table.add_column('#', style=self.colors['dim'], width=3)
+        table.add_column('Type', style=self.colors['accent'], width=10)
+        table.add_column('Name', style=f'bold {self.colors["primary"]}')
+        table.add_column('Details')
+
+        for i, entry in enumerate(tool_log, 1):
+            if entry['role'] == 'tool call':
+                name = entry.get('name', 'tool')
+                # Try to show input summary
+                detail = ''
+                try:
+                    data = json.loads(entry['content']) if isinstance(entry['content'], str) else entry['content']
+                    if isinstance(data, dict):
+                        inp = data.get('input', data.get('arguments', data))
+                        detail = json.dumps(inp, default=str)
+                        if len(detail) > 120:
+                            detail = detail[:120] + '...'
+                except Exception:
+                    detail = entry['content'][:120] if entry['content'] else ''
+                table.add_row(str(i), 'call', name, detail)
+            elif entry['role'] == 'tool response':
+                name = entry.get('name', '')
+                summary = entry.get('summary', '')
+                detail = summary if summary else ''
+                if not detail:
+                    detail = entry['content'][:120] + '...' if len(entry['content']) > 120 else entry['content']
+                table.add_row(str(i), 'response', name, detail)
+
+        self.console.print(table)
+        self.console.print(f'[dim]Use "set verbose on" to see full details inline during Marcus queries.[/dim]')
 
     def _cmd_use(self, args):
         """Select a tool/capability or switch engagement -- context-aware."""

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -29,9 +29,10 @@ class MarcusCommands:
         response_text = self._send_to_marcus(message)
 
         if response_text:
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
             self.console.print(Panel(
                 Markdown(response_text),
-                title='Marcus',
+                title=panel_title,
                 border_style=self.colors['primary'],
             ))
 
@@ -58,7 +59,10 @@ class MarcusCommands:
 
         self.console.print(f'[primary]Entering conversation mode[/primary] [dim](type "/back" to return)[/dim]')
         self.console.print(f'[dim]Commands: /back, /new, /query, /agent, or just chat[/dim]')
-        self.console.print(f'[dim]Context: {self.context.summary()}[/dim]\n')
+        self.console.print(f'[dim]Context: {self.context.summary()}[/dim]')
+        if not self.context.account:
+            self.console.print(f'[warning]No account set -- Marcus will query your personal account. Use "set account <email>" first.[/warning]')
+        self.console.print()
 
         while True:
             try:
@@ -151,8 +155,11 @@ class MarcusCommands:
         max_wait = 180
         start_time = time.time()
         pending_tool = None
+        tool_log = []  # Store all tool calls/responses for this interaction
+        seen_tool_keys = set()  # Track which tool messages we displayed live
 
-        self.console.print(f'[dim]Thinking...[/dim]', end='')
+        acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
+        self.console.print(f'[dim]Thinking...[/dim]{acct_label}', end='')
 
         while time.time() - start_time < max_wait:
             try:
@@ -172,38 +179,68 @@ class MarcusCommands:
                     if role == 'chariot':
                         if pending_tool:
                             self.console.print()  # newline after tool output
+                        # Retroactively show any tool calls we missed during polling
+                        missed = [t for t in tool_log if t['key'] not in seen_tool_keys]
+                        if missed:
+                            self.console.print()
+                            for entry in missed:
+                                if entry['role'] == 'tool call':
+                                    self.console.print(f'  [dim]->[/dim] [accent]{entry["name"]}[/accent]', end='')
+                                elif entry['role'] == 'tool response':
+                                    summary = entry.get('summary', '')
+                                    if summary:
+                                        self.console.print(f' [dim]-- {summary}[/dim]', end='')
+                                    self.console.print(f' [success]done[/success]')
+                        # Save tool log for "show tools" command
+                        self._last_tool_log = tool_log
                         return content
                     elif role == 'tool call':
-                        # Parse tool call content for display
                         tool_name = self._parse_tool_name(content, msg)
+                        tool_log.append({'role': role, 'name': tool_name, 'content': content, 'msg': msg, 'key': msg.get('key', '')})
                         if pending_tool:
                             self.console.print(f' [success]done[/success]')
                         self.console.print(f'  [dim]->[/dim] [accent]{tool_name}[/accent]', end='')
+                        seen_tool_keys.add(msg.get('key', ''))
+                        if self.context.verbose:
+                            self.console.print()
+                            self._print_verbose_tool_call(content, msg)
                         pending_tool = tool_name
                     elif role == 'tool response':
-                        # Show result summary
                         result_summary = self._parse_tool_result(content)
+                        inferred = self._infer_tool_from_response(content)
+                        tool_log.append({'role': role, 'name': inferred, 'content': content, 'summary': result_summary, 'key': msg.get('key', '')})
+                        # Retroactively fix the pending tool name if we inferred one
+                        if inferred and pending_tool == 'tool':
+                            # Rewrite the line: clear current and reprint with inferred name
+                            self.console.print(f'\r  [dim]->[/dim] [accent]{inferred}[/accent]', end='')
                         if result_summary:
                             self.console.print(f' [dim]-- {result_summary}[/dim]', end='')
                         self.console.print(f' [success]done[/success]')
+                        seen_tool_keys.add(msg.get('key', ''))
+                        if self.context.verbose:
+                            self._print_verbose_tool_response(content)
                         pending_tool = None
             except Exception:
                 pass
 
             time.sleep(1)
 
+        self._last_tool_log = tool_log
         self.console.print('\n[warning]Timed out waiting for response[/warning]')
         return None
 
     def _parse_tool_name(self, content: str, msg: dict = None) -> str:
         """Extract a human-readable tool name from a tool call message."""
-        # Try toolUseContent field first (structured tool input)
-        tool_content = msg.get('toolUseContent', '') if msg else ''
-        # Try the message name field (some backends store tool name there)
-        msg_name = msg.get('name', '') if msg else ''
-        if msg_name and msg_name not in ('user', 'chariot', 'tool call', 'tool response'):
-            return msg_name
+        # Try explicit name fields first
+        if msg:
+            msg_name = msg.get('name', '')
+            if msg_name and msg_name not in ('user', 'chariot', 'tool call', 'tool response'):
+                return msg_name
+            tool_content = msg.get('toolUseContent', '')
+        else:
+            tool_content = ''
 
+        # Try parsing JSON content for structured tool calls
         for raw in (tool_content, content):
             if not raw:
                 continue
@@ -223,6 +260,29 @@ class MarcusCommands:
                 continue
         return 'tool'
 
+    def _infer_tool_from_response(self, content: str) -> str:
+        """Infer what tool was called based on the response content."""
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            if isinstance(data, dict):
+                if 'instructions' in data:
+                    return 'schema_lookup'
+                for key in ('assets', 'risks', 'seeds', 'jobs', 'preseeds'):
+                    if key in data:
+                        return f'search_{key}'
+                if 'status' in data:
+                    return 'status_check'
+            elif isinstance(data, list) and data:
+                first = data[0]
+                if isinstance(first, dict):
+                    if 'dns' in first or 'source' in first:
+                        return 'search_assets'
+                    if 'status' in first and 'finding' in str(first):
+                        return 'search_risks'
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            pass
+        return ''
+
     def _parse_tool_result(self, content: str) -> str:
         """Extract a brief summary from a tool response message."""
         try:
@@ -241,6 +301,38 @@ class MarcusCommands:
         except (json.JSONDecodeError, TypeError, AttributeError):
             pass
         return ''
+
+    def _print_verbose_tool_call(self, content: str, msg: dict):
+        """Print expanded tool call details in verbose mode."""
+        # Show all message fields except common ones
+        extra_keys = {k: v for k, v in msg.items() if k not in ('key', 'role', 'content', 'source') and v}
+        if extra_keys:
+            self.console.print(f'    [dim]msg fields: {json.dumps(extra_keys, default=str)[:200]}[/dim]')
+        # Show the tool call content (input/arguments)
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            formatted = json.dumps(data, indent=2, default=str)
+            # Truncate to avoid flooding the terminal
+            if len(formatted) > 500:
+                formatted = formatted[:500] + '\n    ...'
+            for line in formatted.split('\n'):
+                self.console.print(f'    [dim]{line}[/dim]')
+        except (json.JSONDecodeError, TypeError):
+            if content:
+                self.console.print(f'    [dim]{content[:300]}[/dim]')
+
+    def _print_verbose_tool_response(self, content: str):
+        """Print expanded tool response details in verbose mode."""
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            formatted = json.dumps(data, indent=2, default=str)
+            if len(formatted) > 800:
+                formatted = formatted[:800] + '\n    ...'
+            for line in formatted.split('\n'):
+                self.console.print(f'    [dim]{line}[/dim]')
+        except (json.JSONDecodeError, TypeError):
+            if content:
+                self.console.print(f'    [dim]{content[:400]}[/dim]')
 
     def _marcus_read(self, args):
         """Have Marcus read and analyze a file."""
@@ -283,7 +375,8 @@ class MarcusCommands:
         message = self.context.apply_scope_to_message(message)
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _marcus_ingest(self, args):
         """Have Marcus read a file and automatically ingest data into Guard."""
@@ -314,7 +407,8 @@ class MarcusCommands:
         self.console.print(f'[info]Marcus is reading and ingesting {path}...[/info]')
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus -- Ingestion Complete', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account} -- Ingestion Complete' if self.context.account else 'Marcus -- Ingestion Complete'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _marcus_do(self, args):
         """Give Marcus a direct instruction to execute."""
@@ -330,7 +424,8 @@ class MarcusCommands:
         message = self.context.apply_scope_to_message(instruction)
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _cmd_critfinder(self, args):
         """Run CritFinder adversarial vulnerability research pipeline."""

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -110,6 +110,19 @@ class GuardConsole(
                 f' <style fg="{COMPLEMENTARY_GOLD}" bg="">({tool})</style>'
                 f' <style fg="{PRIMARY_RED}" bg="">&gt;</style> '
             )
+        if self.context.account:
+            # Show short account label (strip chariot+/guard+ prefix and @praetorian.com suffix)
+            acct = self.context.account
+            for prefix in ('chariot+', 'guard+'):
+                if acct.startswith(prefix):
+                    acct = acct[len(prefix):]
+                    break
+            acct = acct.replace('@praetorian.com', '')
+            return HTML(
+                f'<style fg="{PRIMARY_RED}" bg="">guard</style>'
+                f' <style fg="{COMPLEMENTARY_GOLD}" bg="">[{acct}]</style>'
+                f' <style fg="{PRIMARY_RED}" bg="">&gt;</style> '
+            )
         return HTML(f'<style fg="{PRIMARY_RED}" bg="">guard &gt;</style> ')
 
     def _show_banner(self):

--- a/praetorian_cli/ui/console/context.py
+++ b/praetorian_cli/ui/console/context.py
@@ -14,6 +14,7 @@ class EngagementContext:
     active_tool: Optional[str] = None
     active_tool_config: Optional[Dict[str, Any]] = None
     target: Optional[str] = None
+    verbose: bool = False
 
     def clear_conversation(self):
         self.conversation_id = None


### PR DESCRIPTION
## Summary (required)

Adds filtering and aggregation methods to the Jobs SDK class and CLI. Previously, finding jobs by scan type or status required fetching all jobs and filtering client-side. The new methods use existing server-side DynamoDB GSI queries for efficient filtering:
  - list_by_capability() — filter by scan type (e.g., nuclei, portscan, diana-agent)
  - list_by_status() — filter by job state (JQ, JR, JP, JF)
  - list_by_target() — filter by target DNS/hostname
  - summary() — aggregate counts by capability and status
No backend changes. All changes are additive

## JIRA (required)
N/A
