### PR TITLE
Rename cato → probus in tool registry (blocked on praetorian-inc/cato repo rename)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-eng-3042-guard-tool-args.md
+++ b/docs/superpowers/plans/2026-04-17-eng-3042-guard-tool-args.md
@@ -1126,7 +1126,7 @@ In `praetorian_cli/runners/local.py`, directly above the `TOOL_PLUGINS = {` line
 # - julius/nerva/nero: use -t <target>; unverified against each binary's --help
 # - titus/trajan/vespasian/constantine/caligula: `scan <target>` — unverified
 # - augustus/gato: `scan -t <target>` / `enumerate -t <target>` — unverified
-# - cato/florian/hadrian: `scan -u <target>` — unverified
+# - probus/florian/hadrian: `scan -u <target>` — unverified
 # Users can always override via `guard run tool <tool> <target> -- <raw args>`.
 ```
 

--- a/docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md
+++ b/docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md
@@ -115,7 +115,7 @@ Verify each plugin whose current `_build()` uses `-t`, `-u`, or a `scan` sub-com
 | trajan | `scan <target>` | verify | — |
 | augustus | `scan -t <target>` | verify | fix if wrong |
 | gato | `enumerate -t <target>` | verify | fix if wrong |
-| cato/florian/hadrian | `scan -u <target>` | verify | fix if wrong |
+| probus/florian/hadrian | `scan -u <target>` | verify | fix if wrong |
 | vespasian/constantine/caligula | `scan <target>` | verify | fix if wrong |
 
 Audits that fail become small follow-up fixes within the same PR; if a binary isn't readily installable in the sandbox, document it in the plugin as *"verified against vX.Y help"* or flag it for a separate ticket.

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -19,7 +19,7 @@ INSTALLABLE_TOOLS = {
     'augustus':     {'repo': 'praetorian-inc/augustus',     'description': 'LLM security testing (190+ probes)'},
     'titus':       {'repo': 'praetorian-inc/titus',       'description': 'Secrets scanner (487 rules)'},
     'trajan':      {'repo': 'praetorian-inc/trajan',      'description': 'CI/CD vulnerability scanner'},
-    'cato':        {'repo': 'praetorian-inc/cato',        'description': 'Injection scanner (SQLi, SSRF, SSTI, XXE)'},
+    'probus':      {'repo': 'praetorian-inc/probus',      'description': 'Injection scanner (SQLi, SSRF, SSTI, XXE)'},
     'nerva':       {'repo': 'praetorian-inc/nerva',       'description': 'Service fingerprinting (120+ protocols)'},
     'vespasian':   {'repo': 'praetorian-inc/vespasian',   'description': 'API discovery from traffic'},
     'nuclei':      {'repo': 'praetorian-inc/nuclei',      'description': 'Vulnerability scanner templates'},
@@ -356,7 +356,7 @@ class ScanTargetPlugin(ToolPlugin):
 # - julius/nerva/nero: use -t <target>; unverified against each binary's --help
 # - titus/trajan/vespasian/constantine/caligula: `scan <target>` — unverified
 # - augustus/gato: `scan -t <target>` / `enumerate -t <target>` — unverified
-# - cato/florian/hadrian: `scan -u <target>` — unverified
+# - probus/florian/hadrian: `scan -u <target>` — unverified
 # Users can always override via `guard run tool <tool> <target> -- <raw args>`.
 TOOL_PLUGINS = {
     'brutus':      BrutusPlugin(),
@@ -367,7 +367,7 @@ TOOL_PLUGINS = {
     'augustus':     AugustusPlugin(),
     'nerva':       NervaPlugin(),
     'gato':        GatoPlugin(),
-    'cato':        UrlTargetPlugin(),
+    'probus':      UrlTargetPlugin(),
     'vespasian':   ScanTargetPlugin(),
     'constantine': ScanTargetPlugin(),
     'florian':     UrlTargetPlugin(),

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -41,7 +41,7 @@ CONSOLE_COMMANDS = [
     'scan', 'tag',
     'run', 'status', 'download', 'install', 'installed',
     'asset-analyzer', 'brutus', 'julius', 'augustus', 'aurelius',
-    'trajan', 'cato', 'priscus', 'seneca', 'titus',
+    'trajan', 'probus', 'priscus', 'seneca', 'titus',
     'nuclei', 'portscan', 'subdomain', 'crawler', 'capabilities',
     'evidence', 'report',
     'ask', 'marcus',


### PR DESCRIPTION
## Summary

Updates praetorian-cli's tool registry to use `probus` instead of `cato`. The injection scanner `cato` has been renamed to `probus` — see [LAB-3327](https://linear.app/praetorianlabs/issue/LAB-3327) and the upstream rename PR [praetorian-inc/cato#86](https://github.com/praetorian-inc/cato/pull/86).

## Changes

- `praetorian_cli/runners/local.py:22` — `TOOLS` dict: `'cato'` key → `'probus'`; repo path `praetorian-inc/cato` → `praetorian-inc/probus`
- `praetorian_cli/runners/local.py:359` — comment `cato/florian/hadrian` → `probus/florian/hadrian`
- `praetorian_cli/runners/local.py:370` — `TOOL_PLUGINS` map: `'cato'` key → `'probus'`
- `praetorian_cli/ui/console/console.py:44` — Roman-name banner list: `'cato'` → `'probus'`
- `docs/superpowers/specs/2026-04-17-eng-3042-guard-tool-args-design.md:118` — design-spec table row
- `docs/superpowers/plans/2026-04-17-eng-3042-guard-tool-args.md:1129` — plan comment

4 files, +6 / −6 lines.

## Blocked on

The upstream `praetorian-inc/cato` → `praetorian-inc/probus` GitHub repo rename. GitHub's URL redirect would technically allow the old `praetorian-inc/cato` path to keep working, but this PR removes the indirection for clarity. Merge order:

1. praetorian-inc/cato#86 merges
2. GitHub admin renames `praetorian-inc/cato` → `praetorian-inc/probus`
3. This PR + two parallel ones against `praetorian-inc/capabilities` and `praetorian-inc/praetorian-claude` get marked ready and merged

Draft until that sequence is unblocked.