### PR TITLE
fix: validate set account and improve Marcus tool call display

### DIFF
--- a/praetorian_cli/ui/console/commands/context.py
+++ b/praetorian_cli/ui/console/commands/context.py
@@ -14,11 +14,28 @@ class ContextCommands:
         if len(args) < 2:
             self.console.print('[dim]Usage: set <account|scope|mode|target> <value>[/dim]')
             return
-        key, value = args[0].lower(), ' '.join(args[1:])
+        key, value = args[0].lower(), ' '.join(args[1:]).strip().rstrip('.')
         if key == 'account':
+            # Always validate against the real account list
+            if not (hasattr(self, '_account_list') and self._account_list):
+                try:
+                    accounts_list, _ = self.sdk.accounts.list()
+                    self._account_list = [a.get('name', '') for a in (accounts_list or [])]
+                except Exception:
+                    self._account_list = []
+            if self._account_list and value not in self._account_list:
+                self.console.print(f'[error]Unknown account: {value}[/error]')
+                self.console.print(f'[dim]Run "accounts" to see the list, or "switch <#>" to select by number.[/dim]')
+                return
             self.context.account = value
             self.context.clear_conversation()
+            self.context.clear_tool()
+            # Update SDK impersonation so all API calls use this account
+            self.sdk.keychain.account = value
+            # Clear stale target lists from previous engagement
+            self._target_list = []
             self.console.print(f'[success]Account set to {value}[/success]')
+            self._show_engagement_status()
         elif key == 'scope':
             self.context.scope = value
             self.console.print(f'[success]Scope set to {value}[/success]')
@@ -55,8 +72,17 @@ class ContextCommands:
                     return
             self.context.target = value
             self.console.print(f'[success]TARGET => {value}[/success]')
+        elif key == 'verbose':
+            if value.lower() in ('on', 'true', '1', 'yes'):
+                self.context.verbose = True
+                self.console.print('[success]Verbose mode ON -- tool calls will show full details[/success]')
+            elif value.lower() in ('off', 'false', '0', 'no'):
+                self.context.verbose = False
+                self.console.print('[success]Verbose mode OFF[/success]')
+            else:
+                self.console.print('[error]Usage: set verbose on|off[/error]')
         else:
-            self.console.print(f'[dim]Unknown setting: {key}. Use: account, scope, mode, target[/dim]')
+            self.console.print(f'[dim]Unknown setting: {key}. Use: account, scope, mode, target, verbose[/dim]')
 
     def _cmd_unset(self, args):
         if not args:
@@ -81,6 +107,7 @@ class ContextCommands:
             table.add_row('Mode', self.context.mode)
             table.add_row('Tool', self.context.active_tool or '[dim]none[/dim]')
             table.add_row('Target', self.context.target or '[dim]not set[/dim]')
+            table.add_row('Verbose', 'on' if self.context.verbose else '[dim]off[/dim]')
             table.add_row('Agent', self.context.active_agent or '[dim]default[/dim]')
             table.add_row('Conversation', self.context.conversation_id[:8] + '...' if self.context.conversation_id else '[dim]none[/dim]')
             self.console.print(table)
@@ -90,6 +117,8 @@ class ContextCommands:
             self._cmd_options(args[1:])
         elif target == 'tools':
             self._cmd_run([])
+        elif target in ('calls', 'toolcalls'):
+            self._show_tool_calls()
         elif target == 'assets':
             self._cmd_assets(args[1:])
         elif target == 'risks':
@@ -196,6 +225,45 @@ class ContextCommands:
                     self.console.print(f'[dim]Not found: {key}[/dim]')
         except Exception as e:
             self.console.print(f'[error]{e}[/error]')
