### PR TITLE
chore(claude-code): bump public-workflows SHA for ready_for_review fix

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@c4e898f83b9c4008cc3dbe295cc420e53ec6b16b  # v2.0.9
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@e64522990f20da94ab7554985ae3c27f1e552d85  # v2.0.12
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Bumps public-workflows claude-code.yml SHA to include the `ready_for_review` fix
- Points at [public-workflows@e645229](https://github.com/praetorian-inc/public-workflows/commit/e64522990f20da94ab7554985ae3c27f1e552d85) which accepts `ready_for_review` in job `if:` conditions
- Completes the draft-PR fix: callers now deliver the event AND the reusable workflow accepts it

Generated with [Claude Code](https://claude.com/claude-code)
