### PR TITLE
fix(credential): send Resolution to broker on Get (PS-1019)

### DIFF
--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -4,7 +4,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import error, print_json
 
 
 @chariot.group()
@@ -259,31 +259,51 @@ def configuration(chariot, key):
 
 @get.command()
 @cli_handler
-@click.argument('credential_id', required=True)
+@click.argument('credential_id', required=False, default='')
 @click.option('--category', default='env-integration', help='The category of the credential (e.g., integration, cloud)')
 @click.option('--type', default='default', help='The type of credential (e.g., aws, gcp, azure, static, ssh_key, json)')
 @click.option('--format', default='token', help='The format of the credential response')
+@click.option('--resolution',
+              type=click.Choice(['by-target', 'from-parent', 'global'], case_sensitive=False),
+              default='by-target',
+              show_default=True,
+              help='How the broker should locate the credential. '
+                   'by-target: use the supplied CREDENTIAL_ID as-is. '
+                   'from-parent: walk DISCOVERED ancestors of --resource-key to find one with a matching credential. '
+                   'global: platform-wide singleton credential identified by --type (CREDENTIAL_ID ignored).')
+@click.option('--resource-key', default=None,
+              help='Asset/resource key to scope the lookup. Required when --resolution=from-parent.')
 @click.option('--parameters', nargs=2, multiple=True, help='Additional parameters, as --parameters key value')
-def credential(chariot, credential_id, category, type, format, parameters):
+def credential(chariot, credential_id, category, type, format, resolution, resource_key, parameters):
     """ Get a specific credential
 
     Retrieve a specific credential using the credential broker.
 
     \b
     Argument:
-        - CREDENTIAL_ID: the ID of the credential to retrieve
+        - CREDENTIAL_ID: the ID of the credential to retrieve. Required for
+          --resolution=by-target; optional for from-parent; ignored for global.
 
     \b
     Example usages:
         - guard get credential aws-prod --category integration --type aws --format json
         - guard get credential ssh-key-1 --category cloud --type ssh_key --format pem
+        - guard get credential --resolution global --type shodan
+        - guard get credential --resolution from-parent --resource-key '#asset#example.com#1.2.3.4' --type aws
     """
-    
+    if resolution == 'by-target' and not credential_id:
+        error('CREDENTIAL_ID is required when --resolution=by-target.')
+    if resolution == 'from-parent' and not resource_key:
+        error('--resource-key is required when --resolution=from-parent.')
+
     params = {}
     if parameters:
         params = {key: value for key, value in parameters}
-    
-    result = chariot.credentials.get(credential_id, category, type, [format], **params)
+
+    result = chariot.credentials.get(
+        credential_id, category, type, [format],
+        resolution=resolution, resource_key=resource_key, **params,
+    )
     output = chariot.credentials.format_output(result)
     click.echo(output)
 

--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -264,13 +264,12 @@ def configuration(chariot, key):
 @click.option('--type', default='default', help='The type of credential (e.g., aws, gcp, azure, static, ssh_key, json)')
 @click.option('--format', default='token', help='The format of the credential response')
 @click.option('--resolution',
-              type=click.Choice(['by-target', 'from-parent', 'global'], case_sensitive=False),
+              type=click.Choice(['by-target', 'from-parent'], case_sensitive=False),
               default='by-target',
               show_default=True,
               help='How the broker should locate the credential. '
                    'by-target: use the supplied CREDENTIAL_ID as-is. '
-                   'from-parent: walk DISCOVERED ancestors of --resource-key to find one with a matching credential. '
-                   'global: platform-wide singleton credential identified by --type (CREDENTIAL_ID ignored).')
+                   'from-parent: walk DISCOVERED ancestors of --resource-key to find one with a matching credential.')
 @click.option('--resource-key', default=None,
               help='Asset/resource key to scope the lookup. Required when --resolution=from-parent.')
 @click.option('--parameters', nargs=2, multiple=True, help='Additional parameters, as --parameters key value')