+
+    def _show_tool_calls(self):
+        """Show tool calls from the last Marcus interaction."""
+        tool_log = getattr(self, '_last_tool_log', None)
+        if not tool_log:
+            self.console.print('[dim]No tool calls recorded. Run "ask" or "marcus" first.[/dim]')
+            return
+
+        table = Table(title='Last Marcus Tool Calls', border_style=self.colors['primary'])
+        table.add_column('#', style=self.colors['dim'], width=3)
+        table.add_column('Type', style=self.colors['accent'], width=10)
+        table.add_column('Name', style=f'bold {self.colors["primary"]}')
+        table.add_column('Details')
+
+        for i, entry in enumerate(tool_log, 1):
+            if entry['role'] == 'tool call':
+                name = entry.get('name', 'tool')
+                # Try to show input summary
+                detail = ''
+                try:
+                    data = json.loads(entry['content']) if isinstance(entry['content'], str) else entry['content']
+                    if isinstance(data, dict):
+                        inp = data.get('input', data.get('arguments', data))
+                        detail = json.dumps(inp, default=str)
+                        if len(detail) > 120:
+                            detail = detail[:120] + '...'
+                except Exception:
+                    detail = entry['content'][:120] if entry['content'] else ''
+                table.add_row(str(i), 'call', name, detail)
+            elif entry['role'] == 'tool response':
+                name = entry.get('name', '')
+                summary = entry.get('summary', '')
+                detail = summary if summary else ''
+                if not detail:
+                    detail = entry['content'][:120] + '...' if len(entry['content']) > 120 else entry['content']
+                table.add_row(str(i), 'response', name, detail)
+
+        self.console.print(table)
+        self.console.print(f'[dim]Use "set verbose on" to see full details inline during Marcus queries.[/dim]')
 
     def _cmd_use(self, args):
         """Select a tool/capability or switch engagement -- context-aware."""

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -29,9 +29,10 @@ class MarcusCommands:
         response_text = self._send_to_marcus(message)
 
         if response_text:
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
             self.console.print(Panel(
                 Markdown(response_text),
-                title='Marcus',
+                title=panel_title,
                 border_style=self.colors['primary'],
             ))
 
@@ -58,7 +59,10 @@ class MarcusCommands:
 
         self.console.print(f'[primary]Entering conversation mode[/primary] [dim](type "/back" to return)[/dim]')
         self.console.print(f'[dim]Commands: /back, /new, /query, /agent, or just chat[/dim]')
-        self.console.print(f'[dim]Context: {self.context.summary()}[/dim]\n')
+        self.console.print(f'[dim]Context: {self.context.summary()}[/dim]')
+        if not self.context.account:
+            self.console.print(f'[warning]No account set -- Marcus will query your personal account. Use "set account <email>" first.[/warning]')
+        self.console.print()
 
         while True:
             try:
@@ -151,8 +155,11 @@ class MarcusCommands:
         max_wait = 180
         start_time = time.time()
         pending_tool = None
+        tool_log = []  # Store all tool calls/responses for this interaction
+        seen_tool_keys = set()  # Track which tool messages we displayed live
 
-        self.console.print(f'[dim]Thinking...[/dim]', end='')
+        acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
+        self.console.print(f'[dim]Thinking...[/dim]{acct_label}', end='')
 
         while time.time() - start_time < max_wait:
             try:
@@ -172,38 +179,68 @@ class MarcusCommands:
                     if role == 'chariot':
                         if pending_tool:
                             self.console.print()  # newline after tool output
+                        # Retroactively show any tool calls we missed during polling
+                        missed = [t for t in tool_log if t['key'] not in seen_tool_keys]
+                        if missed:
+                            self.console.print()
+                            for entry in missed:
+                                if entry['role'] == 'tool call':
+                                    self.console.print(f'  [dim]->[/dim] [accent]{entry["name"]}[/accent]', end='')
+                                elif entry['role'] == 'tool response':
+                                    summary = entry.get('summary', '')
+                                    if summary:
+                                        self.console.print(f' [dim]-- {summary}[/dim]', end='')
+                                    self.console.print(f' [success]done[/success]')
+                        # Save tool log for "show tools" command
+                        self._last_tool_log = tool_log
                         return content
                     elif role == 'tool call':
-                        # Parse tool call content for display
                         tool_name = self._parse_tool_name(content, msg)
+                        tool_log.append({'role': role, 'name': tool_name, 'content': content, 'msg': msg, 'key': msg.get('key', '')})
                         if pending_tool:
                             self.console.print(f' [success]done[/success]')
                         self.console.print(f'  [dim]->[/dim] [accent]{tool_name}[/accent]', end='')
