### PR TITLE
feat(guard): add --sow, --footer, --confidential-label flags to report export

### DIFF
--- a/praetorian_cli/handlers/export.py
+++ b/praetorian_cli/handlers/export.py
@@ -30,6 +30,7 @@ def export():
 @click.option('--version', 'report_version', default='1.0', help='Report version string')
 @click.option('--sow', default='', help='Statement of Work identifier (expands %%SOW%% shortcode).')
 @click.option('--footer', default='', help='Custom page-footer text (overrides the report title when set).')
+@click.option('--confidential-label', 'confidential_label', default='', help='Confidentiality label shown on cover, header, and footer (defaults to "Confidential").')
 @click.option('--format', 'export_format', type=click.Choice(['pdf', 'zip']),
               default='pdf', help='Export format')
 @click.option('--group-by', type=click.Choice(['attack_surface', 'tag']),
@@ -50,7 +51,7 @@ def export():
               help='Skip downloading the file; just print the job result')
 def report(chariot, title, client_name, status_filter, risk_keys,
            target, start_date, end_date, report_date, draft, retest,
-           report_version, sow, footer, export_format, group_by, shared,
+           report_version, sow, footer, confidential_label, export_format, group_by, shared,
            executive_summary, narratives, appendix, output,
            timeout, no_download):
     """ Generate and download a PDF or ZIP report.
@@ -88,6 +89,7 @@ def report(chariot, title, client_name, status_filter, risk_keys,
         version=report_version,
         sow=sow,
         footer=footer,
+        confidential_label=confidential_label,
         export_format=export_format,
         group_by=group_by,
         shared_output=shared,

--- a/praetorian_cli/handlers/export.py
+++ b/praetorian_cli/handlers/export.py
@@ -28,6 +28,8 @@ def export():
 @click.option('--retest/--no-retest', default=False,
               help='Include retest status badges and sections')
 @click.option('--version', 'report_version', default='1.0', help='Report version string')
+@click.option('--sow', default='', help='Statement of Work identifier (expands %%SOW%% shortcode).')
+@click.option('--footer', default='', help='Custom page-footer text (overrides the report title when set).')
 @click.option('--format', 'export_format', type=click.Choice(['pdf', 'zip']),
               default='pdf', help='Export format')
 @click.option('--group-by', type=click.Choice(['attack_surface', 'tag']),
@@ -48,7 +50,7 @@ def export():
               help='Skip downloading the file; just print the job result')
 def report(chariot, title, client_name, status_filter, risk_keys,
            target, start_date, end_date, report_date, draft, retest,
-           report_version, export_format, group_by, shared,
+           report_version, sow, footer, export_format, group_by, shared,
            executive_summary, narratives, appendix, output,
            timeout, no_download):
     """ Generate and download a PDF or ZIP report.
@@ -84,6 +86,8 @@ def report(chariot, title, client_name, status_filter, risk_keys,
         draft=draft,
         retest=retest,
         version=report_version,
+        sow=sow,
+        footer=footer,
         export_format=export_format,
         group_by=group_by,
         shared_output=shared,

--- a/praetorian_cli/sdk/entities/reports.py
+++ b/praetorian_cli/sdk/entities/reports.py
@@ -36,7 +36,7 @@ class Reports:
                           status_filter=('O', 'T'), risk_keys=(),
                           target='', start_date='', end_date='',
                           report_date='', draft=False, retest=False,
-                          version='1.0', sow='', footer='',
+                          version='1.0', sow='', footer='', confidential_label='',
                           export_format='pdf', group_by='attack_surface',
                           shared_output=False, executive_summary_path='',
                           narratives_path='', appendix_path=''):
@@ -71,6 +71,8 @@ class Reports:
         :type sow: str
         :param footer: Custom page-footer text (overrides the report title when set)
         :type footer: str
+        :param confidential_label: Confidentiality label shown on cover, page header, and footer (defaults to "Confidential" when empty)
+        :type confidential_label: str
         :param export_format: Output format ('pdf' or 'zip')
         :type export_format: str
         :param group_by: Finding grouping strategy ('attack_surface' or 'tag')
@@ -117,6 +119,8 @@ class Reports:
             body['config']['sow'] = sow
         if footer:
             body['config']['footer'] = footer
+        if confidential_label:
+            body['config']['confidential_label'] = confidential_label
         if executive_summary_path:
             body['executive_summary_path'] = executive_summary_path
         if narratives_path:

--- a/praetorian_cli/sdk/entities/reports.py
+++ b/praetorian_cli/sdk/entities/reports.py
@@ -36,7 +36,7 @@ class Reports:
                           status_filter=('O', 'T'), risk_keys=(),
                           target='', start_date='', end_date='',
                           report_date='', draft=False, retest=False,