@@ -282,13 +281,12 @@ def credential(chariot, credential_id, category, type, format, resolution, resou
     \b
     Argument:
         - CREDENTIAL_ID: the ID of the credential to retrieve. Required for
-          --resolution=by-target; optional for from-parent; ignored for global.
+          --resolution=by-target; optional for from-parent.
 
     \b
     Example usages:
         - guard get credential aws-prod --category integration --type aws --format json
         - guard get credential ssh-key-1 --category cloud --type ssh_key --format pem
-        - guard get credential --resolution global --type shodan
         - guard get credential --resolution from-parent --resource-key '#asset#example.com#1.2.3.4' --type aws
     """
     if resolution == 'by-target' and not credential_id:

--- a/praetorian_cli/sdk/entities/credentials.py
+++ b/praetorian_cli/sdk/entities/credentials.py
@@ -72,11 +72,14 @@ class Credentials:
         """
         return self.api.search.by_key_prefix('#credential', offset=offset, pages=pages)
 
-    def get(self, credential_id, category, type, format, **parameters):
+    def get(self, credential_id, category, type, format, resolution='by-target',
+            resource_key=None, **parameters):
         """
         Get a specific credential using the credential broker.
 
-        :param credential_id: The ID of the credential to retrieve
+        :param credential_id: The ID of the credential to retrieve. Required for
+            resolution='by-target'; ignored by the broker for 'global' (synthesized
+            from type); optional for 'from-parent' (broker walks the graph).
         :type credential_id: str
         :param category: The category of the credential ('integration', 'cloud', 'env-integration')
         :type category: str
@@ -84,6 +87,14 @@ class Credentials:
         :type type: str
         :param format: The format of the credential response ('token', 'file', 'env')
         :type format: str or list
+        :param resolution: How the broker should locate the credential. One of
+            'by-target' (use credential_id as-is; default), 'from-parent' (walk
+            DISCOVERED ancestors of resource_key), or 'global' (platform-wide
+            singleton keyed by type).
+        :type resolution: str
+        :param resource_key: Asset/resource key the credential is scoped to.
+            Required when resolution='from-parent'.
+        :type resource_key: str or None
         :param parameters: Additional parameters required for the credential request (e.g., region, role_arn)
         :type parameters: dict
         :return: The processed credential response based on the requested format
@@ -101,8 +112,11 @@ class Credentials:
             'Category': category,
             'Type': type,
             'Format': broker_format,
-            'Parameters': parameters
+            'Resolution': resolution,
+            'Parameters': parameters,
         }
+        if resource_key:
+            request['ResourceKey'] = resource_key
         response = self.api.post('broker', request)
         return self._process_credential_output(response, format)
 

--- a/praetorian_cli/sdk/entities/credentials.py
+++ b/praetorian_cli/sdk/entities/credentials.py
@@ -78,8 +78,8 @@ class Credentials:
         Get a specific credential using the credential broker.
 
         :param credential_id: The ID of the credential to retrieve. Required for
-            resolution='by-target'; ignored by the broker for 'global' (synthesized
-            from type); optional for 'from-parent' (broker walks the graph).
+            resolution='by-target'; optional for 'from-parent' (broker walks the
+            graph if empty).
         :type credential_id: str
         :param category: The category of the credential ('integration', 'cloud', 'env-integration')
         :type category: str
@@ -88,9 +88,8 @@ class Credentials:
         :param format: The format of the credential response ('token', 'file', 'env')
         :type format: str or list
         :param resolution: How the broker should locate the credential. One of
-            'by-target' (use credential_id as-is; default), 'from-parent' (walk
-            DISCOVERED ancestors of resource_key), or 'global' (platform-wide
-            singleton keyed by type).
+            'by-target' (use credential_id as-is; default) or 'from-parent'
+            (walk DISCOVERED ancestors of resource_key).
         :type resolution: str
         :param resource_key: Asset/resource key the credential is scoped to.
             Required when resolution='from-parent'.

--- a/praetorian_cli/sdk/test/test_credentials.py
+++ b/praetorian_cli/sdk/test/test_credentials.py
@@ -129,26 +129,6 @@ class TestCredentialsGet:
             'ResourceKey': '#asset#example.com#1.2.3.4',
         })
 
-    def test_get_with_global_resolution_omits_resource_key(self):
-        """global: broker synthesizes CredentialID from Type — ResourceKey is
-        not used, and the SDK should not include it."""
-        api = MagicMock()
-        api.post.return_value = {'ok': True}
-        creds = Credentials(api=api)
-
-        creds.get(
-            credential_id='',
-            category='env-integration',
-            type='shodan',
-            format=['token'],
-            resolution='global',
-        )
-
-        sent = api.post.call_args.args[1]
-        assert sent['Resolution'] == 'global'
-        assert sent['Type'] == 'shodan'
-        assert 'ResourceKey' not in sent
-
 
 class TestCredentialsDelete:
     def test_delete_builds_broker_request(self):
@@ -406,18 +386,6 @@ class TestGetCredentialCLI:
             '', 'env-integration', 'aws', ['token'],
             resolution='from-parent',
             resource_key='#asset#example.com#1.2.3.4',
-        )
-
-    def test_global_resolution_does_not_require_credential_id(self, runner, fake_sdk):
-        result = _invoke(runner, fake_sdk, [
-            'get', 'credential',
-            '--resolution', 'global',
-            '--type', 'shodan',
-        ])
-        assert result.exit_code == 0, result.output
-        fake_sdk.credentials.get.assert_called_once_with(
-            '', 'env-integration', 'shodan', ['token'],
-            resolution='global', resource_key=None,
         )
 
     def test_by_target_requires_credential_id(self, runner, fake_sdk):

--- a/praetorian_cli/sdk/test/test_credentials.py
+++ b/praetorian_cli/sdk/test/test_credentials.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 # Click commands on the `chariot` group via decorators at import time.
 import praetorian_cli.handlers.add  # noqa: F401
 import praetorian_cli.handlers.delete  # noqa: F401
+import praetorian_cli.handlers.get  # noqa: F401
 import praetorian_cli.handlers.update  # noqa: F401
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.sdk.entities.assets import Assets
@@ -44,6 +45,109 @@ class TestCredentialsAdd:
                 'label': 'Prod token',
             },
         })
+
+
+class TestCredentialsGet:
+    def test_get_builds_broker_request_with_resolution_by_target(self):
+        """The broker rejects Get requests without Resolution (PR #5457). The
+        CLI always passes an explicit credential_id, so Resolution must be
+        'by-target' — anything else either ignores the id (global) or requires
+        a ResourceKey the CLI doesn't have (from-parent)."""
+        api = MagicMock()
+        api.post.return_value = {'credentialValue': {'token': 'abc'}}
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='e699e73e-e371-4117-9192-e32147dfe98c',
+            category='env-integration',
+            type='aws',
+            format=['token'],
+            accountId='123456789012',
+        )
+
+        api.post.assert_called_once_with('broker', {
+            'Operation': 'get',
+            'CredentialID': 'e699e73e-e371-4117-9192-e32147dfe98c',
+            'Category': 'env-integration',
+            'Type': 'aws',
+            'Format': ['token'],
+            'Resolution': 'by-target',
+            'Parameters': {'accountId': '123456789012'},
+        })
+
+    def test_get_rewrites_credential_process_format_to_token(self):
+        """`credential-process` is a client-side format — the broker sees
+        'token' and the SDK assembles the AWS credential_process JSON from the
+        response."""
+        api = MagicMock()
+        api.post.return_value = {
+            'credentialValue': {
+                'accessKeyId': 'ASIA...',
+                'secretAccessKey': 'secret',
+                'sessionToken': 'session',
+                'expiration': '2026-04-10T12:00:00Z',
+            }
+        }
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='abc-123',
+            category='env-integration',
+            type='aws',
+            format=['credential-process'],
+        )
+
+        sent = api.post.call_args.args[1]
+        assert sent['Format'] == ['token']
+        assert sent['Resolution'] == 'by-target'
+
+    def test_get_with_from_parent_sends_resource_key(self):
+        """from-parent: broker walks DISCOVERED ancestors of ResourceKey for a
+        matching credential. ResourceKey is required, CredentialID may be
+        empty."""
+        api = MagicMock()
+        api.post.return_value = {'ok': True}
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='',
+            category='env-integration',
+            type='aws',
+            format=['token'],
+            resolution='from-parent',
+            resource_key='#asset#example.com#1.2.3.4',
+        )
+
+        api.post.assert_called_once_with('broker', {
+            'Operation': 'get',
+            'CredentialID': '',
+            'Category': 'env-integration',
+            'Type': 'aws',
+            'Format': ['token'],
+            'Resolution': 'from-parent',
+            'Parameters': {},
+            'ResourceKey': '#asset#example.com#1.2.3.4',
+        })
+
+    def test_get_with_global_resolution_omits_resource_key(self):
+        """global: broker synthesizes CredentialID from Type — ResourceKey is
+        not used, and the SDK should not include it."""
+        api = MagicMock()
+        api.post.return_value = {'ok': True}
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='',
+            category='env-integration',
+            type='shodan',
+            format=['token'],
+            resolution='global',
+        )
+
+        sent = api.post.call_args.args[1]
+        assert sent['Resolution'] == 'global'
+        assert sent['Type'] == 'shodan'
+        assert 'ResourceKey' not in sent
 
 
 class TestCredentialsDelete:
