### PR TITLE
fix(guard): tool-arg passthrough for guard run tool and console run (ENG-3042)

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -114,6 +114,19 @@ guard (brutus) > 10.0.1.5      # runs locally, uploads results to Guard
 
 Use `--remote` to force backend execution, `--local` to force local.
 
+### Passing tool-specific flags
+
+Any arguments after `<target>` that the console doesn't recognise are forwarded
+verbatim to the local tool binary. Use `--` as an explicit separator if a flag
+collides with a console-owned option (`--ask`, `--wait`).
+
+    run brutus 10.0.1.5:22 --protocol ssh -U users.txt
+    run brutus 10.0.1.5:22 -- --wait --spray       # forwards --wait to brutus
+
+`run <tool> --help` runs the local binary's `--help` and streams the output
+into the console. Extra arguments require the binary to be installed
+(`install <tool>`) and are rejected for the Marcus agent path (`--ask`).
+
 ## Target Resolution
 
 Targets can be specified as:

--- a/docs/superpowers/plans/2026-04-17-eng-3042-guard-tool-args.md
+++ b/docs/superpowers/plans/2026-04-17-eng-3042-guard-tool-args.md
@@ -1,0 +1,1219 @@
+# ENG-3042 — Guard tool argument handling implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix broken argument handling for `guard run tool <tool> <target> [extras]` (CLI) and `run <tool> <target> [extras]` (console) so operators can pass tool-specific flags (like Brutus's `-U users.txt --protocol ssh`), and fix `BrutusPlugin` emitting the wrong target flag.
+
+**Architecture:** Two-layer fix. (1) `runners/local.py` — correct `BrutusPlugin` to emit `--target`/`--protocol` and thread a `pass_through` list through every plugin so caller-supplied flags reach the binary. (2) `handlers/run.py` and `ui/console/commands/tools.py` — collect unknown trailing options plus `--`-separated args, forward them to local plugins, and refuse combinations that don't make sense (`--remote`, `--ask`).
+
+**Spec:** `docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md`
+
+**Tech Stack:** Python, Click, pytest, prompt_toolkit + Rich (console)
+
+---
+
+### File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `praetorian_cli/runners/local.py` | Add `_infer_protocol`, `_has_flag` helpers; fix `BrutusPlugin`; thread `pass_through` through base + all plugins |
+| Modify | `praetorian_cli/handlers/run.py` | `guard run tool` accepts `tool_args` via `nargs=-1 UNPROCESSED` + `ignore_unknown_options`; forwards to `_run_local`; errors on `--remote` / `--ask` + passthrough |
+| Modify | `praetorian_cli/ui/console/commands/tools.py` | `_cmd_run` splits own flags from pass-through; adds local execution path (reusing `LocalRunner`); `run <tool> --help` forwards to binary |
+| Modify | `docs/console.md` | Document passthrough usage in console docs |
+| Create | `praetorian_cli/sdk/test/test_local_runner.py` | Unit tests for `BrutusPlugin._build`, `_infer_protocol`, `_has_flag`, base plugin pass_through |
+| Create | `praetorian_cli/sdk/test/test_run_cli.py` | CLI tests for `guard run tool` passthrough via `CliRunner` |
+| Create | `praetorian_cli/sdk/test/ui/test_console_tools.py` | Console `_cmd_run` tests for passthrough & local exec |
+
+---
+
+## Task 1 — Helpers: `_infer_protocol` and `_has_flag`
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+- Create: `praetorian_cli/sdk/test/test_local_runner.py`
+
+- [ ] **Step 1: Write failing tests for `_infer_protocol` and `_has_flag`**
+
+Create `praetorian_cli/sdk/test/test_local_runner.py`:
+
+```python
+import pytest
+
+from praetorian_cli.runners.local import _infer_protocol, _has_flag
+
+
+class TestInferProtocol:
+    def test_ssh_port(self):
+        assert _infer_protocol('10.0.1.5:22') == 'ssh'
+
+    def test_rdp_port(self):
+        assert _infer_protocol('host.example.com:3389') == 'rdp'
+
+    def test_ftp_port(self):
+        assert _infer_protocol('192.168.1.1:21') == 'ftp'
+
+    def test_smb_port(self):
+        assert _infer_protocol('10.0.0.5:445') == 'smb'
+
+    def test_telnet_port(self):
+        assert _infer_protocol('10.0.0.5:23') == 'telnet'
+
+    def test_mysql_port(self):
+        assert _infer_protocol('db.example.com:3306') == 'mysql'
+
+    def test_postgres_port(self):
+        assert _infer_protocol('db.example.com:5432') == 'postgres'
+
+    def test_unknown_port_returns_none(self):
+        assert _infer_protocol('host:9999') is None
+
+    def test_no_port_returns_none(self):
+        assert _infer_protocol('example.com') is None
+
+    def test_malformed_port_returns_none(self):
+        assert _infer_protocol('host:notaport') is None
+
+    def test_ipv6_bracket_form(self):
+        # IPv6 addresses use [::1]:22 bracket form — we don't need to support this,
+        # just not crash on it.
+        assert _infer_protocol('[::1]:22') in ('ssh', None)
+
+
+class TestHasFlag:
+    def test_empty_passthrough(self):
+        assert _has_flag(None, '-u') is False
+        assert _has_flag([], '-u') is False
+
+    def test_single_flag_present(self):
+        assert _has_flag(['-u', 'foo'], '-u') is True
+
+    def test_any_of_multiple(self):
+        assert _has_flag(['-U', 'users.txt'], '-u', '-U') is True
+        assert _has_flag(['-u', 'foo'], '-u', '-U') is True
+
+    def test_flag_absent(self):
+        assert _has_flag(['--other', 'val'], '-u') is False
+
+    def test_flag_as_value_ignored(self):
+        # A flag appearing only as a value to another flag should not match.
+        # Simpler: we match anywhere in the list. This keeps the helper small.
+        # If a user's file path happens to be '-u', that's their problem.
+        assert _has_flag(['--config', '-u'], '-u') is True
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests fail with `ImportError: cannot import name '_infer_protocol'` (or similar).
+
+- [ ] **Step 3: Implement `_infer_protocol` and `_has_flag`**
+
+Open `praetorian_cli/runners/local.py` and add, after the `INSTALLABLE_TOOLS` dict (before `_detect_platform`):
+
+```python
+# Well-known service ports for Brutus protocol auto-detection.
+# Keep this minimal: only protocols Brutus natively supports.
+_WELL_KNOWN_PORTS = {
+    22: 'ssh',
+    3389: 'rdp',
+    21: 'ftp',
+    445: 'smb',
+    23: 'telnet',
+    3306: 'mysql',
+    5432: 'postgres',
+}
+
+
+def _infer_protocol(target: str):
+    """Infer protocol from a 'host:port' target using well-known ports.
+
+    Returns the protocol name or None if no inference is possible.
+    """
+    if not target or ':' not in target:
+        return None
+    # rsplit so 'host:port' works even if host contains ':'
+    _, sep, port_str = target.rpartition(':')
+    if not sep:
+        return None
+    try:
+        port = int(port_str)
+    except ValueError:
+        return None
+    return _WELL_KNOWN_PORTS.get(port)
+
+
+def _has_flag(pass_through, *flags):
+    """Return True if any of the given flag names appears in pass_through."""
+    if not pass_through:
+        return False
+    flag_set = set(flags)
+    return any(arg in flag_set for arg in pass_through)
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py praetorian_cli/sdk/test/test_local_runner.py
+git commit -m "feat: add _infer_protocol/_has_flag helpers for tool plugins"
+```
+
+---
+
+## Task 2 — Thread `pass_through` through base `ToolPlugin`
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+- Modify: `praetorian_cli/sdk/test/test_local_runner.py`
+
+- [ ] **Step 1: Write failing test for base plugin pass_through**
+
+Append to `praetorian_cli/sdk/test/test_local_runner.py`:
+
+```python
+from praetorian_cli.runners.local import ToolPlugin
+
+
+class TestToolPluginBase:
+    def test_default_plugin_passes_through(self):
+        plugin = ToolPlugin()
+        args = plugin.build_args('example.com', pass_through=['--flag', 'val'])
+        assert args == ['example.com', '--flag', 'val']
+
+    def test_default_plugin_without_passthrough(self):
+        plugin = ToolPlugin()
+        assert plugin.build_args('example.com') == ['example.com']
+
+    def test_default_plugin_with_json_config_and_passthrough(self):
+        plugin = ToolPlugin()
+        args = plugin.build_args('t', extra_config='{"k":"v"}', pass_through=['--x'])
+        # Default plugin ignores config but appends pass_through.
+        assert args == ['t', '--x']
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py::TestToolPluginBase -v`
+Expected: TypeError about unexpected keyword `pass_through` or similar.
+
+- [ ] **Step 3: Update base `ToolPlugin` to accept and forward `pass_through`**
+
+In `praetorian_cli/runners/local.py`, replace the `ToolPlugin` class (around line 191-204) with:
+
+```python
+class ToolPlugin:
+    """Base class for local tool argument builders."""
+
+    def build_args(self, target, extra_config='', pass_through=None):
+        config = {}
+        if extra_config:
+            try:
+                config = json.loads(extra_config) if isinstance(extra_config, str) else extra_config
+            except (json.JSONDecodeError, TypeError):
+                pass
+        args = self._build(target, config, pass_through=pass_through)
+        return args
+
+    def _build(self, target, config, pass_through=None):
+        args = [target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+```
+
+- [ ] **Step 4: Run the test and verify pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py::TestToolPluginBase -v`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py praetorian_cli/sdk/test/test_local_runner.py
+git commit -m "feat: base ToolPlugin accepts pass_through kwarg"
+```
+
+---
+
+## Task 3 — Fix `BrutusPlugin`
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+- Modify: `praetorian_cli/sdk/test/test_local_runner.py`
+
+- [ ] **Step 1: Write failing tests for `BrutusPlugin`**
+
+Append to `praetorian_cli/sdk/test/test_local_runner.py`:
+
+```python
+from praetorian_cli.runners.local import BrutusPlugin
+
+
+class TestBrutusPlugin:
+    def setup_method(self):
+        self.plugin = BrutusPlugin()
+
+    def test_bare_target_emits_target_flag(self):
+        args = self.plugin.build_args('example.com')
+        assert args == ['--target', 'example.com']
+
+    def test_target_with_ssh_port_infers_protocol(self):
+        args = self.plugin.build_args('10.0.1.5:22')
+        assert args == ['--target', '10.0.1.5:22', '--protocol', 'ssh']
+
+    def test_target_with_rdp_port_infers_protocol(self):
+        args = self.plugin.build_args('host.example.com:3389')
+        assert args == ['--target', 'host.example.com:3389', '--protocol', 'rdp']
+
+    def test_unknown_port_does_not_infer_protocol(self):
+        args = self.plugin.build_args('host:9999')
+        assert args == ['--target', 'host:9999']
+
+    def test_config_protocol_overrides_inference(self):
+        args = self.plugin.build_args('10.0.1.5:22', extra_config='{"protocol":"smb"}')
+        assert '--protocol' in args
+        idx = args.index('--protocol')
+        assert args[idx + 1] == 'smb'
+
+    def test_config_usernames_and_passwords(self):
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"usernames":"root,admin","passwords":"pw1,pw2"}',
+        )
+        assert args == [
+            '--target', 'host:22', '--protocol', 'ssh',
+            '-u', 'root,admin', '-p', 'pw1,pw2',
+        ]
+
+    def test_passthrough_appended(self):
+        args = self.plugin.build_args('host:22', pass_through=['--spray', '-v'])
+        assert args == ['--target', 'host:22', '--protocol', 'ssh', '--spray', '-v']
+
+    def test_passthrough_username_file_suppresses_structured_u(self):
+        # Caller-supplied -U wins — we should not also emit structured -u.
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"usernames":"root,admin"}',
+            pass_through=['-U', 'users.txt'],
+        )
+        # '-u' (structured) must NOT be present; '-U' must be.
+        assert '-u' not in args
+        assert '-U' in args
+        assert args[args.index('-U') + 1] == 'users.txt'
+
+    def test_passthrough_protocol_suppresses_inference(self):
+        args = self.plugin.build_args(
+            'host:22',
+            pass_through=['--protocol', 'rdp'],
+        )
+        # Only one --protocol, and it's the passthrough value.
+        assert args.count('--protocol') == 1
+        assert args[args.index('--protocol') + 1] == 'rdp'
+
+    def test_passthrough_password_file_suppresses_structured_p(self):
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"passwords":"pw"}',
+            pass_through=['-P', 'passes.txt'],
+        )
+        assert '-p' not in args
+        assert '-P' in args
+```
+
+- [ ] **Step 2: Run the tests and verify failure**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py::TestBrutusPlugin -v`
+Expected: Failures — current plugin emits `-t target`, not `--target target`, and doesn't support pass_through.
+
+- [ ] **Step 3: Replace `BrutusPlugin._build`**
+
+In `praetorian_cli/runners/local.py`, find the `BrutusPlugin` class (around line 207-214) and replace it with:
+
+```python
+class BrutusPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['--target', target]
+
+        # Protocol: explicit config > caller passthrough wins silently > inferred
+        caller_has_protocol = _has_flag(pass_through, '--protocol')
+        if not caller_has_protocol:
+            proto = config.get('protocol') or _infer_protocol(target)
+            if proto:
+                args.extend(['--protocol', proto])
+
+        if config.get('usernames') and not _has_flag(pass_through, '-u', '-U'):
+            args.extend(['-u', config['usernames']])
+        if config.get('passwords') and not _has_flag(pass_through, '-p', '-P'):
+            args.extend(['-p', config['passwords']])
+
+        if pass_through:
+            args.extend(pass_through)
+        return args
+```
+
+- [ ] **Step 4: Run the tests and verify pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py::TestBrutusPlugin -v`
+Expected: All 10 tests pass.
+
+- [ ] **Step 5: Run the full `test_local_runner.py` suite to catch regressions**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py praetorian_cli/sdk/test/test_local_runner.py
+git commit -m "fix(brutus): emit --target/--protocol and accept passthrough flags"
+```
+
+---
+
+## Task 4 — Propagate `pass_through` to the remaining plugins
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+- Modify: `praetorian_cli/sdk/test/test_local_runner.py`
+
+These plugins already exist and all must accept (and forward) `pass_through` so callers can always tack on flags regardless of tool.
+
+- [ ] **Step 1: Write failing tests for each plugin's passthrough behavior**
+
+Append to `praetorian_cli/sdk/test/test_local_runner.py`:
+
+```python
+from praetorian_cli.runners.local import (
+    NucleiPlugin, TitusPlugin, TrajanPlugin, JuliusPlugin, AugustusPlugin,
+    NervaPlugin, GatoPlugin, UrlTargetPlugin, ScanTargetPlugin,
+)
+
+
+class TestPluginsForwardPassthrough:
+    """Every plugin must append pass_through args last."""
+
+    @pytest.mark.parametrize('plugin_cls,expected_prefix', [
+        (NucleiPlugin, ['-u', 'example.com', '-jsonl']),
+        (TitusPlugin, ['scan', 'example.com']),
+        (TrajanPlugin, ['scan', 'example.com']),
+        (JuliusPlugin, ['-t', 'example.com']),
+        (AugustusPlugin, ['scan', '-t', 'example.com']),
+        (NervaPlugin, ['-t', 'example.com']),
+        (GatoPlugin, ['enumerate', '-t', 'example.com']),
+        (UrlTargetPlugin, ['scan', '-u', 'example.com']),
+        (ScanTargetPlugin, ['scan', 'example.com']),
+    ])
+    def test_plugin_appends_passthrough(self, plugin_cls, expected_prefix):
+        plugin = plugin_cls()
+        args = plugin.build_args('example.com', pass_through=['--debug', '-v'])
+        assert args[:len(expected_prefix)] == expected_prefix
+        assert args[-2:] == ['--debug', '-v']
+
+    def test_plugin_no_passthrough_unchanged(self):
+        # Regression guard for the default (no passthrough) path.
+        assert NucleiPlugin().build_args('example.com') == ['-u', 'example.com', '-jsonl']
+        assert TitusPlugin().build_args('x') == ['scan', 'x']
+        assert JuliusPlugin().build_args('x') == ['-t', 'x']
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py::TestPluginsForwardPassthrough -v`
+Expected: Fails — plugins' `_build` signatures don't accept `pass_through`.
+
+- [ ] **Step 3: Update each plugin's `_build` signature**
+
+In `praetorian_cli/runners/local.py`, replace each of the following classes' `_build` methods. Keep all other methods untouched. Every `_build` now takes `pass_through=None` and appends it last.
+
+```python
+class NucleiPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['-u', target, '-jsonl']
+        if config.get('templates'):
+            args.extend(['-t', config['templates']])
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class TitusPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['scan', target]
+        if config.get('validation') == 'true':
+            args.append('--validate')
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class TrajanPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['scan', target]
+        if config.get('token'):
+            args.extend(['--token', config['token']])
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class JuliusPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class AugustusPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['scan', '-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class NervaPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class GatoPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['enumerate', '-t', target]
+        if config.get('token'):
+            args.extend(['--token', config['token']])
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class UrlTargetPlugin(ToolPlugin):
+    """For tools that take scan -u <target>."""
+    def _build(self, target, config, pass_through=None):
+        args = ['scan', '-u', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+
+
+class ScanTargetPlugin(ToolPlugin):
+    """For tools that take scan <target>."""
+    def _build(self, target, config, pass_through=None):
+        args = ['scan', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py praetorian_cli/sdk/test/test_local_runner.py
+git commit -m "feat: thread pass_through through all local tool plugins"
+```
+
+---
+
+## Task 5 — Wire `tool_args` into the CLI `guard run tool` command
+
+**Files:**
+- Modify: `praetorian_cli/handlers/run.py`
+- Create: `praetorian_cli/sdk/test/test_run_cli.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `praetorian_cli/sdk/test/test_run_cli.py`:
+
+```python
+"""Unit tests for `guard run tool` argument passthrough and errors."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    """Build a minimal fake SDK covering the calls `guard run tool` makes."""
+    sdk = MagicMock()
+    sdk.capabilities.list.return_value = [
+        {'name': 'brutus', 'target': ['asset'], 'description': 'creds', 'executor': 'chariot'},
+    ]
+    sdk.search.fulltext.return_value = ([{'key': '#asset#10.0.1.5', 'dns': '10.0.1.5'}], None)
+    sdk.jobs.add.return_value = [{'key': '#job#abc'}]
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv):
+    """Invoke the CLI with a patched SDK factory."""
+    with patch('praetorian_cli.handlers.cli_decorators.Chariot', return_value=fake_sdk):
+        return runner.invoke(chariot, argv, catch_exceptions=False)
+
+
+def test_passthrough_collects_unknown_options(runner, fake_sdk):
+    """Unknown options after target flow into tool_args and reach the local plugin."""
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.handlers.run._run_local') as mock_local:
+        _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5:22',
+            '--protocol', 'ssh', '-U', 'users.txt',
+        ])
+    assert mock_local.called
+    kwargs = mock_local.call_args.kwargs or {}
+    # The fifth positional is either pass_through or tool_args depending on our impl;
+    # we assert on the call_args tuple directly.
+    pass_through = mock_local.call_args.args[-1]
+    assert list(pass_through) == ['--protocol', 'ssh', '-U', 'users.txt']
+
+
+def test_double_dash_separator_forwards_own_flag_collisions(runner, fake_sdk):
+    """Flags that collide with our own names (e.g. --wait) still pass through after `--`."""
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.handlers.run._run_local') as mock_local:
+        result = _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5:22', '--', '--wait', '--foo',
+        ])
+    assert result.exit_code == 0
+    pass_through = mock_local.call_args.args[-1]
+    assert list(pass_through) == ['--wait', '--foo']
+
+
+def test_passthrough_with_remote_errors(runner, fake_sdk):
+    """Extra args are local-only — remote execution must reject them."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5:22', '--remote',
+        '--protocol', 'ssh',
+    ])
+    assert result.exit_code != 0
+    assert 'local' in result.output.lower()
+
+
+def test_passthrough_with_ask_errors(runner, fake_sdk):
+    """Extra args can't route through Marcus (agent path)."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5:22', '--ask',
+        '--protocol', 'ssh',
+    ])
+    assert result.exit_code != 0
+    assert 'local' in result.output.lower() or 'agent' in result.output.lower()
+
+
+def test_no_passthrough_preserves_remote_path(runner, fake_sdk):
+    """No trailing args and --remote: existing direct-job path still works."""
+    with patch('praetorian_cli.handlers.run._run_direct') as mock_direct:
+        result = _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5', '--remote',
+        ])
+    assert result.exit_code == 0
+    assert mock_direct.called
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `pytest praetorian_cli/sdk/test/test_run_cli.py -v`
+Expected: Fails — Click rejects `-U` / `--protocol` as unknown options; `--remote + extras` check doesn't exist.
+
+- [ ] **Step 3: Update the `tool` command to accept `tool_args`**
+
+In `praetorian_cli/handlers/run.py`, replace the `@run.command('tool')` decorator block (currently at lines 127-173) with:
+
+```python
+@run.command(
+    'tool',
+    context_settings={'ignore_unknown_options': True, 'allow_extra_args': True},
+)
+@cli_handler
+@click.argument('tool_name')
+@click.argument('target')
+@click.argument('tool_args', nargs=-1, type=click.UNPROCESSED)
+@click.option('-c', '--config', 'extra_config', default='', help='Extra JSON config to merge')
+@click.option('--credential', multiple=True, help='Credential ID(s) to use')
+@click.option('--wait', is_flag=True, default=False, help='Wait for job completion and show results')
+@click.option('--ask', 'use_agent', is_flag=True, default=False, help='Run via Marcus AI agent instead of direct job')
+@click.option('--local', is_flag=True, default=False, help='Run locally using installed binary')
+@click.option('--remote', is_flag=True, default=False, help='Force remote job execution on Guard backend')
+def tool(sdk, tool_name, target, tool_args, extra_config, credential, wait, use_agent, local, remote):
+    """ Execute a named security tool against a target
+
+    By default, runs LOCALLY if the binary is installed, otherwise schedules
+    a remote job. Use --local or --remote to force. Any additional arguments
+    after the target are forwarded to the local binary. Use `--` to pass
+    flags that collide with our own options.
+
+    \b
+    Example usages:
+        guard run tool brutus 10.0.1.5:22
+        guard run tool brutus 10.0.1.5:22 --protocol ssh -U users.txt
+        guard run tool brutus 10.0.1.5:22 -- --wait
+        guard run tool nuclei example.com --remote -c '{"templates":"cves/"}'
+    """
+    from praetorian_cli.runners.local import is_installed as _is_installed
+
+    cap = resolve_capability(sdk, tool_name.lower())
+    if not cap:
+        error(f'Unknown capability: {tool_name}. Use "guard run capabilities" to see available capabilities.')
+
+    tool_args = list(tool_args or [])
+
+    # Decide local vs remote first so we can validate tool_args against the resolved path.
+    run_local = local or (not remote and not use_agent and _is_installed(tool_name.lower()))
+
+    if tool_args and (remote or use_agent or not run_local):
+        error(
+            'Extra arguments after the target are only supported when running locally. '
+            'Install the tool locally ("guard run install %s") or encode settings as JSON '
+            'via -c \'{"key":"value"}\'.' % tool_name.lower()
+        )
+
+    if run_local:
+        _run_local(sdk, tool_name.lower(), target, extra_config, tool_args)
+    elif use_agent:
+        target_key, warning = resolve_target(sdk, target, cap['target_type'])
+        if not target_key:
+            error(warning)
+        if warning:
+            click.echo(warning, err=True)
+        _run_via_agent(sdk, cap, target_key)
+    else:
+        target_key, warning = resolve_target(sdk, target, cap['target_type'])
+        if not target_key:
+            error(warning)
+        if warning:
+            click.echo(warning, err=True)
+        _run_direct(sdk, cap, target_key, extra_config, list(credential), wait)
+```
+
+- [ ] **Step 4: Update `_run_local` to accept and forward `tool_args`**
+
+In the same file (`praetorian_cli/handlers/run.py`), update `_run_local` (currently at lines 379-433):
+
+Change signature from:
+```python
+def _run_local(sdk, tool_name, target, extra_config):
+```
+to:
+```python
+def _run_local(sdk, tool_name, target, extra_config, tool_args=None):
+```
+
+Inside the function, change the `plugin.build_args` call (line 395) from:
+```python
+    args = plugin.build_args(raw_target, extra_config)
+```
+to:
+```python
+    args = plugin.build_args(raw_target, extra_config, pass_through=list(tool_args or []))
+```
+
+Leave the rest of `_run_local` untouched.
+
+- [ ] **Step 5: Run CLI tests and verify pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_run_cli.py -v`
+Expected: All 5 tests pass.
+
+- [ ] **Step 6: Run the full local-runner test file (regression check)**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add praetorian_cli/handlers/run.py praetorian_cli/sdk/test/test_run_cli.py
+git commit -m "feat(run): forward trailing args to local tool binaries"
+```
+
+---
+
+## Task 6 — Add local execution path + passthrough to console `run`
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/commands/tools.py`
+- Create: `praetorian_cli/sdk/test/ui/test_console_tools.py`
+
+The console currently only queues remote jobs or routes to Marcus. For the passthrough story to work it needs a local execution path (reusing the CLI's `LocalRunner`). Local execution kicks in only when (a) the binary is installed AND (b) the user passed extras, OR (c) the user explicitly asked with `--local`.
+
+- [ ] **Step 1: Write failing tests for `_cmd_run` passthrough**
+
+Create `praetorian_cli/sdk/test/ui/test_console_tools.py`:
+
+```python
+"""Unit tests for console `run` passthrough and local execution path."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praetorian_cli.ui.console.commands.tools import ToolCommands
+from praetorian_cli.sdk.test.ui_mocks import MockConsole
+
+pytestmark = pytest.mark.tui
+
+
+class _FakeContext:
+    active_tool = None
+    account = 'acct'
+    _last_job_key = ''
+
+    def apply_scope_to_message(self, msg):
+        return msg
+
+
+class _Harness(ToolCommands):
+    """Bare wrapper to exercise ToolCommands methods in isolation."""
+
+    def __init__(self, sdk=None):
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FakeContext()
+        self.colors = {
+            'primary': 'cyan', 'accent': 'magenta', 'dim': 'dim',
+            'info': 'blue', 'success': 'green', 'warning': 'yellow', 'error': 'red',
+        }
+
+    # Stubs for methods the real console provides elsewhere.
+    def _send_to_marcus(self, message):  # pragma: no cover — not used in these tests
+        return ''
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+
+def test_run_with_passthrough_executes_locally_when_installed():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_run_tool_locally') as mock_local:
+        h._cmd_run(['brutus', '10.0.1.5:22', '--protocol', 'ssh', '-U', 'users.txt'])
+
+    assert mock_local.called
+    args, kwargs = mock_local.call_args
+    # Expect (tool_name, target, pass_through)
+    assert args[0] == 'brutus'
+    assert args[1] == '10.0.1.5:22'
+    assert list(args[2]) == ['--protocol', 'ssh', '-U', 'users.txt']
+
+
+def test_run_with_passthrough_but_not_installed_errors():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False):
+        h._cmd_run(['brutus', '10.0.1.5:22', '--protocol', 'ssh'])
+    output = '\n'.join(h.console.lines)
+    assert 'install' in output.lower() or 'local' in output.lower()
+
+
+def test_double_dash_forwards_own_flags():
+    """After `--`, even console-owned flags like --wait pass through."""
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_run_tool_locally') as mock_local:
+        h._cmd_run(['brutus', '10.0.1.5:22', '--', '--wait', '--spray'])
+    args, _ = mock_local.call_args
+    assert list(args[2]) == ['--wait', '--spray']
+
+
+def test_own_wait_flag_routes_to_remote_with_wait():
+    """`run brutus x --wait` (no `--`) keeps --wait as a console flag and routes remote."""
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_try_queue_job', return_value=[{'key': '#job#x'}]) as mock_queue, \
+         patch.object(_Harness, '_wait_for_job') as mock_wait:
+        h._cmd_run(['brutus', '#asset#10.0.1.5', '--wait'])
+    assert mock_queue.called
+    assert mock_wait.called
+
+
+def test_help_forwards_to_local_binary(tmp_path):
+    h = _Harness()
+    fake_proc = MagicMock()
+    fake_proc.stdout.__iter__.return_value = iter(['Brutus help\n', 'options\n'])
+    fake_proc.stderr.read.return_value = ''
+    fake_proc.returncode = 0
+
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.runners.local.LocalRunner') as mock_cls:
+        mock_cls.return_value.run_streaming.return_value = fake_proc
+        h._cmd_run(['brutus', '--help'])
+
+    # run_streaming should have been called with ['--help'].
+    mock_cls.return_value.run_streaming.assert_called_once()
+    call_args = mock_cls.return_value.run_streaming.call_args.args[0]
+    assert call_args == ['--help']
+
+
+def test_help_when_not_installed_prints_install_hint():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False):
+        h._cmd_run(['brutus', '--help'])
+    output = '\n'.join(h.console.lines)
+    assert 'install' in output.lower()
+
+
+def test_no_passthrough_uses_remote_path():
+    """Back-compat: bare `run brutus <key>` still queues a remote job."""
+    h = _Harness()
+    # Force remote by claiming the binary is NOT installed.
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False), \
+         patch.object(_Harness, '_try_queue_job', return_value=[{'key': '#job#x'}]) as mock_queue:
+        h._cmd_run(['brutus', '#asset#10.0.1.5'])
+    assert mock_queue.called
+```
+
+- [ ] **Step 2: Run the new tests and verify failure**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+Expected: Failures — `_run_tool_locally` does not exist; `--` handling / `--help` passthrough don't exist.
+
+- [ ] **Step 3: Update `_cmd_run` to split own flags from passthrough and route**
+
+In `praetorian_cli/ui/console/commands/tools.py`, replace the entire `_cmd_run` method (starting around line 41, ending around line 118) with:
+
+```python
+    def _cmd_run(self, args):
+        """Run a named security tool against a target, or execute active tool."""
+        from praetorian_cli.handlers.run import TOOL_ALIASES
+        from praetorian_cli.runners.local import is_installed as _is_installed
+
+        if not args and self.context.active_tool:
+            self._cmd_execute([])
+            return
+        if not args:
+            self._print_tool_catalog(TOOL_ALIASES)
+            return
+
+        tool_name = args[0].lower()
+        alias = TOOL_ALIASES.get(tool_name)
+        if not alias:
+            available = ', '.join(sorted(k for k in TOOL_ALIASES if k != 'secrets'))
+            self.console.print(f'[error]Unknown tool: {tool_name}. Available: {available}[/error]')
+            return
+
+        rest = args[1:]
+
+        # `run <tool> --help` — forward to local binary if installed.
+        if rest and rest[0] == '--help':
+            self._print_tool_help(tool_name)
+            return
+
+        if not rest:
+            self.console.print(f'[dim]Usage: {tool_name} <target_key> [--ask] [--wait] [-- <tool-args>...][/dim]')
+            self.console.print(f'[dim]  Target type: {alias["target_type"]}[/dim]')
+            self.console.print(f'[dim]  {alias["description"]}[/dim]')
+            return
+
+        raw_target = rest[0]
+        remaining = rest[1:]
+
+        # Split own flags from passthrough. Honor `--` as an explicit boundary:
+        # everything after `--` is passthrough, even if it collides with `--wait`/`--ask`.
+        OWN_FLAGS = {'--ask', '--wait'}
+        pass_through = []
+        own = []
+        if '--' in remaining:
+            idx = remaining.index('--')
+            own = remaining[:idx]
+            pass_through = remaining[idx + 1:]
+        else:
+            for a in remaining:
+                if a in OWN_FLAGS:
+                    own.append(a)
+                else:
+                    pass_through.append(a)
+
+        use_agent = '--ask' in own
+        wait = '--wait' in own
+
+        if pass_through and use_agent:
+            self.console.print(
+                '[error]Extra arguments are not supported with --ask (agent path). '
+                'Drop --ask or use structured config.[/error]'
+            )
+            return
+
+        if pass_through:
+            if not _is_installed(tool_name):
+                self.console.print(
+                    f'[error]Extra arguments require the {tool_name} binary to be installed locally. '
+                    f'Run "install {tool_name}" first.[/error]'
+                )
+                return
+            self._run_tool_locally(tool_name, raw_target, pass_through)
+            return
+
+        # No passthrough — existing remote/agent flow.
+        from praetorian_cli.handlers.run import resolve_target
+        target_key, warning = resolve_target(self.sdk, raw_target, alias['target_type'])
+        if not target_key:
+            self.console.print(f'[error]{warning}[/error]')
+            return
+        if warning:
+            self.console.print(f'[warning]{warning}[/warning]')
+
+        capability = alias.get('capability')
+        config = dict(alias.get('default_config', {}))
+
+        if alias.get('agent') and (use_agent or not capability):
+            agent_name = alias['agent']
+            task_desc = f'Run {capability} against {target_key} and analyze the results.' if capability else f'Analyze {target_key} thoroughly.'
+            message = self.context.apply_scope_to_message(task_desc)
+            self.console.print(f'[info]Delegating to {agent_name} via Marcus...[/info]')
+            response_text = self._send_to_marcus(message)
+            if response_text:
+                from rich.markdown import Markdown
+                self.console.print(Markdown(response_text))
+        else:
+            import json
+            config_str = json.dumps(config) if config else None
+            result = self._try_queue_job(target_key, capability, config_str)
+            if result is None:
+                return
+            if wait:
+                self._wait_for_job(target_key, capability)
+
+    def _print_tool_catalog(self, TOOL_ALIASES):
+        """Render the agents/capabilities catalog shown when `run` is called bare."""
+        agents = {k: v for k, v in TOOL_ALIASES.items() if v.get('agent') and k != 'secrets'}
+        table = Table(title='Agents', border_style=self.colors['primary'])
+        table.add_column('Agent', style=f'bold {self.colors["primary"]}', min_width=16)
+        table.add_column('Description')
+        for name, info in sorted(agents.items()):
+            table.add_row(name, info['description'])
+        self.console.print(table)
+
+        caps = {k: v for k, v in TOOL_ALIASES.items() if not v.get('agent') and k != 'secrets'}
+        if caps:
+            table2 = Table(title='Capabilities', border_style=self.colors['dim'])
+            table2.add_column('Capability', style=f'bold {self.colors["primary"]}', min_width=16)
+            table2.add_column('Target', style=self.colors['accent'])
+            table2.add_column('Description')
+            for name, info in sorted(caps.items()):
+                table2.add_row(name, info['target_type'], info['description'])
+            self.console.print(table2)
+
+        self.console.print(f'\n[dim]Usage: use <name> or <name> <target_key>[/dim]')
+
+    def _print_tool_help(self, tool_name):
+        """Run `<tool> --help` locally and stream its output to the console."""
+        from praetorian_cli.runners.local import is_installed as _is_installed, LocalRunner
+        if not _is_installed(tool_name):
+            self.console.print(
+                f'[warning]{tool_name} is not installed locally. Run "install {tool_name}" first.[/warning]'
+            )
+            return
+        try:
+            runner = LocalRunner(tool_name)
+            proc = runner.run_streaming(['--help'])
+            for line in proc.stdout:
+                self.console.print(line.rstrip('\n'))
+            stderr = proc.stderr.read() if proc.stderr else ''
+            if stderr:
+                self.console.print(f'[dim]{stderr}[/dim]')
+        except Exception as e:
+            self.console.print(f'[error]{e}[/error]')
+
+    def _run_tool_locally(self, tool_name, raw_target, pass_through):
+        """Run an installed tool binary locally from the console."""
+        from praetorian_cli.runners.local import LocalRunner, get_tool_plugin
+
+        # Strip Guard key prefix for the raw target (same logic as CLI _run_local).
+        target = raw_target
+        if raw_target.startswith('#'):
+            parts = raw_target.split('#')
+            target = parts[-1] if len(parts) > 3 else parts[2] if len(parts) > 2 else raw_target
+
+        plugin = get_tool_plugin(tool_name)
+        tool_argv = plugin.build_args(target, pass_through=list(pass_through or []))
+
+        try:
+            runner = LocalRunner(tool_name)
+        except FileNotFoundError as e:
+            self.console.print(f'[error]{e}[/error]')
+            return
+
+        self.console.print(f'[info]Running {tool_name} locally against {target}...[/info]')
+        self.console.print(f'[dim]Command: {tool_name} {" ".join(tool_argv)}[/dim]')
+        self.console.print('[dim]' + '─' * 60 + '[/dim]')
+
+        import subprocess
+        proc = runner.run_streaming(tool_argv)
+        output_lines = []
+        try:
+            for line in proc.stdout:
+                self.console.print(line.rstrip('\n'))
+                output_lines.append(line)
+            proc.wait(timeout=600)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            self.console.print('[error]Timed out (10 min).[/error]')
+
+        stderr = proc.stderr.read() if proc.stderr else ''
+        if stderr:
+            self.console.print(f'[dim]{stderr}[/dim]')
+
+        self.console.print('[dim]' + '─' * 60 + '[/dim]')
+        self.console.print(f'[dim]Exit code: {proc.returncode}[/dim]')
+
+        # Best-effort upload to Guard (mirrors CLI behavior).
+        output_text = ''.join(output_lines)
+        if output_text.strip():
+            try:
+                import tempfile, os
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, prefix=f'{tool_name}-') as f:
+                    f.write(output_text)
+                    tmp_path = f.name
+                guard_path = f'proofs/local/{tool_name}/{target.replace("/", "_")}'
+                self.sdk.files.add(tmp_path, guard_path)
+                os.unlink(tmp_path)
+                self.console.print(f'[success]Output uploaded to Guard: {guard_path}[/success]')
+            except Exception as e:
+                self.console.print(f'[warning]Failed to upload output: {e}[/warning]')
+```
+
+(Keep every other method in `ToolCommands` unchanged.)
+
+- [ ] **Step 4: Run the console tests and verify pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Run the full unit-test scope (regression check)**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py praetorian_cli/sdk/test/test_run_cli.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/tools.py praetorian_cli/sdk/test/ui/test_console_tools.py
+git commit -m "feat(console): add local exec path with tool-arg passthrough to run"
+```
+
+---
+
+## Task 7 — Audit notes for remaining plugins
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+
+No behaviour change — this task adds short annotations that record which plugin argument shapes have been verified against the binary's real help output, so future confusion about flags like `-t` doesn't reproduce the Brutus bug.
+
+- [ ] **Step 1: Add verification note above `TOOL_PLUGINS`**
+
+In `praetorian_cli/runners/local.py`, directly above the `TOOL_PLUGINS = {` line (around line 276), add:
+
+```python
+# Plugin verification status:
+# - brutus:      verified against brutus --help (ENG-3042)
+# - nuclei:      -u is the documented URL flag — OK
+# - julius/nerva/nero: use -t <target>; unverified against each binary's --help
+# - titus/trajan/vespasian/constantine/caligula: `scan <target>` — unverified
+# - augustus/gato: `scan -t <target>` / `enumerate -t <target>` — unverified
+# - cato/florian/hadrian: `scan -u <target>` — unverified
+# Users can always override via `guard run tool <tool> <target> -- <raw args>`.
+```
+
+- [ ] **Step 2: Verify no test regressions**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py
+git commit -m "docs(runners): annotate tool plugin verification status"
+```
+
+---
+
+## Task 8 — Update `docs/console.md` with passthrough example
+
+**Files:**
+- Modify: `docs/console.md`
+
+- [ ] **Step 1: Read the current `run` section**
+
+Open `docs/console.md` and find the section that documents the `run` command. If no dedicated section exists, scan for the first mention of `run` / `brutus` in the file.
+
+- [ ] **Step 2: Add a subsection titled "Passing tool-specific flags"**
+
+Insert after the existing `run` usage documentation:
+
+```markdown
+### Passing tool-specific flags
+
+Any arguments after `<target>` that the console doesn't recognise are forwarded
+verbatim to the local tool binary. Use `--` as an explicit separator if a flag
+collides with a console-owned option (`--ask`, `--wait`).
+
+    run brutus 10.0.1.5:22 --protocol ssh -U users.txt
+    run brutus 10.0.1.5:22 -- --wait --spray       # forwards --wait to brutus
+
+`run <tool> --help` runs the local binary's `--help` and streams the output
+into the console. Extra arguments require the binary to be installed
+(`install <tool>`) and are rejected for the Marcus agent path (`--ask`).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/console.md
+git commit -m "docs(console): document tool-arg passthrough and --help"
+```
+
+---
+
+## Task 9 — End-to-end smoke check
+
+This task is manual verification — no code change.
+
+- [ ] **Step 1: Re-run the whole test scope**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py praetorian_cli/sdk/test/test_run_cli.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+Expected: All pass.
+
+- [ ] **Step 2: Hand-verify with the real Brutus binary (requires `~/.praetorian/bin/brutus`)**
+
+Run (replace target with any SSH host you own or a local port):
+
+```
+praetorian-cli guard run tool brutus 127.0.0.1:2222 --protocol ssh -U /tmp/empty-users.txt
+```
+
+Expected: The command runs brutus with the correct flag order; no Click "no such option" errors; no Brutus "invalid threads" error.
+
+- [ ] **Step 3: Hand-verify remote-rejection**
+
+```
+praetorian-cli guard run tool brutus 127.0.0.1:2222 --remote --protocol ssh
+```
+
+Expected: Error "Extra arguments after the target are only supported when running locally…"
+
+- [ ] **Step 4: Hand-verify console `run brutus --help`**
+
+Launch `praetorian-cli guard console`, then type:
+
+```
+run brutus --help
+```
+
+Expected: Brutus' own help is printed inside the console.

--- a/docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md
+++ b/docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md
@@ -1,0 +1,164 @@
+# ENG-3042 — Fix Guard CLI/console tool argument handling
+
+Linear: https://linear.app/praetorianlabs/issue/ENG-3042
+Parent: OFFSEC-2383 (Marcus + long-username-list crash — **not in this sub-ticket**)
+
+## Problem
+
+Running Brutus via `guard run tool` (CLI) or `run brutus` (console) is broken in several ways:
+
+1. **Wrong target flag.** `BrutusPlugin._build()` in `praetorian_cli/runners/local.py:207-214` emits `-t <target>`. In Brutus `-t` is `--threads`, not the target. The target flag is `--target`, and single-target mode also requires `--protocol <proto>`. Result: Brutus rejects the invocation with a threads-parse error.
+2. **CLI rejects extra arguments.** `guard run tool` (`handlers/run.py:127-137`) uses fixed Click options. A user running `guard run tool brutus 10.0.1.5:2200 -U users.txt --protocol ssh` gets a Click "no such option" error — Click parses before the plugin ever sees the target.
+3. **Console has no passthrough.** `_cmd_run` in `ui/console/commands/tools.py` only recognises `--ask` and `--wait`. There is no way to pass `-U`, `--protocol`, `--spray`, etc. from the console. The help text for the tool's own options is never shown.
+4. **Some other local plugins use the same `-t` pattern** (`julius`, `nerva`, `nero`). Unverified against each binary's real flag set.
+
+The workaround Hunter landed on was `go install`-ing Brutus directly and bypassing the CLI entirely, which defeats the point of `guard run tool`.
+
+## Out of scope
+
+- Marcus crashing on long username lists (tracked under OFFSEC-2383, Noah).
+- Backend/remote job support for arbitrary tool args. Remote jobs take structured JSON config; adding raw-arg passthrough there would require a backend change. This sub-ticket keeps remote semantics as-is and explicitly rejects passthrough with `--remote`.
+- Auto-translating passthrough flags into remote JSON config. Fragile and asymmetric (no sensible translation for `--spray` / `--badkeys-only`, etc.).
+
+## Design
+
+### A. Fix `BrutusPlugin`
+
+Update `_build()` to:
+- Emit `--target <target>`.
+- Emit `--protocol <proto>` when the target or config specifies one. Resolution order:
+  1. `config['protocol']` if the caller passes it explicitly via `-c '{"protocol":"ssh"}'`.
+  2. Inferred from `target` if it matches `host:port` and the port is a well-known service (22→ssh, 3389→rdp, 21→ftp, 445→smb, 23→telnet, 3306→mysql, 5432→postgres). Keep the table minimal — anything unknown falls through.
+  3. Otherwise omit `--protocol` and rely on the user passing it via trailing passthrough args.
+- Preserve existing `-u`/`-p` emission for `config['usernames']` / `config['passwords']`.
+- Accept a `pass_through` list argument that is appended last, so user-provided flags always win over defaults.
+
+```python
+class BrutusPlugin(ToolPlugin):
+    def _build(self, target, config, pass_through=None):
+        args = ['--target', target]
+        proto = config.get('protocol') or _infer_protocol(target)
+        if proto and not _has_flag(pass_through, '--protocol'):
+            args.extend(['--protocol', proto])
+        if config.get('usernames') and not _has_flag(pass_through, '-u', '-U'):
+            args.extend(['-u', config['usernames']])
+        if config.get('passwords') and not _has_flag(pass_through, '-p', '-P'):
+            args.extend(['-p', config['passwords']])
+        if pass_through:
+            args.extend(pass_through)
+        return args
+```
+
+`_has_flag` is a small helper that checks whether any of the given flags appear in the passthrough list — so a caller's `-U users.txt` suppresses the structured-config `-u` and there's no duplicate flag conflict.
+
+### B. `ToolPlugin.build_args` signature update
+
+Extend the base method signature to accept a `pass_through` list and thread it through every concrete plugin. Plugins that don't care about it still accept the kwarg (ignored by default). This is a small surface change touching all plugins in `local.py` but keeps the extension additive.
+
+### C. `guard run tool` CLI
+
+Add trailing-args support to the `tool` command:
+
+```python
+@run.command(
+    'tool',
+    context_settings={'ignore_unknown_options': True, 'allow_extra_args': True},
+)
+@click.argument('tool_name')
+@click.argument('target')
+@click.argument('tool_args', nargs=-1, type=click.UNPROCESSED)
+@click.option('-c', '--config', ...)
+@click.option('--credential', ...)
+@click.option('--wait', ...)
+@click.option('--ask', 'use_agent', ...)
+@click.option('--local', ...)
+@click.option('--remote', ...)
+def tool(sdk, tool_name, target, tool_args, ...):
+```
+
+Effects:
+- `guard run tool brutus 10.0.1.5:2200 --protocol ssh -U users.txt` — unknown options `-U`/`--protocol` get collected into `tool_args`.
+- `guard run tool brutus 10.0.1.5:2200 -- --wait foo` — the `--` forces everything after to `tool_args`, so a tool's own `--wait` (or any flag that collides with ours) still passes through.
+- `tool_args` flows into `_run_local` → `plugin.build_args(target, config, pass_through=list(tool_args))`.
+- If `tool_args` is non-empty and the resolved path is remote (either `--remote` explicit, or local fallback not installed and `--remote` inferred), fail loudly:
+  *"Extra args after the target are only supported when running locally. Install the tool locally (`guard run install <tool>`) or encode the settings as JSON via `-c '{...}'`."*
+- If `tool_args` is non-empty and `--ask` (agent) is used, same error. Agent path talks to Marcus, not the binary.
+
+### D. Console `run <tool>`
+
+Update `_cmd_run` in `ui/console/commands/tools.py`:
+
+1. Separate console-owned flags (`--ask`, `--wait`) from tool-specific args:
+   ```python
+   OWN_FLAGS = {'--ask', '--wait'}
+   pass_through = [a for a in args[2:] if a not in OWN_FLAGS]
+   use_agent = '--ask' in args
+   wait = '--wait' in args
+   ```
+   Honour the same `--` boundary: everything after a literal `--` goes to `pass_through` regardless, so you can pass `run brutus 10.0.1.5:2200 -- --wait` to forward `--wait` to the binary itself.
+2. `run <tool> --help` — if the binary is installed locally, invoke `<tool> --help` via the runner and stream output into the console; otherwise print a message pointing at `guard run install <tool>`.
+3. Force-local when `pass_through` is non-empty and the tool is installed. If the tool is not installed, refuse with the same error as the CLI ("install the tool locally or use structured config").
+4. When routing to the direct-remote path with no pass_through, behaviour is unchanged.
+
+### E. Audit other plugins
+
+Verify each plugin whose current `_build()` uses `-t`, `-u`, or a `scan` sub-command against the corresponding binary's `--help`. This list covers everything in `TOOL_PLUGINS` today:
+
+| Plugin | Current | Verify | Action if wrong |
+|---|---|---|---|
+| brutus | `-t <target>` | known bad | fix per §A |
+| julius | `-t <target>` | verify | fix if wrong |
+| nerva | `-t <target>` | verify | fix if wrong |
+| nero | `-t <target>` (via `NervaPlugin`) | verify | fix if wrong |
+| nuclei | `-u <target>` | correct (documented) | — |
+| titus | `scan <target>` | verify | — |
+| trajan | `scan <target>` | verify | — |
+| augustus | `scan -t <target>` | verify | fix if wrong |
+| gato | `enumerate -t <target>` | verify | fix if wrong |
+| cato/florian/hadrian | `scan -u <target>` | verify | fix if wrong |
+| vespasian/constantine/caligula | `scan <target>` | verify | fix if wrong |
+
+Audits that fail become small follow-up fixes within the same PR; if a binary isn't readily installable in the sandbox, document it in the plugin as *"verified against vX.Y help"* or flag it for a separate ticket.
+
+### F. Errors and UX
+
+- Errors use the existing `error()` helper (CLI) / `self.console.print('[error]...[/error]')` (console). No new error types.
+- `guard run tool <tool> --help` — keep native Click `--help` for the command itself (shows our options and mentions passthrough). Tool-specific help comes from `guard run tool <tool> <any-target> -- --help`, which forwards `--help` to the binary. Document this in the docstring.
+
+## Testing
+
+Unit tests (new file `praetorian_cli/sdk/test/test_run_passthrough.py` alongside existing test layout):
+
+- `BrutusPlugin._build`
+  - bare target → `['--target', 'x']`
+  - `host:22` → adds `--protocol ssh`
+  - `host:9999` → no inferred protocol
+  - config with `usernames`/`passwords` → adds `-u`/`-p`
+  - pass_through `['-U', 'users.txt']` suppresses structured `-u`
+  - pass_through `['--protocol', 'rdp']` suppresses inferred `--protocol ssh`
+- `guard run tool` CLI via `click.testing.CliRunner`
+  - `guard run tool brutus <target> --protocol ssh -U foo` — tool_args collected
+  - `guard run tool brutus <target> -- --wait` — `--wait` after `--` goes to tool_args, not the command's own `--wait`
+  - `guard run tool brutus <target> --protocol ssh --remote` — error about remote + passthrough
+  - `guard run tool brutus <target> --protocol ssh --ask` — error about agent + passthrough
+- Console `_cmd_run`
+  - `run brutus key --protocol ssh` forwards `--protocol ssh` to the plugin
+  - `run brutus key -- --wait` forwards `--wait`, does NOT trigger console's own wait
+  - `run brutus --help` when not installed prints install hint
+
+Mock the binary execution (`LocalRunner.run_streaming`) so tests stay hermetic.
+
+## Rollout / risk
+
+- Pure additive change to plugin signatures (new optional kwarg).
+- Click context settings are backward-compatible — existing invocations without trailing args keep working.
+- The one behaviour change users will notice: `guard run tool brutus x` will now emit `--target x` instead of `-t x`. That's the bug fix.
+- Update `docs/console.md` and the `guard run tool` docstring to show a passthrough example.
+
+## Acceptance
+
+- `guard run tool brutus 10.0.1.5:2200 -U users.txt --protocol ssh` (when brutus is installed locally) runs brutus with the expected flags.
+- `run brutus 10.0.1.5:2200 -U users.txt --protocol ssh` in the console does the same.
+- `run brutus --help` inside the console prints brutus' own help.
+- `guard run tool brutus x --protocol ssh --remote` emits a clear error.
+- All new tests pass.

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -159,6 +159,12 @@ def tool(sdk, tool_name, target, tool_args, extra_config, credential, wait, use_
     if not cap:
         error(f'Unknown capability: {tool_name}. Use "guard run capabilities" to see available capabilities.')
 
+    # --local / --remote / --ask are mutually exclusive routing flags.
+    mode_flags = [('--local', local), ('--remote', remote), ('--ask', use_agent)]
+    set_flags = [name for name, v in mode_flags if v]
+    if len(set_flags) > 1:
+        error(f'Mutually exclusive flags: {", ".join(set_flags)}. Choose one.')
+
     tool_args = list(tool_args or [])
 
     # Decide local vs remote first so we can validate tool_args against the resolved path.

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -430,6 +430,10 @@ def _run_local(sdk, tool_name, target, extra_config, tool_args=None):
         proc.wait(timeout=600)
     except subprocess.TimeoutExpired:
         proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
         click.echo('\nTimed out (10 min).', err=True)
 
     stderr = proc.stderr.read() if proc.stderr else ''

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -124,27 +124,34 @@ def run():
     pass
 
 
-@run.command('tool')
+@run.command(
+    'tool',
+    context_settings={'ignore_unknown_options': True, 'allow_extra_args': True},
+)
 @cli_handler
 @click.argument('tool_name')
 @click.argument('target')
+@click.argument('tool_args', nargs=-1, type=click.UNPROCESSED)
 @click.option('-c', '--config', 'extra_config', default='', help='Extra JSON config to merge')
 @click.option('--credential', multiple=True, help='Credential ID(s) to use')
 @click.option('--wait', is_flag=True, default=False, help='Wait for job completion and show results')
 @click.option('--ask', 'use_agent', is_flag=True, default=False, help='Run via Marcus AI agent instead of direct job')
 @click.option('--local', is_flag=True, default=False, help='Run locally using installed binary')
 @click.option('--remote', is_flag=True, default=False, help='Force remote job execution on Guard backend')
-def tool(sdk, tool_name, target, extra_config, credential, wait, use_agent, local, remote):
+def tool(sdk, tool_name, target, tool_args, extra_config, credential, wait, use_agent, local, remote):
     """ Execute a named security tool against a target
 
     By default, runs LOCALLY if the binary is installed, otherwise schedules
-    a remote job. Use --local or --remote to force.
+    a remote job. Use --local or --remote to force. Any additional arguments
+    after the target are forwarded to the local binary. Use `--` to pass
+    flags that collide with our own options.
 
     \b
     Example usages:
-        guard run tool brutus 10.0.1.5
-        guard run tool nuclei example.com --remote
-        guard run tool titus github.com/org/repo
+        guard run tool brutus 10.0.1.5:22
+        guard run tool brutus 10.0.1.5:22 --protocol ssh -U users.txt
+        guard run tool brutus 10.0.1.5:22 -- --wait
+        guard run tool nuclei example.com --remote -c '{"templates":"cves/"}'
     """
     from praetorian_cli.runners.local import is_installed as _is_installed
 
@@ -152,11 +159,20 @@ def tool(sdk, tool_name, target, extra_config, credential, wait, use_agent, loca
     if not cap:
         error(f'Unknown capability: {tool_name}. Use "guard run capabilities" to see available capabilities.')
 
-    # Decide local vs remote
+    tool_args = list(tool_args or [])
+
+    # Decide local vs remote first so we can validate tool_args against the resolved path.
     run_local = local or (not remote and not use_agent and _is_installed(tool_name.lower()))
 
+    if tool_args and (remote or use_agent or not run_local):
+        error(
+            'Extra arguments after the target are only supported when running locally. '
+            'Install the tool locally ("guard run install %s") or encode settings as JSON '
+            'via -c \'{"key":"value"}\'.' % tool_name.lower()
+        )
+
     if run_local:
-        _run_local(sdk, tool_name.lower(), target, extra_config)
+        _run_local(sdk, tool_name.lower(), target, extra_config, tool_args)
     elif use_agent:
         target_key, warning = resolve_target(sdk, target, cap['target_type'])
         if not target_key:
@@ -376,7 +392,7 @@ def _run_via_agent(sdk, cap, target_key):
         error(str(e))
 
 
-def _run_local(sdk, tool_name, target, extra_config):
+def _run_local(sdk, tool_name, target, extra_config, tool_args=None):
     """Run a tool locally using the installed binary."""
     from praetorian_cli.runners.local import LocalRunner, get_tool_plugin
 
@@ -392,7 +408,7 @@ def _run_local(sdk, tool_name, target, extra_config):
         raw_target = parts[-1] if len(parts) > 3 else parts[2] if len(parts) > 2 else target
 
     plugin = get_tool_plugin(tool_name)
-    args = plugin.build_args(raw_target, extra_config)
+    args = plugin.build_args(raw_target, extra_config, pass_through=list(tool_args or []))
 
     click.echo(f'Running {tool_name} locally against {raw_target}...')
     click.echo(f'Command: {tool_name} {" ".join(args)}')

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -34,6 +34,45 @@ INSTALLABLE_TOOLS = {
 }
 
 
+# Well-known service ports for Brutus protocol auto-detection.
+# Keep this minimal: only protocols Brutus natively supports.
+_WELL_KNOWN_PORTS = {
+    22: 'ssh',
+    3389: 'rdp',
+    21: 'ftp',
+    445: 'smb',
+    23: 'telnet',
+    3306: 'mysql',
+    5432: 'postgres',
+}
+
+
+def _infer_protocol(target: str):
+    """Infer protocol from a 'host:port' target using well-known ports.
+
+    Returns the protocol name or None if no inference is possible.
+    """
+    if not target or ':' not in target:
+        return None
+    # rsplit so 'host:port' works even if host contains ':'
+    _, sep, port_str = target.rpartition(':')
+    if not sep:
+        return None
+    try:
+        port = int(port_str)
+    except ValueError:
+        return None
+    return _WELL_KNOWN_PORTS.get(port)
+
+
+def _has_flag(pass_through, *flags):
+    """Return True if any of the given flag names appears in pass_through."""
+    if not pass_through:
+        return False
+    flag_set = set(flags)
+    return any(arg in flag_set for arg in pass_through)
+
+
 def _detect_platform():
     """Detect OS and architecture for binary download."""
     system = platform.system().lower()

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -273,6 +273,8 @@ class NucleiPlugin(ToolPlugin):
         args = ['-u', target, '-jsonl']
         if config.get('templates'):
             args.extend(['-t', config['templates']])
+        if pass_through:
+            args.extend(pass_through)
         return args
 
 
@@ -281,6 +283,8 @@ class TitusPlugin(ToolPlugin):
         args = ['scan', target]
         if config.get('validation') == 'true':
             args.append('--validate')
+        if pass_through:
+            args.extend(pass_through)
         return args
 
 
@@ -289,22 +293,33 @@ class TrajanPlugin(ToolPlugin):
         args = ['scan', target]
         if config.get('token'):
             args.extend(['--token', config['token']])
+        if pass_through:
+            args.extend(pass_through)
         return args
 
 
 class JuliusPlugin(ToolPlugin):
     def _build(self, target, config, pass_through=None):
-        return ['-t', target]
+        args = ['-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 class AugustusPlugin(ToolPlugin):
     def _build(self, target, config, pass_through=None):
-        return ['scan', '-t', target]
+        args = ['scan', '-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 class NervaPlugin(ToolPlugin):
     def _build(self, target, config, pass_through=None):
-        return ['-t', target]
+        args = ['-t', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 class GatoPlugin(ToolPlugin):
@@ -312,19 +327,27 @@ class GatoPlugin(ToolPlugin):
         args = ['enumerate', '-t', target]
         if config.get('token'):
             args.extend(['--token', config['token']])
+        if pass_through:
+            args.extend(pass_through)
         return args
 
 
 class UrlTargetPlugin(ToolPlugin):
     """For tools that take scan -u <target>."""
     def _build(self, target, config, pass_through=None):
-        return ['scan', '-u', target]
+        args = ['scan', '-u', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 class ScanTargetPlugin(ToolPlugin):
     """For tools that take scan <target>."""
     def _build(self, target, config, pass_through=None):
-        return ['scan', target]
+        args = ['scan', target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 TOOL_PLUGINS = {

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -350,6 +350,14 @@ class ScanTargetPlugin(ToolPlugin):
         return args
 
 
+# Plugin verification status:
+# - brutus:      verified against brutus --help (ENG-3042)
+# - nuclei:      -u is the documented URL flag — OK
+# - julius/nerva/nero: use -t <target>; unverified against each binary's --help
+# - titus/trajan/vespasian/constantine/caligula: `scan <target>` — unverified
+# - augustus/gato: `scan -t <target>` / `enumerate -t <target>` — unverified
+# - cato/florian/hadrian: `scan -u <target>` — unverified
+# Users can always override via `guard run tool <tool> <target> -- <raw args>`.
 TOOL_PLUGINS = {
     'brutus':      BrutusPlugin(),
     'nuclei':      NucleiPlugin(),

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -248,7 +248,7 @@ class ToolPlugin:
 
 
 class BrutusPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         args = ['-t', target]
         if config.get('usernames'):
             args.extend(['-u', config['usernames']])
@@ -258,7 +258,7 @@ class BrutusPlugin(ToolPlugin):
 
 
 class NucleiPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         args = ['-u', target, '-jsonl']
         if config.get('templates'):
             args.extend(['-t', config['templates']])
@@ -266,7 +266,7 @@ class NucleiPlugin(ToolPlugin):
 
 
 class TitusPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         args = ['scan', target]
         if config.get('validation') == 'true':
             args.append('--validate')
@@ -274,7 +274,7 @@ class TitusPlugin(ToolPlugin):
 
 
 class TrajanPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         args = ['scan', target]
         if config.get('token'):
             args.extend(['--token', config['token']])
@@ -282,22 +282,22 @@ class TrajanPlugin(ToolPlugin):
 
 
 class JuliusPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         return ['-t', target]
 
 
 class AugustusPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         return ['scan', '-t', target]
 
 
 class NervaPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         return ['-t', target]
 
 
 class GatoPlugin(ToolPlugin):
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         args = ['enumerate', '-t', target]
         if config.get('token'):
             args.extend(['--token', config['token']])
@@ -306,13 +306,13 @@ class GatoPlugin(ToolPlugin):
 
 class UrlTargetPlugin(ToolPlugin):
     """For tools that take scan -u <target>."""
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         return ['scan', '-u', target]
 
 
 class ScanTargetPlugin(ToolPlugin):
     """For tools that take scan <target>."""
-    def _build(self, target, config):
+    def _build(self, target, config, pass_through=None):
         return ['scan', target]
 
 

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -249,11 +249,22 @@ class ToolPlugin:
 
 class BrutusPlugin(ToolPlugin):
     def _build(self, target, config, pass_through=None):
-        args = ['-t', target]
-        if config.get('usernames'):
+        args = ['--target', target]
+
+        # Protocol: explicit config > caller passthrough wins silently > inferred
+        caller_has_protocol = _has_flag(pass_through, '--protocol')
+        if not caller_has_protocol:
+            proto = config.get('protocol') or _infer_protocol(target)
+            if proto:
+                args.extend(['--protocol', proto])
+
+        if config.get('usernames') and not _has_flag(pass_through, '-u', '-U'):
             args.extend(['-u', config['usernames']])
-        if config.get('passwords'):
+        if config.get('passwords') and not _has_flag(pass_through, '-p', '-P'):
             args.extend(['-p', config['passwords']])
+
+        if pass_through:
+            args.extend(pass_through)
         return args
 
 

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -251,7 +251,7 @@ class BrutusPlugin(ToolPlugin):
     def _build(self, target, config, pass_through=None):
         args = ['--target', target]
 
-        # Protocol: explicit config > caller passthrough wins silently > inferred
+        # Protocol precedence: caller passthrough (silent) > config['protocol'] > inferred from port
         caller_has_protocol = _has_flag(pass_through, '--protocol')
         if not caller_has_protocol:
             proto = config.get('protocol') or _infer_protocol(target)

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -230,17 +230,21 @@ class LocalRunner:
 class ToolPlugin:
     """Base class for local tool argument builders."""
 
-    def build_args(self, target, extra_config=''):
+    def build_args(self, target, extra_config='', pass_through=None):
         config = {}
         if extra_config:
             try:
                 config = json.loads(extra_config) if isinstance(extra_config, str) else extra_config
             except (json.JSONDecodeError, TypeError):
                 pass
-        return self._build(target, config)
+        args = self._build(target, config, pass_through=pass_through)
+        return args
 
-    def _build(self, target, config):
-        return [target]
+    def _build(self, target, config, pass_through=None):
+        args = [target]
+        if pass_through:
+            args.extend(pass_through)
+        return args
 
 
 class BrutusPlugin(ToolPlugin):

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -1,0 +1,62 @@
+import pytest
+
+from praetorian_cli.runners.local import _infer_protocol, _has_flag
+
+
+class TestInferProtocol:
+    def test_ssh_port(self):
+        assert _infer_protocol('10.0.1.5:22') == 'ssh'
+
+    def test_rdp_port(self):
+        assert _infer_protocol('host.example.com:3389') == 'rdp'
+
+    def test_ftp_port(self):
+        assert _infer_protocol('192.168.1.1:21') == 'ftp'
+
+    def test_smb_port(self):
+        assert _infer_protocol('10.0.0.5:445') == 'smb'
+
+    def test_telnet_port(self):
+        assert _infer_protocol('10.0.0.5:23') == 'telnet'
+
+    def test_mysql_port(self):
+        assert _infer_protocol('db.example.com:3306') == 'mysql'
+
+    def test_postgres_port(self):
+        assert _infer_protocol('db.example.com:5432') == 'postgres'
+
+    def test_unknown_port_returns_none(self):
+        assert _infer_protocol('host:9999') is None
+
+    def test_no_port_returns_none(self):
+        assert _infer_protocol('example.com') is None
+
+    def test_malformed_port_returns_none(self):
+        assert _infer_protocol('host:notaport') is None
+
+    def test_ipv6_bracket_form(self):
+        # IPv6 addresses use [::1]:22 bracket form — we don't need to support this,
+        # just not crash on it.
+        assert _infer_protocol('[::1]:22') in ('ssh', None)
+
+
+class TestHasFlag:
+    def test_empty_passthrough(self):
+        assert _has_flag(None, '-u') is False
+        assert _has_flag([], '-u') is False
+
+    def test_single_flag_present(self):
+        assert _has_flag(['-u', 'foo'], '-u') is True
+
+    def test_any_of_multiple(self):
+        assert _has_flag(['-U', 'users.txt'], '-u', '-U') is True
+        assert _has_flag(['-u', 'foo'], '-u', '-U') is True
+
+    def test_flag_absent(self):
+        assert _has_flag(['--other', 'val'], '-u') is False
+
+    def test_flag_as_value_ignored(self):
+        # A flag appearing only as a value to another flag should not match.
+        # Simpler: we match anywhere in the list. This keeps the helper small.
+        # If a user's file path happens to be '-u', that's their problem.
+        assert _has_flag(['--config', '-u'], '-u') is True

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -112,3 +112,77 @@ class TestSubclassesAcceptPassThroughKwarg:
     def test_build_args_without_passthrough_still_works(self, plugin_cls):
         plugin = plugin_cls()
         plugin.build_args('example.com')
+
+
+from praetorian_cli.runners.local import BrutusPlugin
+
+
+class TestBrutusPlugin:
+    def setup_method(self):
+        self.plugin = BrutusPlugin()
+
+    def test_bare_target_emits_target_flag(self):
+        args = self.plugin.build_args('example.com')
+        assert args == ['--target', 'example.com']
+
+    def test_target_with_ssh_port_infers_protocol(self):
+        args = self.plugin.build_args('10.0.1.5:22')
+        assert args == ['--target', '10.0.1.5:22', '--protocol', 'ssh']
+
+    def test_target_with_rdp_port_infers_protocol(self):
+        args = self.plugin.build_args('host.example.com:3389')
+        assert args == ['--target', 'host.example.com:3389', '--protocol', 'rdp']
+
+    def test_unknown_port_does_not_infer_protocol(self):
+        args = self.plugin.build_args('host:9999')
+        assert args == ['--target', 'host:9999']
+
+    def test_config_protocol_overrides_inference(self):
+        args = self.plugin.build_args('10.0.1.5:22', extra_config='{"protocol":"smb"}')
+        assert '--protocol' in args
+        idx = args.index('--protocol')
+        assert args[idx + 1] == 'smb'
+
+    def test_config_usernames_and_passwords(self):
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"usernames":"root,admin","passwords":"pw1,pw2"}',
+        )
+        assert args == [
+            '--target', 'host:22', '--protocol', 'ssh',
+            '-u', 'root,admin', '-p', 'pw1,pw2',
+        ]
+
+    def test_passthrough_appended(self):
+        args = self.plugin.build_args('host:22', pass_through=['--spray', '-v'])
+        assert args == ['--target', 'host:22', '--protocol', 'ssh', '--spray', '-v']
+
+    def test_passthrough_username_file_suppresses_structured_u(self):
+        # Caller-supplied -U wins — we should not also emit structured -u.
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"usernames":"root,admin"}',
+            pass_through=['-U', 'users.txt'],
+        )
+        # '-u' (structured) must NOT be present; '-U' must be.
+        assert '-u' not in args
+        assert '-U' in args
+        assert args[args.index('-U') + 1] == 'users.txt'
+
+    def test_passthrough_protocol_suppresses_inference(self):
+        args = self.plugin.build_args(
+            'host:22',
+            pass_through=['--protocol', 'rdp'],
+        )
+        # Only one --protocol, and it's the passthrough value.
+        assert args.count('--protocol') == 1
+        assert args[args.index('--protocol') + 1] == 'rdp'
+
+    def test_passthrough_password_file_suppresses_structured_p(self):
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"passwords":"pw"}',
+            pass_through=['-P', 'passes.txt'],
+        )
+        assert '-p' not in args
+        assert '-P' in args

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -60,3 +60,23 @@ class TestHasFlag:
         # Simpler: we match anywhere in the list. This keeps the helper small.
         # If a user's file path happens to be '-u', that's their problem.
         assert _has_flag(['--config', '-u'], '-u') is True
+
+
+from praetorian_cli.runners.local import ToolPlugin
+
+
+class TestToolPluginBase:
+    def test_default_plugin_passes_through(self):
+        plugin = ToolPlugin()
+        args = plugin.build_args('example.com', pass_through=['--flag', 'val'])
+        assert args == ['example.com', '--flag', 'val']
+
+    def test_default_plugin_without_passthrough(self):
+        plugin = ToolPlugin()
+        assert plugin.build_args('example.com') == ['example.com']
+
+    def test_default_plugin_with_json_config_and_passthrough(self):
+        plugin = ToolPlugin()
+        args = plugin.build_args('t', extra_config='{"k":"v"}', pass_through=['--x'])
+        # Default plugin ignores config but appends pass_through.
+        assert args == ['t', '--x']

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -195,3 +195,36 @@ class TestBrutusPlugin:
         )
         assert args.count('--protocol') == 1
         assert args[args.index('--protocol') + 1] == 'rdp'
+
+
+from praetorian_cli.runners.local import (
+    NucleiPlugin, TitusPlugin, TrajanPlugin, JuliusPlugin, AugustusPlugin,
+    NervaPlugin, GatoPlugin, UrlTargetPlugin, ScanTargetPlugin,
+)
+
+
+class TestPluginsForwardPassthrough:
+    """Every plugin must append pass_through args last."""
+
+    @pytest.mark.parametrize('plugin_cls,expected_prefix', [
+        (NucleiPlugin, ['-u', 'example.com', '-jsonl']),
+        (TitusPlugin, ['scan', 'example.com']),
+        (TrajanPlugin, ['scan', 'example.com']),
+        (JuliusPlugin, ['-t', 'example.com']),
+        (AugustusPlugin, ['scan', '-t', 'example.com']),
+        (NervaPlugin, ['-t', 'example.com']),
+        (GatoPlugin, ['enumerate', '-t', 'example.com']),
+        (UrlTargetPlugin, ['scan', '-u', 'example.com']),
+        (ScanTargetPlugin, ['scan', 'example.com']),
+    ])
+    def test_plugin_appends_passthrough(self, plugin_cls, expected_prefix):
+        plugin = plugin_cls()
+        args = plugin.build_args('example.com', pass_through=['--debug', '-v'])
+        assert args[:len(expected_prefix)] == expected_prefix
+        assert args[-2:] == ['--debug', '-v']
+
+    def test_plugin_no_passthrough_unchanged(self):
+        # Regression guard for the default (no passthrough) path.
+        assert NucleiPlugin().build_args('example.com') == ['-u', 'example.com', '-jsonl']
+        assert TitusPlugin().build_args('x') == ['scan', 'x']
+        assert JuliusPlugin().build_args('x') == ['-t', 'x']

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -80,3 +80,35 @@ class TestToolPluginBase:
         args = plugin.build_args('t', extra_config='{"k":"v"}', pass_through=['--x'])
         # Default plugin ignores config but appends pass_through.
         assert args == ['t', '--x']
+
+
+from praetorian_cli.runners.local import (
+    BrutusPlugin, NucleiPlugin, TitusPlugin, TrajanPlugin, JuliusPlugin,
+    AugustusPlugin, NervaPlugin, GatoPlugin, UrlTargetPlugin, ScanTargetPlugin,
+)
+
+
+class TestSubclassesAcceptPassThroughKwarg:
+    """Every concrete plugin must accept pass_through so the base class can forward it.
+
+    Body-level use of pass_through is added in Tasks 3 and 4; this test only guards
+    the signature so mid-sequence HEADs remain runnable.
+    """
+
+    @pytest.mark.parametrize('plugin_cls', [
+        BrutusPlugin, NucleiPlugin, TitusPlugin, TrajanPlugin, JuliusPlugin,
+        AugustusPlugin, NervaPlugin, GatoPlugin, UrlTargetPlugin, ScanTargetPlugin,
+    ])
+    def test_build_args_does_not_raise_with_passthrough(self, plugin_cls):
+        plugin = plugin_cls()
+        # Just prove it doesn't TypeError. We don't assert on pass_through being
+        # appended — Tasks 3 and 4 add that behavior per-plugin.
+        plugin.build_args('example.com', pass_through=['--noop'])
+
+    @pytest.mark.parametrize('plugin_cls', [
+        BrutusPlugin, NucleiPlugin, TitusPlugin, TrajanPlugin, JuliusPlugin,
+        AugustusPlugin, NervaPlugin, GatoPlugin, UrlTargetPlugin, ScanTargetPlugin,
+    ])
+    def test_build_args_without_passthrough_still_works(self, plugin_cls):
+        plugin = plugin_cls()
+        plugin.build_args('example.com')

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -186,3 +186,12 @@ class TestBrutusPlugin:
         )
         assert '-p' not in args
         assert '-P' in args
+
+    def test_passthrough_protocol_beats_config_protocol(self):
+        args = self.plugin.build_args(
+            'host:22',
+            extra_config='{"protocol":"smb"}',
+            pass_through=['--protocol', 'rdp'],
+        )
+        assert args.count('--protocol') == 1
+        assert args[args.index('--protocol') + 1] == 'rdp'

--- a/praetorian_cli/sdk/test/test_run_cli.py
+++ b/praetorian_cli/sdk/test/test_run_cli.py
@@ -1,0 +1,98 @@
+"""Unit tests for `guard run tool` argument passthrough and errors."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    """Build a minimal fake SDK covering the calls `guard run tool` makes."""
+    sdk = MagicMock()
+    sdk.capabilities.list.return_value = [
+        {'name': 'brutus', 'target': ['asset'], 'description': 'creds', 'executor': 'chariot'},
+    ]
+    sdk.search.fulltext.return_value = ([{'key': '#asset#10.0.1.5', 'dns': '10.0.1.5'}], None)
+    sdk.jobs.add.return_value = [{'key': '#job#abc'}]
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv):
+    """Invoke the CLI with a patched SDK factory.
+
+    The `chariot` click group replaces `ctx.obj` with a `Chariot` instance,
+    built lazily inside the group callback via `from praetorian_cli.sdk.chariot
+    import Chariot`. We patch that source symbol so every instantiation yields
+    our fake SDK. We also seed `ctx.obj` with the dict shape the group expects
+    (`{'keychain', 'proxy'}`) so invocation doesn't blow up before the patch
+    takes effect.
+    """
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, catch_exceptions=False)
+
+
+def test_passthrough_collects_unknown_options(runner, fake_sdk):
+    """Unknown options after target flow into tool_args and reach the local plugin."""
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.handlers.run._run_local') as mock_local:
+        _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5:22',
+            '--protocol', 'ssh', '-U', 'users.txt',
+        ])
+    assert mock_local.called
+    kwargs = mock_local.call_args.kwargs or {}
+    # The fifth positional is either pass_through or tool_args depending on our impl;
+    # we assert on the call_args tuple directly.
+    pass_through = mock_local.call_args.args[-1]
+    assert list(pass_through) == ['--protocol', 'ssh', '-U', 'users.txt']
+
+
+def test_double_dash_separator_forwards_own_flag_collisions(runner, fake_sdk):
+    """Flags that collide with our own names (e.g. --wait) still pass through after `--`."""
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.handlers.run._run_local') as mock_local:
+        result = _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5:22', '--', '--wait', '--foo',
+        ])
+    assert result.exit_code == 0
+    pass_through = mock_local.call_args.args[-1]
+    assert list(pass_through) == ['--wait', '--foo']
+
+
+def test_passthrough_with_remote_errors(runner, fake_sdk):
+    """Extra args are local-only — remote execution must reject them."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5:22', '--remote',
+        '--protocol', 'ssh',
+    ])
+    assert result.exit_code != 0
+    assert 'local' in result.output.lower()
+
+
+def test_passthrough_with_ask_errors(runner, fake_sdk):
+    """Extra args can't route through Marcus (agent path)."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5:22', '--ask',
+        '--protocol', 'ssh',
+    ])
+    assert result.exit_code != 0
+    assert 'local' in result.output.lower() or 'agent' in result.output.lower()
+
+
+def test_no_passthrough_preserves_remote_path(runner, fake_sdk):
+    """No trailing args and --remote: existing direct-job path still works."""
+    with patch('praetorian_cli.handlers.run._run_direct') as mock_direct:
+        result = _invoke(runner, fake_sdk, [
+            'run', 'tool', 'brutus', '10.0.1.5', '--remote',
+        ])
+    assert result.exit_code == 0
+    assert mock_direct.called

--- a/praetorian_cli/sdk/test/test_run_cli.py
+++ b/praetorian_cli/sdk/test/test_run_cli.py
@@ -96,3 +96,33 @@ def test_no_passthrough_preserves_remote_path(runner, fake_sdk):
         ])
     assert result.exit_code == 0
     assert mock_direct.called
+
+
+def test_local_and_remote_conflict(runner, fake_sdk):
+    """--local + --remote is always a user error."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5', '--local', '--remote',
+    ])
+    assert result.exit_code != 0
+    assert '--local' in result.output
+    assert '--remote' in result.output
+
+
+def test_local_and_ask_conflict(runner, fake_sdk):
+    """--local + --ask is always a user error."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5', '--local', '--ask',
+    ])
+    assert result.exit_code != 0
+    assert '--local' in result.output
+    assert '--ask' in result.output
+
+
+def test_remote_and_ask_conflict(runner, fake_sdk):
+    """--remote + --ask is always a user error."""
+    result = _invoke(runner, fake_sdk, [
+        'run', 'tool', 'brutus', '10.0.1.5', '--remote', '--ask',
+    ])
+    assert result.exit_code != 0
+    assert '--remote' in result.output
+    assert '--ask' in result.output

--- a/praetorian_cli/sdk/test/ui/test_console_tools.py
+++ b/praetorian_cli/sdk/test/ui/test_console_tools.py
@@ -4,9 +4,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from praetorian_cli.ui.console.commands.tools import ToolCommands
-from praetorian_cli.sdk.test.ui_mocks import MockConsole
+from praetorian_cli.sdk.test.ui_mocks import MockConsole as _BaseMockConsole
 
 pytestmark = pytest.mark.tui
+
+
+class MockConsole(_BaseMockConsole):
+    """Console mock that tolerates Rich kwargs like markup=/highlight=."""
+
+    def print(self, msg="", **kwargs):
+        self.lines.append(str(msg))
 
 
 class _FakeContext:
@@ -115,3 +122,76 @@ def test_no_passthrough_uses_remote_path():
          patch.object(_Harness, '_try_queue_job', return_value=[{'key': '#job#x'}]) as mock_queue:
         h._cmd_run(['brutus', '#asset#10.0.1.5'])
     assert mock_queue.called
+
+
+def test_run_tool_locally_streams_and_uploads(tmp_path, monkeypatch):
+    """Direct exercise of _run_tool_locally body: streaming + Guard upload."""
+    h = _Harness()
+
+    fake_proc = MagicMock()
+    fake_proc.stdout.__iter__.return_value = iter([
+        'scan start\n', '[+] success\n', 'scan done\n',
+    ])
+    fake_proc.stderr.read.return_value = ''
+    fake_proc.returncode = 0
+
+    fake_runner = MagicMock()
+    fake_runner.run_streaming.return_value = fake_proc
+
+    fake_plugin = MagicMock()
+    fake_plugin.build_args.return_value = ['--target', 'example.com', '--protocol', 'ssh']
+
+    with patch('praetorian_cli.runners.local.LocalRunner', return_value=fake_runner), \
+         patch('praetorian_cli.runners.local.get_tool_plugin', return_value=fake_plugin):
+        h._run_tool_locally('brutus', '#asset#example.com', ['--protocol', 'ssh'])
+
+    # Plugin was consulted with the stripped target + pass_through.
+    fake_plugin.build_args.assert_called_once()
+    call_kwargs = fake_plugin.build_args.call_args.kwargs
+    assert call_kwargs.get('pass_through') == ['--protocol', 'ssh']
+
+    # LocalRunner was invoked with the plugin's argv.
+    fake_runner.run_streaming.assert_called_once_with(
+        ['--target', 'example.com', '--protocol', 'ssh'],
+    )
+
+    # Subprocess stdout made it to the console (markup-escaped so [+] doesn't crash Rich).
+    output = '\n'.join(h.console.lines)
+    assert 'scan start' in output
+    assert '[+] success' in output
+    assert 'scan done' in output
+
+    # Guard upload was attempted.
+    assert h.sdk.files.add.called
+    guard_path_arg = h.sdk.files.add.call_args.args[1]
+    assert guard_path_arg.startswith('proofs/local/brutus/')
+
+
+def test_run_tool_locally_timeout_sets_exit_code(monkeypatch):
+    """When the subprocess times out, the post-kill wait sets a real returncode."""
+    import subprocess
+    h = _Harness()
+
+    fake_proc = MagicMock()
+    fake_proc.stdout.__iter__.return_value = iter(['partial\n'])
+    # First .wait raises TimeoutExpired; the second (after kill) succeeds.
+    fake_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd='brutus', timeout=600), None]
+    fake_proc.stderr.read.return_value = ''
+    fake_proc.returncode = -9
+
+    fake_runner = MagicMock()
+    fake_runner.run_streaming.return_value = fake_proc
+
+    fake_plugin = MagicMock()
+    fake_plugin.build_args.return_value = ['--target', 'x']
+
+    with patch('praetorian_cli.runners.local.LocalRunner', return_value=fake_runner), \
+         patch('praetorian_cli.runners.local.get_tool_plugin', return_value=fake_plugin):
+        h._run_tool_locally('brutus', 'x', [])
+
+    fake_proc.kill.assert_called_once()
+    # The post-kill wait must have been called to reap the process.
+    assert fake_proc.wait.call_count >= 2
+    output = '\n'.join(h.console.lines)
+    assert 'Timed out' in output
+    assert 'Exit code: -9' in output  # NOT 'Exit code: None'

--- a/praetorian_cli/sdk/test/ui/test_console_tools.py
+++ b/praetorian_cli/sdk/test/ui/test_console_tools.py
@@ -1,0 +1,117 @@
+"""Unit tests for console `run` passthrough and local execution path."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praetorian_cli.ui.console.commands.tools import ToolCommands
+from praetorian_cli.sdk.test.ui_mocks import MockConsole
+
+pytestmark = pytest.mark.tui
+
+
+class _FakeContext:
+    active_tool = None
+    account = 'acct'
+    _last_job_key = ''
+
+    def apply_scope_to_message(self, msg):
+        return msg
+
+
+class _Harness(ToolCommands):
+    """Bare wrapper to exercise ToolCommands methods in isolation."""
+
+    def __init__(self, sdk=None):
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FakeContext()
+        self.colors = {
+            'primary': 'cyan', 'accent': 'magenta', 'dim': 'dim',
+            'info': 'blue', 'success': 'green', 'warning': 'yellow', 'error': 'red',
+        }
+
+    # Stubs for methods the real console provides elsewhere.
+    def _send_to_marcus(self, message):  # pragma: no cover — not used in these tests
+        return ''
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+
+def test_run_with_passthrough_executes_locally_when_installed():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_run_tool_locally') as mock_local:
+        h._cmd_run(['brutus', '10.0.1.5:22', '--protocol', 'ssh', '-U', 'users.txt'])
+
+    assert mock_local.called
+    args, kwargs = mock_local.call_args
+    # Expect (tool_name, target, pass_through)
+    assert args[0] == 'brutus'
+    assert args[1] == '10.0.1.5:22'
+    assert list(args[2]) == ['--protocol', 'ssh', '-U', 'users.txt']
+
+
+def test_run_with_passthrough_but_not_installed_errors():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False):
+        h._cmd_run(['brutus', '10.0.1.5:22', '--protocol', 'ssh'])
+    output = '\n'.join(h.console.lines)
+    assert 'install' in output.lower() or 'local' in output.lower()
+
+
+def test_double_dash_forwards_own_flags():
+    """After `--`, even console-owned flags like --wait pass through."""
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_run_tool_locally') as mock_local:
+        h._cmd_run(['brutus', '10.0.1.5:22', '--', '--wait', '--spray'])
+    args, _ = mock_local.call_args
+    assert list(args[2]) == ['--wait', '--spray']
+
+
+def test_own_wait_flag_routes_to_remote_with_wait():
+    """`run brutus x --wait` (no `--`) keeps --wait as a console flag and routes remote."""
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch.object(_Harness, '_try_queue_job', return_value=[{'key': '#job#x'}]) as mock_queue, \
+         patch.object(_Harness, '_wait_for_job') as mock_wait:
+        h._cmd_run(['brutus', '#asset#10.0.1.5', '--wait'])
+    assert mock_queue.called
+    assert mock_wait.called
+
+
+def test_help_forwards_to_local_binary(tmp_path):
+    h = _Harness()
+    fake_proc = MagicMock()
+    fake_proc.stdout.__iter__.return_value = iter(['Brutus help\n', 'options\n'])
+    fake_proc.stderr.read.return_value = ''
+    fake_proc.returncode = 0
+
+    with patch('praetorian_cli.runners.local.is_installed', return_value=True), \
+         patch('praetorian_cli.runners.local.LocalRunner') as mock_cls:
+        mock_cls.return_value.run_streaming.return_value = fake_proc
+        h._cmd_run(['brutus', '--help'])
+
+    # run_streaming should have been called with ['--help'].
+    mock_cls.return_value.run_streaming.assert_called_once()
+    call_args = mock_cls.return_value.run_streaming.call_args.args[0]
+    assert call_args == ['--help']
+
+
+def test_help_when_not_installed_prints_install_hint():
+    h = _Harness()
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False):
+        h._cmd_run(['brutus', '--help'])
+    output = '\n'.join(h.console.lines)
+    assert 'install' in output.lower()
+
+
+def test_no_passthrough_uses_remote_path():
+    """Back-compat: bare `run brutus <key>` still queues a remote job."""
+    h = _Harness()
+    # Force remote by claiming the binary is NOT installed.
+    with patch('praetorian_cli.runners.local.is_installed', return_value=False), \
+         patch.object(_Harness, '_try_queue_job', return_value=[{'key': '#job#x'}]) as mock_queue:
+        h._cmd_run(['brutus', '#asset#10.0.1.5'])
+    assert mock_queue.called

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -41,32 +41,13 @@ class ToolCommands:
     def _cmd_run(self, args):
         """Run a named security tool against a target, or execute active tool."""
         from praetorian_cli.handlers.run import TOOL_ALIASES
+        from praetorian_cli.runners.local import is_installed as _is_installed
+
         if not args and self.context.active_tool:
-            # "run" with no args while tool is selected = execute
             self._cmd_execute([])
             return
         if not args:
-            # Show agents
-            agents = {k: v for k, v in TOOL_ALIASES.items() if v.get('agent') and k != 'secrets'}
-            table = Table(title='Agents', border_style=self.colors['primary'])
-            table.add_column('Agent', style=f'bold {self.colors["primary"]}', min_width=16)
-            table.add_column('Description')
-            for name, info in sorted(agents.items()):
-                table.add_row(name, info['description'])
-            self.console.print(table)
-
-            # Show direct capabilities
-            caps = {k: v for k, v in TOOL_ALIASES.items() if not v.get('agent') and k != 'secrets'}
-            if caps:
-                table2 = Table(title='Capabilities', border_style=self.colors['dim'])
-                table2.add_column('Capability', style=f'bold {self.colors["primary"]}', min_width=16)
-                table2.add_column('Target', style=self.colors['accent'])
-                table2.add_column('Description')
-                for name, info in sorted(caps.items()):
-                    table2.add_row(name, info['target_type'], info['description'])
-                self.console.print(table2)
-
-            self.console.print(f'\n[dim]Usage: use <name> or <name> <target_key>[/dim]')
+            self._print_tool_catalog(TOOL_ALIASES)
             return
 
         tool_name = args[0].lower()
@@ -76,17 +57,59 @@ class ToolCommands:
             self.console.print(f'[error]Unknown tool: {tool_name}. Available: {available}[/error]')
             return
 
-        if len(args) < 2:
-            self.console.print(f'[dim]Usage: {tool_name} <target_key> [--ask] [--wait][/dim]')
+        rest = args[1:]
+
+        # `run <tool> --help` — forward to local binary if installed.
+        if rest and rest[0] == '--help':
+            self._print_tool_help(tool_name)
+            return
+
+        if not rest:
+            self.console.print(f'[dim]Usage: {tool_name} <target_key> [--ask] [--wait] [-- <tool-args>...][/dim]')
             self.console.print(f'[dim]  Target type: {alias["target_type"]}[/dim]')
             self.console.print(f'[dim]  {alias["description"]}[/dim]')
             return
 
-        raw_target = args[1]
-        use_agent = '--ask' in args
-        wait = '--wait' in args
+        raw_target = rest[0]
+        remaining = rest[1:]
 
-        # Resolve friendly target names to Guard keys
+        # Split own flags from passthrough. Honor `--` as an explicit boundary:
+        # everything after `--` is passthrough, even if it collides with `--wait`/`--ask`.
+        OWN_FLAGS = {'--ask', '--wait'}
+        pass_through = []
+        own = []
+        if '--' in remaining:
+            idx = remaining.index('--')
+            own = remaining[:idx]
+            pass_through = remaining[idx + 1:]
+        else:
+            for a in remaining:
+                if a in OWN_FLAGS:
+                    own.append(a)
+                else:
+                    pass_through.append(a)
+
+        use_agent = '--ask' in own
+        wait = '--wait' in own
+
+        if pass_through and use_agent:
+            self.console.print(
+                '[error]Extra arguments are not supported with --ask (agent path). '
+                'Drop --ask or use structured config.[/error]'
+            )
+            return
+
+        if pass_through:
+            if not _is_installed(tool_name):
+                self.console.print(
+                    f'[error]Extra arguments require the {tool_name} binary to be installed locally. '
+                    f'Run "install {tool_name}" first.[/error]'
+                )
+                return
+            self._run_tool_locally(tool_name, raw_target, pass_through)
+            return
+
+        # No passthrough — existing remote/agent flow.
         from praetorian_cli.handlers.run import resolve_target
         target_key, warning = resolve_target(self.sdk, raw_target, alias['target_type'])
         if not target_key:
@@ -99,23 +122,120 @@ class ToolCommands:
         config = dict(alias.get('default_config', {}))
 
         if alias.get('agent') and (use_agent or not capability):
-            # Route through Marcus (forced for agent-only tools, optional for others)
             agent_name = alias['agent']
             task_desc = f'Run {capability} against {target_key} and analyze the results.' if capability else f'Analyze {target_key} thoroughly.'
             message = self.context.apply_scope_to_message(task_desc)
             self.console.print(f'[info]Delegating to {agent_name} via Marcus...[/info]')
             response_text = self._send_to_marcus(message)
             if response_text:
+                from rich.markdown import Markdown
                 self.console.print(Markdown(response_text))
         else:
-            # Direct job execution -- with fallback to own account if frozen/blocked
+            import json
             config_str = json.dumps(config) if config else None
             result = self._try_queue_job(target_key, capability, config_str)
             if result is None:
                 return
-
             if wait:
                 self._wait_for_job(target_key, capability)
+
+    def _print_tool_catalog(self, TOOL_ALIASES):
+        """Render the agents/capabilities catalog shown when `run` is called bare."""
+        agents = {k: v for k, v in TOOL_ALIASES.items() if v.get('agent') and k != 'secrets'}
+        table = Table(title='Agents', border_style=self.colors['primary'])
+        table.add_column('Agent', style=f'bold {self.colors["primary"]}', min_width=16)
+        table.add_column('Description')
+        for name, info in sorted(agents.items()):
+            table.add_row(name, info['description'])
+        self.console.print(table)
+
+        caps = {k: v for k, v in TOOL_ALIASES.items() if not v.get('agent') and k != 'secrets'}
+        if caps:
+            table2 = Table(title='Capabilities', border_style=self.colors['dim'])
+            table2.add_column('Capability', style=f'bold {self.colors["primary"]}', min_width=16)
+            table2.add_column('Target', style=self.colors['accent'])
+            table2.add_column('Description')
+            for name, info in sorted(caps.items()):
+                table2.add_row(name, info['target_type'], info['description'])
+            self.console.print(table2)
+
+        self.console.print(f'\n[dim]Usage: use <name> or <name> <target_key>[/dim]')
+
+    def _print_tool_help(self, tool_name):
+        """Run `<tool> --help` locally and stream its output to the console."""
+        from praetorian_cli.runners.local import is_installed as _is_installed, LocalRunner
+        if not _is_installed(tool_name):
+            self.console.print(
+                f'[warning]{tool_name} is not installed locally. Run "install {tool_name}" first.[/warning]'
+            )
+            return
+        try:
+            runner = LocalRunner(tool_name)
+            proc = runner.run_streaming(['--help'])
+            for line in proc.stdout:
+                self.console.print(line.rstrip('\n'))
+            stderr = proc.stderr.read() if proc.stderr else ''
+            if stderr:
+                self.console.print(f'[dim]{stderr}[/dim]')
+        except Exception as e:
+            self.console.print(f'[error]{e}[/error]')
+
+    def _run_tool_locally(self, tool_name, raw_target, pass_through):
+        """Run an installed tool binary locally from the console."""
+        from praetorian_cli.runners.local import LocalRunner, get_tool_plugin
+
+        # Strip Guard key prefix for the raw target (same logic as CLI _run_local).
+        target = raw_target
+        if raw_target.startswith('#'):
+            parts = raw_target.split('#')
+            target = parts[-1] if len(parts) > 3 else parts[2] if len(parts) > 2 else raw_target
+
+        plugin = get_tool_plugin(tool_name)
+        tool_argv = plugin.build_args(target, pass_through=list(pass_through or []))
+
+        try:
+            runner = LocalRunner(tool_name)
+        except FileNotFoundError as e:
+            self.console.print(f'[error]{e}[/error]')
+            return
+
+        self.console.print(f'[info]Running {tool_name} locally against {target}...[/info]')
+        self.console.print(f'[dim]Command: {tool_name} {" ".join(tool_argv)}[/dim]')
+        self.console.print('[dim]' + '─' * 60 + '[/dim]')
+
+        import subprocess
+        proc = runner.run_streaming(tool_argv)
+        output_lines = []
+        try:
+            for line in proc.stdout:
+                self.console.print(line.rstrip('\n'))
+                output_lines.append(line)
+            proc.wait(timeout=600)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            self.console.print('[error]Timed out (10 min).[/error]')
+
+        stderr = proc.stderr.read() if proc.stderr else ''
+        if stderr:
+            self.console.print(f'[dim]{stderr}[/dim]')
+
+        self.console.print('[dim]' + '─' * 60 + '[/dim]')
+        self.console.print(f'[dim]Exit code: {proc.returncode}[/dim]')
+
+        # Best-effort upload to Guard (mirrors CLI behavior).
+        output_text = ''.join(output_lines)
+        if output_text.strip():
+            try:
+                import tempfile, os
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, prefix=f'{tool_name}-') as f:
+                    f.write(output_text)
+                    tmp_path = f.name
+                guard_path = f'proofs/local/{tool_name}/{target.replace("/", "_")}'
+                self.sdk.files.add(tmp_path, guard_path)
+                os.unlink(tmp_path)
+                self.console.print(f'[success]Output uploaded to Guard: {guard_path}[/success]')
+            except Exception as e:
+                self.console.print(f'[warning]Failed to upload output: {e}[/warning]')
 
     def _try_queue_job(self, target_key, capability, config_str):
         """Try to queue a job. If frozen/blocked, fallback to the login user's own account."""

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -5,6 +5,7 @@ import os
 import time
 
 from rich.markdown import Markdown
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -173,10 +174,10 @@ class ToolCommands:
             runner = LocalRunner(tool_name)
             proc = runner.run_streaming(['--help'])
             for line in proc.stdout:
-                self.console.print(line.rstrip('\n'))
+                self.console.print(line.rstrip('\n'), markup=False, highlight=False)
             stderr = proc.stderr.read() if proc.stderr else ''
             if stderr:
-                self.console.print(f'[dim]{stderr}[/dim]')
+                self.console.print(f'[dim]{escape(stderr)}[/dim]')
         except Exception as e:
             self.console.print(f'[error]{e}[/error]')
 
@@ -208,16 +209,20 @@ class ToolCommands:
         output_lines = []
         try:
             for line in proc.stdout:
-                self.console.print(line.rstrip('\n'))
+                self.console.print(line.rstrip('\n'), markup=False, highlight=False)
                 output_lines.append(line)
             proc.wait(timeout=600)
         except subprocess.TimeoutExpired:
             proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
             self.console.print('[error]Timed out (10 min).[/error]')
 
         stderr = proc.stderr.read() if proc.stderr else ''
         if stderr:
-            self.console.print(f'[dim]{stderr}[/dim]')
+            self.console.print(f'[dim]{escape(stderr)}[/dim]')
 
         self.console.print('[dim]' + '─' * 60 + '[/dim]')
         self.console.print(f'[dim]Exit code: {proc.returncode}[/dim]')


### PR DESCRIPTION
## Summary

Fixes `guard run tool <tool> <target>` and console `run <tool> <target>` argument handling, resolving Hunter's Brutus bug report.

**Root-cause bugs:**
- `BrutusPlugin` emitted `-t <target>` — but `-t` in Brutus is `--threads`, not target. Any `guard run tool brutus …` invocation failed with "invalid threads" errors.
- The Click command ate any extra flags (e.g. `-U users.txt`) as unknown options before the plugin could see them.
- The console had no local-execution path and no way to forward tool-specific flags.

**Behavior now:**
- `guard run tool brutus 10.0.1.5:22 --protocol ssh -U users.txt` — extras flow to the local binary.
- `guard run tool brutus 10.0.1.5:22 -- --wait` — `--` forces passthrough for flags that collide with our own options.
- `run brutus 10.0.1.5:22 --protocol ssh -U users.txt` — works the same inside the interactive console.
- `run brutus --help` — streams the local binary's help into the console.
- `--remote`/`--ask` + extras → clear error telling the user to install locally or use `-c '{…}'`.
- `--local` / `--remote` / `--ask` are now mutually exclusive with a useful error.
- Auto-infers `--protocol` for well-known SSH/RDP/FTP/SMB/Telnet/MySQL/Postgres ports; caller-supplied `--protocol` always wins.
- Caller-supplied `-U`/`-P` (file variants) suppress structured `-u`/`-p` (inline variants) to avoid duplicate-flag conflicts.

## Smoke test

Spun up `linuxserver/openssh-server` on 127.0.0.1:2222 and exercised the end-to-end CLI path (worktree code via `PYTHONPATH`):

```
guard run tool brutus 127.0.0.1:2222 --local --protocol ssh \
  -U /tmp/users.txt -P /tmp/passes.txt --no-badkeys -t 1