-                          version='1.0',
+                          version='1.0', sow='', footer='',
                           export_format='pdf', group_by='attack_surface',
                           shared_output=False, executive_summary_path='',
                           narratives_path='', appendix_path=''):
@@ -67,6 +67,10 @@ class Reports:
         :type retest: bool
         :param version: Report version string
         :type version: str
+        :param sow: Statement of Work identifier (expands %SOW% shortcode)
+        :type sow: str
+        :param footer: Custom page-footer text (overrides the report title when set)
+        :type footer: str
         :param export_format: Output format ('pdf' or 'zip')
         :type export_format: str
         :param group_by: Finding grouping strategy ('attack_surface' or 'tag')
@@ -109,6 +113,10 @@ class Reports:
             body['config']['start_date'] = start_date
         if end_date:
             body['config']['end_date'] = end_date
+        if sow:
+            body['config']['sow'] = sow
+        if footer:
+            body['config']['footer'] = footer
         if executive_summary_path:
             body['executive_summary_path'] = executive_summary_path
         if narratives_path:

--- a/praetorian_cli/sdk/test/test_export_cli.py
+++ b/praetorian_cli/sdk/test/test_export_cli.py
@@ -1,0 +1,100 @@
+"""CLI-level tests for `guard export report` flag forwarding."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.export  # noqa: F401 — register export group on chariot
+from praetorian_cli.handlers.chariot import chariot
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    sdk.reports.customer_email.return_value = 'customer@acme.com'
+    sdk.reports.build_export_body.return_value = {'config': {}}
+    sdk.reports.export.return_value = {'config': {'output': 'home/report.pdf'}}
+    sdk.reports.output_path.return_value = 'home/report.pdf'
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv):
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, catch_exceptions=False)
+
+
+def test_sow_flag_forwarded_to_build_export_body(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'export', 'report',
+        '--title', 'Test Report',
+        '--client-name', 'Acme',
+        '--sow', 'SOW-2026-TEST',
+        '--no-download',
+    ])
+    assert result.exit_code == 0
+    kwargs = fake_sdk.reports.build_export_body.call_args.kwargs
+    assert kwargs['sow'] == 'SOW-2026-TEST'
+
+
+def test_footer_flag_forwarded_to_build_export_body(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'export', 'report',
+        '--title', 'Test Report',
+        '--client-name', 'Acme',
+        '--footer', 'Acme | Q2 External Assessment',
+        '--no-download',
+    ])
+    assert result.exit_code == 0
+    kwargs = fake_sdk.reports.build_export_body.call_args.kwargs
+    assert kwargs['footer'] == 'Acme | Q2 External Assessment'
+
+
+def test_confidential_label_flag_forwarded_to_build_export_body(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'export', 'report',
+        '--title', 'Test Report',
+        '--client-name', 'Acme',
+        '--confidential-label', 'Privileged & Confidential',
+        '--no-download',
+    ])
+    assert result.exit_code == 0
+    kwargs = fake_sdk.reports.build_export_body.call_args.kwargs
+    assert kwargs['confidential_label'] == 'Privileged & Confidential'
+
+
+def test_all_three_flags_together(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'export', 'report',
+        '--title', 'Test Report',
+        '--client-name', 'Acme',
+        '--sow', 'SOW-2026-TEST',
+        '--footer', 'Acme | Q2',
+        '--confidential-label', 'Internal Use Only',
+        '--no-download',
+    ])
+    assert result.exit_code == 0
+    kwargs = fake_sdk.reports.build_export_body.call_args.kwargs
+    assert kwargs['sow'] == 'SOW-2026-TEST'
+    assert kwargs['footer'] == 'Acme | Q2'
+    assert kwargs['confidential_label'] == 'Internal Use Only'
+
+
+def test_new_flags_default_to_empty_when_omitted(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'export', 'report',
+        '--title', 'Test Report',
+        '--client-name', 'Acme',
+        '--no-download',
+    ])
+    assert result.exit_code == 0
+    kwargs = fake_sdk.reports.build_export_body.call_args.kwargs
+    assert kwargs['sow'] == ''
+    assert kwargs['footer'] == ''
+    assert kwargs['confidential_label'] == ''

--- a/praetorian_cli/sdk/test/test_report.py
+++ b/praetorian_cli/sdk/test/test_report.py
@@ -88,6 +88,8 @@ class TestBuildExportBody:
             draft=True,
             retest=True,
             version='2.0',
+            sow='SOW-2026-TEST',
+            footer='Q2 External Assessment',
             export_format='zip',
             group_by='tag',
             shared_output=True,
@@ -103,6 +105,8 @@ class TestBuildExportBody:
         assert body['config']['draft'] is True
         assert body['config']['retest'] is True
         assert body['config']['version'] == '2.0'
+        assert body['config']['sow'] == 'SOW-2026-TEST'
+        assert body['config']['footer'] == 'Q2 External Assessment'
         assert body['export_format'] == 'zip'
         assert body['group_by'] == 'tag'
         assert body['shared_output'] is True
@@ -123,9 +127,12 @@ class TestBuildExportBody:
         reports, _ = make_reports()
         body = reports.build_export_body(
             title='Test', client_name='Test', customer_email='test@test.com',
-            target='', executive_summary_path='', narratives_path='', appendix_path='',
+            target='', sow='', footer='',
+            executive_summary_path='', narratives_path='', appendix_path='',
         )
         assert 'target' not in body['config']
+        assert 'sow' not in body['config']
+        assert 'footer' not in body['config']
         assert 'executive_summary_path' not in body
         assert 'narratives_path' not in body
         assert 'appendix_path' not in body

--- a/praetorian_cli/sdk/test/test_report.py
+++ b/praetorian_cli/sdk/test/test_report.py
@@ -90,6 +90,7 @@ class TestBuildExportBody:
             version='2.0',
             sow='SOW-2026-TEST',
             footer='Q2 External Assessment',
+            confidential_label='Privileged & Confidential',
             export_format='zip',
             group_by='tag',
             shared_output=True,
@@ -107,6 +108,7 @@ class TestBuildExportBody:
         assert body['config']['version'] == '2.0'
         assert body['config']['sow'] == 'SOW-2026-TEST'
         assert body['config']['footer'] == 'Q2 External Assessment'
+        assert body['config']['confidential_label'] == 'Privileged & Confidential'
         assert body['export_format'] == 'zip'
         assert body['group_by'] == 'tag'
         assert body['shared_output'] is True
@@ -127,12 +129,13 @@ class TestBuildExportBody:
         reports, _ = make_reports()
         body = reports.build_export_body(
             title='Test', client_name='Test', customer_email='test@test.com',
-            target='', sow='', footer='',
+            target='', sow='', footer='', confidential_label='',
             executive_summary_path='', narratives_path='', appendix_path='',
         )
         assert 'target' not in body['config']
         assert 'sow' not in body['config']
         assert 'footer' not in body['config']
+        assert 'confidential_label' not in body['config']
         assert 'executive_summary_path' not in body
         assert 'narratives_path' not in body
         assert 'appendix_path' not in body


### PR DESCRIPTION
## Summary (required)

Adds three new optional flags to `guard export report` and the corresponding kwargs on `Reports.build_export_body()`, keeping the Python SDK + CLI in lockstep with new fields surfaced on the Guard UI's PDF export form and supported in orator's report template.

| Flag | Kwarg | Default | Effect |
|---|---|---|---|
| `--sow` | `sow=''` | `''` | Populates `%%SOW%%` shortcode in orator report body |
| `--footer` | `footer=''` | `''` | Overrides report title in page-footer middle span |
| `--confidential-label` | `confidential_label=''` | `''` (CLI), UI prefills `"Confidential"` | Overrides the confidentiality tag on cover/header/footer |

All three follow the existing optional-field pattern (`target`, `start_date`, `end_date`) — only appended to the request body's `config` dict when truthy, so older backends that don't know the field won't receive spurious empty strings.

### Files

- `praetorian_cli/sdk/entities/reports.py` — `build_export_body()` gains `sow=''`, `footer=''`, `confidential_label=''` kwargs; conditional appends to `body['config']`.
- `praetorian_cli/handlers/export.py` — three new `@click.option(...)` decorators on `report`, forwarded into `build_export_body()`.
- `praetorian_cli/sdk/test/test_report.py` — extended `test_all_optional_fields` and `test_empty_optional_strings_excluded` (SDK level) to cover all three.
- `praetorian_cli/sdk/test/test_export_cli.py` — **new** CliRunner tests guarding the Click option wiring itself: each of the three flags is forwarded as the correct kwarg into `build_export_body()`, plus a default-empty-when-omitted case. Mirrors the patching pattern in `test_run_cli.py`.

Full test run: `pytest praetorian_cli/sdk/test/test_report.py praetorian_cli/sdk/test/test_export_cli.py` → 26 passed.

### Usage

```bash
guard export report \
  --title "External Assessment" \
  --client-name "Acme Corp" \
  --customer-email alice@acme.example \
  --sow SOW-2026-TEST \
  --footer "Acme | Q2 External Assessment" \
  --confidential-label "Internal Use Only" \
  …
```

Companion PRs: Guard UI surfaces the fields on the Export PDF form and wires them through `ReportConfig`; orator adds the `Footer` frontmatter + template fallbacks (SOW and ConfidentialLabel already existed on orator's side).

## JIRA (required)

N/A — internal tooling parity with Guard UI and orator template changes.