### PR TITLE
Add --allowed-domain option to customer onboard command

### DIFF
--- a/praetorian_cli/handlers/engagement.py
+++ b/praetorian_cli/handlers/engagement.py
@@ -48,8 +48,7 @@ def create_customer(sdk, email, display_name, scan_level, customer_type, collabo
                 collabs.append({'email': c, 'role': 'admin'})
         body['collaborators'] = collabs
 
-    if allowed_domain:
-        body['allowed_domains'] = [d.lower().strip() for d in allowed_domain]
+    body['allowed_domains'] = [d.lower().strip() for d in allowed_domain]
 
     result = sdk.post('customer/onboard', body)
     click.echo(f'Customer created: {email} ({display_name})')

--- a/praetorian_cli/handlers/engagement.py
+++ b/praetorian_cli/handlers/engagement.py
@@ -18,16 +18,17 @@ from praetorian_cli.handlers.add import add
 @click.option('--type', 'customer_type', type=click.Choice(['ENGAGEMENT', 'MANAGED', 'SAAS', 'PILOT', 'FREEMIUM']),
               default='ENGAGEMENT', show_default=True, help='Customer type')
 @click.option('--collaborator', multiple=True, help='Additional collaborator emails (format: email:role)')
-def create_customer(sdk, email, display_name, scan_level, customer_type, collaborator):
+@click.option('--allowed-domain', multiple=True, help='Allowed email domains for collaborators (e.g., acme.com)')
+def create_customer(sdk, email, display_name, scan_level, customer_type, collaborator, allowed_domain):
     """ Create a new customer account on the Guard platform
 
     Creates a Cognito user, Guard account, and adds default collaborators.
 
     \b
     Example usages:
-        - guard add customer --email ops@acme.com --name "ACME Corp"
-        - guard add customer --email ops@acme.com --name "ACME Corp" --type MANAGED
-        - guard add customer --email ops@acme.com --name "ACME Corp" --collaborator "analyst@praetorian.com:admin"
+        - guard add customer --email ops@acme.com --name "ACME Corp" --allowed-domain acme.com
+        - guard add customer --email ops@acme.com --name "ACME Corp" --type MANAGED --allowed-domain acme.com
+        - guard add customer --email ops@acme.com --name "ACME Corp" --allowed-domain acme.com --collaborator "analyst@praetorian.com:admin"
     """
     body = {
         'username': email,
@@ -46,6 +47,9 @@ def create_customer(sdk, email, display_name, scan_level, customer_type, collabo
             else:
                 collabs.append({'email': c, 'role': 'admin'})
         body['collaborators'] = collabs
+
+    if allowed_domain:
+        body['allowed_domains'] = [d.lower().strip() for d in allowed_domain]
 
     result = sdk.post('customer/onboard', body)
     click.echo(f'Customer created: {email} ({display_name})')

--- a/praetorian_cli/ui/console/commands/accounts.py
+++ b/praetorian_cli/ui/console/commands/accounts.py
@@ -176,8 +176,8 @@ class AccountCommands:
         name = params.get('name', '')
 
         if not email or not name:
-            self.console.print('[dim]Usage: engagements create email=ops@acme.com name="ACME Corp"[/dim]')
-            self.console.print('[dim]Optional: type=ENGAGEMENT scan-level=A[/dim]')
+            self.console.print('[dim]Usage: engagements create email=ops@acme.com name="ACME Corp" allowed-domain=acme.com[/dim]')
+            self.console.print('[dim]Optional: type=ENGAGEMENT scan-level=A allowed-domain=acme.com[/dim]')
             return
 
         from praetorian_cli.handlers.engagement import _generate_password
@@ -188,6 +188,10 @@ class AccountCommands:
             'scan_level': params.get('scan-level', 'A'),
             'customer_type': params.get('type', 'ENGAGEMENT'),
         }
+
+        allowed_domain = params.get('allowed-domain', '')
+        if allowed_domain:
+            body['allowed_domains'] = [d.lower().strip() for d in allowed_domain.split(',')]
 
         try:
             with self.console.status('Creating customer...', spinner='dots', spinner_style=self.colors['primary']):


### PR DESCRIPTION
## Summary
- Adds `--allowed-domain` (repeatable) option to `guard add customer` CLI command
- Adds `allowed-domain=` (comma-separated) support to the `engagements create` console REPL command
- Domains are lowercased/trimmed and sent as `allowed_domains` in the `/customer/onboard` request body

The Guard API now requires `allowed_domains` on the onboard endpoint. Without at least one domain, onboarding fails with `400: allowed_domains is required`.

## Test plan
- [x] Verified `--allowed-domain` flag appears in `guard add customer --help`
- [x] Successfully created a customer account with `--allowed-domain redventures.com` against production Guard API
- [ ] Verify console REPL `engagements create` with `allowed-domain=domain.com` parameter
- [ ] Verify multiple domains: `--allowed-domain acme.com --allowed-domain partner.org`