@@ -105,6 +209,8 @@ def fake_sdk():
     sdk = MagicMock()
     sdk.credentials.add.return_value = {'ok': True}
     sdk.credentials.delete.return_value = {'ok': True}
+    sdk.credentials.get.return_value = {'credentialValue': {'token': 'abc'}}
+    sdk.credentials.format_output.side_effect = lambda r: str(r)
     sdk.assets.update.return_value = {'ok': True}
     return sdk
 
@@ -249,6 +355,88 @@ class TestDeleteCredential:
             '#webapplication#https://app.example.com',
             'web-auth',
         )
+
+
+class TestGetCredentialCLI:
+    """`guard get credential ...` — verifies the --resolution flag and its
+    interaction with CREDENTIAL_ID / --resource-key."""
+
+    def test_default_resolution_is_by_target(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential', 'cred-abc-123',
+            '--category', 'env-integration',
+            '--type', 'aws',
+        ])
+        assert result.exit_code == 0, result.output
+        fake_sdk.credentials.get.assert_called_once_with(
+            'cred-abc-123', 'env-integration', 'aws', ['token'],
+            resolution='by-target', resource_key=None,
+        )
+
+    def test_explicit_by_target_passes_through(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential', 'cred-abc-123',
+            '--resolution', 'by-target',
+            '--type', 'aws',
+        ])
+        assert result.exit_code == 0, result.output
+        kwargs = fake_sdk.credentials.get.call_args.kwargs
+        assert kwargs['resolution'] == 'by-target'
+        assert kwargs['resource_key'] is None
+
+    def test_from_parent_requires_resource_key(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'from-parent',
+            '--type', 'aws',
+        ])
+        assert result.exit_code != 0
+        assert '--resource-key' in result.output
+        fake_sdk.credentials.get.assert_not_called()
+
+    def test_from_parent_with_resource_key(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'from-parent',
+            '--resource-key', '#asset#example.com#1.2.3.4',
+            '--type', 'aws',
+        ])
+        assert result.exit_code == 0, result.output
+        fake_sdk.credentials.get.assert_called_once_with(
+            '', 'env-integration', 'aws', ['token'],
+            resolution='from-parent',
+            resource_key='#asset#example.com#1.2.3.4',
+        )
+
+    def test_global_resolution_does_not_require_credential_id(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'global',
+            '--type', 'shodan',
+        ])
+        assert result.exit_code == 0, result.output
+        fake_sdk.credentials.get.assert_called_once_with(
+            '', 'env-integration', 'shodan', ['token'],
+            resolution='global', resource_key=None,
+        )
+
+    def test_by_target_requires_credential_id(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'by-target',
+            '--type', 'aws',
+        ])
+        assert result.exit_code != 0
+        assert 'CREDENTIAL_ID' in result.output
+        fake_sdk.credentials.get.assert_not_called()
+
+    def test_invalid_resolution_value_is_rejected(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential', 'cred-abc-123',
+            '--resolution', 'nope',
+        ])
+        assert result.exit_code != 0
+        assert 'nope' in result.output or "'by-target'" in result.output
 
 
 class TestUpdateAssetSecret:


