### PR TITLE
fix(ci): pin public-workflows @main → v2.0.4 SHA (hardening + P0 fix)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@1da9a5e29de06e850035b01e1ab5c0e19435ba30  # v2.0.4
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@4e998eb54df4946e9b8547e20da8148f2a57499a  # v2.0.6
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@98b351a8f9a0876d65c8c80c4d5a273d2310ba99  # v2.0.8
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@98b351a8f9a0876d65c8c80c4d5a273d2310ba99  # v2.0.8
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@c4e898f83b9c4008cc3dbe295cc420e53ec6b16b  # v2.0.9
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@37b9b30d48f40522305e01a1ea5eaf32bc346d7a  # v2.0.5
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@4e998eb54df4946e9b8547e20da8148f2a57499a  # v2.0.6
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@1da9a5e29de06e850035b01e1ab5c0e19435ba30  # v2.0.4
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@37b9b30d48f40522305e01a1ea5eaf32bc346d7a  # v2.0.5
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Bumps the `claude-code.yml` reusable-workflow pin from the previous SHA to `v2.0.4` (`1da9a5e29de06e850035b01e1ab5c0e19435ba30`).

## What this pulls in

Four hardening changes shipped to `public-workflows` since your current pin:

1. **`author_association ∈ {OWNER, MEMBER, COLLABORATOR}` gate** (v2.0.3) — Blocks prompt-injection from external-PR authors and requires `@claude` commenters to be insiders.
2. **Restrictive `--allowedTools` + `--disallowedTools` floor** (v2.0.3) — Claude is limited to `Bash(gh pr comment/diff/view:*), Read, Grep, Glob, mcp__github_inline_comment__create_inline_comment`. Explicitly denies `Bash(curl/wget/gh api/gh auth:*), Bash(git add/commit/push/rm:*), Write, Edit, MultiEdit`.
3. **MCP inline-comment tool** (v2.0.3) — Enables CodeRabbit-style line-anchored review comments on this repo's PRs, scoped to the current PR context.
4. **P0 comment-and-control fix** (v2.0.4) — `pull_request_review_comment` now requires BOTH the commenter AND the PR author to be insiders. Closes the CVSS 9.4 attack path documented at [oddguan.com](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) (Anthropic bounty-acknowledged) where an external PR + maintainer `@claude` would let Claude read external content and exfiltrate secrets via allowed posting tools. Also adds explicit `track_progress: "false"` and a defensive system-prompt preamble.

## Caller-visible impact

- **No caller configuration needed** — all hardening lives in the central workflow.
- **Inline line-anchored review comments** will now appear on this repo's PRs automatically (for org members, on PRs from org members).
- **PRs from external accounts / forks → no Claude review** by design. If an external PR needs review, open an internal fix PR mirroring the changes.

## References

- [public-workflows v2.0.4 release](https://github.com/praetorian-inc/public-workflows/releases/tag/v2.0.4)
- [oddguan.com — comment and control](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) (CVSS 9.4)
- [anthropics/claude-code-action#860](https://github.com/anthropics/claude-code-action/issues/860) — track_progress union-merge
- ENG-3113, parent ENG-3079

🤖 Generated via scripted bulk-bump (ENG-3113)