```

Brutus logged `Threads: 1` (proving `-t 1` reached it as the threads flag — the original bug would have made this "invalid threads: 127.0.0.1:2222"), enumerated 4 × 4 = 16 attempts, and uploaded output to `proofs/local/brutus/…`. Direct binary test with a single valid credential returned `[+] VALID: ssh smoketest:Secret123 @ 127.0.0.1:2222`.

## Tests

- `praetorian_cli/sdk/test/test_local_runner.py` (60 tests) — plugin args, protocol inference, flag-collision suppression, all plugins forward `pass_through`.
- `praetorian_cli/sdk/test/test_run_cli.py` (8 tests) — CLI passthrough collection, `--` separator, routing error cases.
- `praetorian_cli/sdk/test/ui/test_console_tools.py` (9 tests) — console routing, `--help` forwarding, local-exec streaming + Guard upload, timeout reap.

**77 unit tests pass.**

## JIRA

ENG-3042 (sub-ticket of OFFSEC-2383). Parent-ticket Marcus-crash work is out of scope here.

## Deferred follow-ups

- `handlers/run.py:_run_local` and `ui/console/commands/tools.py:_run_tool_locally` share near-identical subprocess+upload logic; extract to a shared helper when a third caller appears.
- `ui_mocks.MockConsole.print` should accept `**kwargs` (a test-file shim is used here because of the markup-escape kwargs).
- Plugin audit: julius/nerva/nero/titus/trajan/etc. flag shapes are unverified against their real `--help` (annotated in `runners/local.py`). Users can always override via `-- <raw args>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)