### PR DESCRIPTION
## Summary

- `guard get credential <uuid>` and `guard access aws` have been failing with a 500 since [guard#5457](https://github.com/praetorian-inc/guard/pull/5457) made `Resolution` mandatory on broker Get requests. This adds the field (default `by-target`) so existing flows work again.
- Expose `--resolution` as a `click.Choice` flag with `by-target` / `from-parent`, plus `--resource-key` for the `from-parent` path, so users can pick the broker's lookup strategy explicitly.
- SDK signature gains `resolution` and `resource_key` kwargs (back-compatible — defaults preserve the prior call shape modulo the new mandatory field).

Linear: [PS-1019](https://linear.app/praetorianlabs/issue/PS-1019/guard-get-credential-fails-with-500-cli-missing-required-resolution)

## Background

The broker's `validateGetRequest` (`guard/backend/cmd/async/access_broker/handler/handler.go:195-197`) now rejects requests without a Resolution. The two values exposed in the CLI:

- **by-target** — caller passes a known credential ID (UUID). Broker uses it as-is. This matches the CLI's existing semantics.
- **from-parent** — broker walks `DISCOVERED` ancestors of `ResourceKey` for a matching credential.

The broker also supports a `global` mode, but it is not exposed in the CLI because no current flow returns a usable credential through it.

## Test plan

- [x] `uv run pytest praetorian_cli/sdk/test/test_credentials.py` — 23 passed (7 new)
- [x] `uv run pytest praetorian_cli/sdk/test/test_credentials.py praetorian_cli/sdk/test/test_credential_process.py praetorian_cli/sdk/test/test_access_aws.py` — 43 passed
- [ ] Manual: `guard --account <acct> get credential <uuid> --category env-integration --type aws` against a deployed stack
- [ ] Manual: `guard access aws` against a deployed stack
- [ ] Manual: `guard get credential --resolution from-parent --resource-key '#asset#...' --type aws` returns the inherited credential