+                        seen_tool_keys.add(msg.get('key', ''))
+                        if self.context.verbose:
+                            self.console.print()
+                            self._print_verbose_tool_call(content, msg)
                         pending_tool = tool_name
                     elif role == 'tool response':
-                        # Show result summary
                         result_summary = self._parse_tool_result(content)
+                        inferred = self._infer_tool_from_response(content)
+                        tool_log.append({'role': role, 'name': inferred, 'content': content, 'summary': result_summary, 'key': msg.get('key', '')})
+                        # Retroactively fix the pending tool name if we inferred one
+                        if inferred and pending_tool == 'tool':
+                            # Rewrite the line: clear current and reprint with inferred name
+                            self.console.print(f'\r  [dim]->[/dim] [accent]{inferred}[/accent]', end='')
                         if result_summary:
                             self.console.print(f' [dim]-- {result_summary}[/dim]', end='')
                         self.console.print(f' [success]done[/success]')
+                        seen_tool_keys.add(msg.get('key', ''))
+                        if self.context.verbose:
+                            self._print_verbose_tool_response(content)
                         pending_tool = None
             except Exception:
                 pass
 
             time.sleep(1)
 
+        self._last_tool_log = tool_log
         self.console.print('\n[warning]Timed out waiting for response[/warning]')
         return None
 
     def _parse_tool_name(self, content: str, msg: dict = None) -> str:
         """Extract a human-readable tool name from a tool call message."""
-        # Try toolUseContent field first (structured tool input)
-        tool_content = msg.get('toolUseContent', '') if msg else ''
-        # Try the message name field (some backends store tool name there)
-        msg_name = msg.get('name', '') if msg else ''
-        if msg_name and msg_name not in ('user', 'chariot', 'tool call', 'tool response'):
-            return msg_name
+        # Try explicit name fields first
+        if msg:
+            msg_name = msg.get('name', '')
+            if msg_name and msg_name not in ('user', 'chariot', 'tool call', 'tool response'):
+                return msg_name
+            tool_content = msg.get('toolUseContent', '')
+        else:
+            tool_content = ''
 
+        # Try parsing JSON content for structured tool calls
         for raw in (tool_content, content):
             if not raw:
                 continue
@@ -223,6 +260,29 @@ class MarcusCommands:
                 continue
         return 'tool'
 
+    def _infer_tool_from_response(self, content: str) -> str:
+        """Infer what tool was called based on the response content."""
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            if isinstance(data, dict):
+                if 'instructions' in data:
+                    return 'schema_lookup'
+                for key in ('assets', 'risks', 'seeds', 'jobs', 'preseeds'):
+                    if key in data:
+                        return f'search_{key}'
+                if 'status' in data:
+                    return 'status_check'
+            elif isinstance(data, list) and data:
+                first = data[0]
+                if isinstance(first, dict):
+                    if 'dns' in first or 'source' in first:
+                        return 'search_assets'
+                    if 'status' in first and 'finding' in str(first):
+                        return 'search_risks'
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            pass
+        return ''
+
     def _parse_tool_result(self, content: str) -> str:
         """Extract a brief summary from a tool response message."""
         try:
@@ -241,6 +301,38 @@ class MarcusCommands:
         except (json.JSONDecodeError, TypeError, AttributeError):
             pass
         return ''
