### PR TITLE
Handle list-based targets in Aegis job picker

### DIFF
--- a/praetorian_cli/sdk/test/ui/test_aegis_job.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_job.py
@@ -1,7 +1,10 @@
 import json
 
 import pytest
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
 from praetorian_cli.ui.aegis.commands.job import handle_job
+from praetorian_cli.ui.aegis.commands.job_helpers import CapabilityCompleter
 from rich.prompt import Confirm
 from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
 
@@ -30,6 +33,22 @@ def test_job_capabilities_lists_caps():
     calls = menu.sdk.aegis.calls
     assert len(calls) == 1
     assert calls[0]['capabilities'] is None
+
+
+def test_capability_completer_accepts_list_target():
+    completer = CapabilityCompleter([
+        {
+            'name': 'linux-enum-linpeas',
+            'description': 'Linux enumeration',
+            'target': ['asset'],
+        }
+    ])
+
+    completions = list(completer.get_completions(Document('linux'), CompleteEvent()))
+
+    assert len(completions) == 1
+    assert completions[0].text == 'linux-enum-linpeas'
+    assert '[asset]' in str(completions[0].display_meta)
 
 
 def test_job_run_success(monkeypatch):

--- a/praetorian_cli/sdk/test/ui/test_aegis_job.py
+++ b/praetorian_cli/sdk/test/ui/test_aegis_job.py
@@ -4,7 +4,7 @@ import pytest
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 from praetorian_cli.ui.aegis.commands.job import handle_job
-from praetorian_cli.ui.aegis.commands.job_helpers import CapabilityCompleter
+from praetorian_cli.ui.aegis.commands.job_helpers import CapabilityCompleter, extract_target_type
 from rich.prompt import Confirm
 from praetorian_cli.sdk.test.ui_mocks import MockMenuBase, MockSDK, MockAgent
 
@@ -49,6 +49,11 @@ def test_capability_completer_accepts_list_target():
     assert len(completions) == 1
     assert completions[0].text == 'linux-enum-linpeas'
     assert '[asset]' in str(completions[0].display_meta)
+
+
+def test_extract_target_type_normalizes_empty_and_non_string_lists():
+    assert extract_target_type({'target': []}) == 'asset'
+    assert extract_target_type({'target': [123]}) == '123'
 
 
 def test_job_run_success(monkeypatch):

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -15,7 +15,15 @@ from ..constants import DEFAULT_COLORS
 def extract_target_type(capability_info: dict) -> str:
     """Extract the target type from capability info, handling list or string values."""
     target_raw = capability_info.get('target', 'asset')
-    return (target_raw[0] if isinstance(target_raw, list) and target_raw else str(target_raw)).lower()
+
+    if isinstance(target_raw, str):
+        return target_raw.lower()
+
+    if isinstance(target_raw, list):
+        normalized = [str(item).lower() for item in target_raw]
+        return normalized[0] if normalized else 'asset'
+
+    return str(target_raw).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/praetorian_cli/ui/aegis/commands/job_helpers.py
+++ b/praetorian_cli/ui/aegis/commands/job_helpers.py
@@ -53,10 +53,7 @@ class CapabilityCompleter(Completer):
         for cap in self.capabilities:
             name = cap.get('name', '')
             name_lower = name.lower()
-            target = cap.get('target', 'asset')
-            if isinstance(target, list):
-                target = target[0] if target else 'asset'
-            target = str(target).lower()
+            target = extract_target_type(cap)
             description = cap.get('description', '') or ''
             parsed = _parse_capability_name(name)
             category = parsed.get('category', '')


### PR DESCRIPTION
## Summary
- reuse the shared target normalization helper in the Aegis job capability completer
- prevent prompt-toolkit completion crashes when capability targets are returned as lists
- add a regression test covering list-based target metadata in the completer

## Testing
- python3 -m pytest praetorian_cli/sdk/test/ui/test_aegis_job.py -q
- python3 -m pytest praetorian_cli/sdk/test/ui/test_aegis_schedule.py -q