+
+    def _print_verbose_tool_call(self, content: str, msg: dict):
+        """Print expanded tool call details in verbose mode."""
+        # Show all message fields except common ones
+        extra_keys = {k: v for k, v in msg.items() if k not in ('key', 'role', 'content', 'source') and v}
+        if extra_keys:
+            self.console.print(f'    [dim]msg fields: {json.dumps(extra_keys, default=str)[:200]}[/dim]')
+        # Show the tool call content (input/arguments)
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            formatted = json.dumps(data, indent=2, default=str)
+            # Truncate to avoid flooding the terminal
+            if len(formatted) > 500:
+                formatted = formatted[:500] + '\n    ...'
+            for line in formatted.split('\n'):
+                self.console.print(f'    [dim]{line}[/dim]')
+        except (json.JSONDecodeError, TypeError):
+            if content:
+                self.console.print(f'    [dim]{content[:300]}[/dim]')
+
+    def _print_verbose_tool_response(self, content: str):
+        """Print expanded tool response details in verbose mode."""
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+            formatted = json.dumps(data, indent=2, default=str)
+            if len(formatted) > 800:
+                formatted = formatted[:800] + '\n    ...'
+            for line in formatted.split('\n'):
+                self.console.print(f'    [dim]{line}[/dim]')
+        except (json.JSONDecodeError, TypeError):
+            if content:
+                self.console.print(f'    [dim]{content[:400]}[/dim]')
 
     def _marcus_read(self, args):
         """Have Marcus read and analyze a file."""
@@ -283,7 +375,8 @@ class MarcusCommands:
         message = self.context.apply_scope_to_message(message)
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _marcus_ingest(self, args):
         """Have Marcus read a file and automatically ingest data into Guard."""
@@ -314,7 +407,8 @@ class MarcusCommands:
         self.console.print(f'[info]Marcus is reading and ingesting {path}...[/info]')
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus -- Ingestion Complete', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account} -- Ingestion Complete' if self.context.account else 'Marcus -- Ingestion Complete'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _marcus_do(self, args):
         """Give Marcus a direct instruction to execute."""
@@ -330,7 +424,8 @@ class MarcusCommands:
         message = self.context.apply_scope_to_message(instruction)
         response = self._send_to_marcus(message)
         if response:
-            self.console.print(Panel(Markdown(response), title='Marcus', border_style=self.colors['primary']))
+            panel_title = f'Marcus @ {self.context.account}' if self.context.account else 'Marcus'
+            self.console.print(Panel(Markdown(response), title=panel_title, border_style=self.colors['primary']))
 
     def _cmd_critfinder(self, args):
         """Run CritFinder adversarial vulnerability research pipeline."""

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -110,6 +110,19 @@ class GuardConsole(
                 f' <style fg="{COMPLEMENTARY_GOLD}" bg="">({tool})</style>'
                 f' <style fg="{PRIMARY_RED}" bg="">&gt;</style> '
             )
+        if self.context.account:
+            # Show short account label (strip chariot+/guard+ prefix and @praetorian.com suffix)
+            acct = self.context.account
+            for prefix in ('chariot+', 'guard+'):
+                if acct.startswith(prefix):
+                    acct = acct[len(prefix):]
+                    break
+            acct = acct.replace('@praetorian.com', '')
+            return HTML(
+                f'<style fg="{PRIMARY_RED}" bg="">guard</style>'
+                f' <style fg="{COMPLEMENTARY_GOLD}" bg="">[{acct}]</style>'
+                f' <style fg="{PRIMARY_RED}" bg="">&gt;</style> '
+            )
         return HTML(f'<style fg="{PRIMARY_RED}" bg="">guard &gt;</style> ')
 
     def _show_banner(self):

--- a/praetorian_cli/ui/console/context.py
+++ b/praetorian_cli/ui/console/context.py
@@ -14,6 +14,7 @@ class EngagementContext:
     active_tool: Optional[str] = None
     active_tool_config: Optional[Dict[str, Any]] = None
     target: Optional[str] = None
+    verbose: bool = False
 
     def clear_conversation(self):
         self.conversation_id = None


### PR DESCRIPTION
## Summary (required)
  - **Fixed `set account` silently failing** — was only setting display context, not `sdk.keychain.account`, so all Marcus/API queries hit the wrong account
  - **Added account validation** — fetches real account list and rejects unknown accounts instead of accepting anything
  - **Added account display** — prompt shows `guard [syniverse] >`, Marcus panels show `Marcus @ account`, Thinking line shows active account
  - **Added `set verbose on/off`** and **`show calls`** — inspect Marcus tool calls inline or after the fact
  - **Infer tool names from responses** — backend doesn't send tool names, so we detect them from response content (schema_lookup, search_assets, etc.)

## JIRA (required)
N/A
