### PR TITLE
feat(modules): Metasploit-style module management system (10T-277)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include praetorian_cli/sdk/test/pytest.ini
 include modules/registry.json
+include praetorian_cli/modules/capabilities_snapshot.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include praetorian_cli/sdk/test/pytest.ini 
+include praetorian_cli/sdk/test/pytest.ini
+include modules/registry.json

--- a/docs/specs/2026-05-19-module-system-design.md
+++ b/docs/specs/2026-05-19-module-system-design.md
@@ -1,0 +1,239 @@
+# Guard CLI Module System
+
+**Date:** 2026-05-19
+**Linear:** 10T-277
+**Author:** AJ Hammond
+**Origin:** Carter Ross suggestion — Metasploit-style module management for the Guard CLI
+
+## Problem
+
+The Guard CLI already supports installing and running 17 security tools locally (`guard run install`, `guard run tool`), but:
+
+1. **Tool definitions are hardcoded** in `runners/local.py` (`INSTALLABLE_TOOLS`) and `handlers/run.py` (`TOOL_ALIASES`, `FRIENDLY_NAMES`). Adding a tool requires a CLI release.
+2. **No discovery UX.** Users can't search, filter, or inspect tools the way Metasploit lets you browse modules. `guard run list` exists but is flat and sparse.
+3. **No version tracking or updates.** Users can install but not check versions, update individual tools, or see changelogs.
+4. **Claude integration is ad-hoc.** Claude skills have no structured way to discover available tools, check install status, or invoke them. The chariot-mcp server exists but has no module management tools.
+
+## Goals
+
+- New tools can be added by editing a registry file — no CLI release required.
+- Users get msf-style `search`, `info`, `options`, `update` commands in both CLI and console.
+- Claude (via MCP or structured CLI output) can list, install, and run any module programmatically.
+- Backward compatible: `guard run install/tool` continues to work.
+
+## Non-Goals
+
+- Complex dependency management between tools.
+- Module categories as a deep hierarchy (msf's exploit/auxiliary/post tree).
+- Automatic execution on install (no post-install hooks).
+- Workspaces or per-engagement module configs (future iteration).
+
+## Design
+
+### 1. Registry File
+
+A single `modules/registry.json` in the praetorian-cli repo serves as the source of truth for all installable tools. The CLI fetches and caches it locally.
+
+**Schema:**
+
+```json
+{
+  "version": 1,
+  "modules": {
+    "brutus": {
+      "repo": "praetorian-inc/brutus",
+      "description": "Credential attacks across 20+ protocols (SSH, RDP, FTP, SMB, etc.)",
+      "category": "credential",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "protocol": {"type": "string", "description": "Target protocol", "required": false},
+        "usernames": {"type": "string", "description": "Username file or comma-separated list", "required": false},
+        "passwords": {"type": "string", "description": "Password file or comma-separated list", "required": false}
+      },
+      "args_template": ["--target", "{target}"],
+      "tags": ["brute-force", "password", "network"]
+    }
+  }
+}
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `repo` | yes | GitHub `owner/repo` for release downloads |
+| `description` | yes | One-line description |
+| `category` | yes | One of: `scanner`, `credential`, `recon`, `cloud`, `cicd`, `ai`, `supply-chain`, `api` |
+| `author` | yes | Tool author/team |
+| `target_type` | yes | Guard entity type the tool targets (`asset`, `port`, `webpage`, `repository`, etc.) |
+| `options` | no | Configurable parameters with type/description/required |
+| `args_template` | no | Default argument pattern for local execution. `{target}` is replaced at runtime. |
+| `tags` | no | Searchable keywords |
+| `binary_pattern` | no | Override for GitHub release asset pattern (default: `{name}-{os}-{arch}*`) |
+| `post_install_message` | no | Shown after successful install (e.g., "Requires API key in BRUTUS_TOKEN") |
+
+**Registry lifecycle:**
+
+1. CLI checks `~/.praetorian/registry.json` on module commands.
+2. If missing or stale (>24h), fetches from GitHub raw URL: `https://raw.githubusercontent.com/praetorian-inc/praetorian-cli/main/modules/registry.json`.
+3. Falls back to bundled copy (shipped with CLI package) if fetch fails.
+4. `guard module update --registry` forces a refresh.
+
+### 2. Module Commands (CLI)
+
+New `guard module` subcommand group. Existing `guard run install/installed` continue to work as aliases.
+
+```
+guard module search [query]        # Search modules by name, category, tag, description
+guard module info <name>           # Full module details: description, options, version, install status
+guard module options <name>        # Show configurable options for a module
+guard module install <name|all>    # Install module binary from GitHub releases
+guard module uninstall <name>      # Remove installed binary
+guard module update [name|all]     # Update installed modules to latest release
+guard module installed             # List installed modules with versions
+guard module list                  # List all available modules (alias for search with no query)
+```
+
+All commands support `--json` for structured output.
+
+**`guard module search` examples:**
+
+```
+$ guard module search credential
+NAME        CATEGORY    INSTALLED   DESCRIPTION
+brutus      credential  v1.2.3      Credential attacks across 20+ protocols
+nero        credential  —           Default credential scanner
+
+$ guard module search --category scanner --json
+[{"name": "nuclei", "category": "scanner", "installed": true, "version": "3.1.0", ...}]
+```
+
+**`guard module info` example:**
+
+```
+$ guard module info brutus
+
+  Name:        brutus
+  Category:    credential
+  Author:      Praetorian
+  Repository:  praetorian-inc/brutus
+  Installed:   v1.2.3 (~/.praetorian/bin/brutus)
+  Target:      asset (host:port)
+  Description: Credential attacks across 20+ protocols (SSH, RDP, FTP, SMB, etc.)
+  Tags:        brute-force, password, network
+
+  Options:
+    --protocol    string   Target protocol (auto-detected from port)
+    --usernames   string   Username file or comma-separated list
+    --passwords   string   Password file or comma-separated list
+
+  Usage:
+    guard run tool brutus 10.0.1.5:22
+    guard run tool brutus 10.0.1.5:22 --protocol ssh -U users.txt
+```
+
+**`guard module update` behavior:**
+
+1. Fetches latest GitHub release tag for the tool's repo.
+2. Compares against installed version (stored in `~/.praetorian/versions.json`).
+3. If newer, downloads and replaces. Shows before/after versions.
+
+### 3. Console Commands
+
+The interactive console (`guard console`) gets matching commands:
+
+| Console Command | Behavior |
+|----------------|----------|
+| `search [query]` | Search modules (replaces current capabilities-only search) |
+| `info <name>` | Show module details panel |
+| `options [name]` | Show options for active or named module |
+| `update [name\|all]` | Update installed modules |
+| `install <name\|all>` | Install module (existing, unchanged) |
+| `installed` | List installed (existing, unchanged) |
+
+`search` in the console merges module registry results with backend capabilities so users see the full picture.
+
+### 4. Version Tracking
+
+Install and update operations write to `~/.praetorian/versions.json`:
+
+```json
+{
+  "brutus": {"version": "v1.2.3", "installed_at": "2026-05-19T12:00:00Z", "path": "~/.praetorian/bin/brutus"},
+  "nuclei": {"version": "v3.1.0", "installed_at": "2026-05-18T09:30:00Z", "path": "~/.praetorian/bin/nuclei"}
+}
+```
+
+Version is extracted from the GitHub release tag at install time via `gh release view --repo <repo> --json tagName`.
+
+### 5. Claude Integration
+
+#### Structured CLI Output
+
+All `guard module` commands support `--json`. This is sufficient for Claude Code skills that shell out to the CLI.
+
+Example Claude skill flow:
+```
+1. guard module search --json              → discover available tools
+2. guard module info brutus --json         → check options and install status
+3. guard module install brutus --json      → install if needed
+4. guard run tool brutus 10.0.1.5:22 --json → execute and get structured results
+```
+
+#### MCP Tools
+
+Add to the existing `chariot-mcp` server (or a new lightweight `guard-mcp` that wraps the CLI):
+
+| MCP Tool | Description |
+|----------|-------------|
+| `list_modules` | List all modules with install status. Params: `category`, `query` (optional filters) |
+| `module_info` | Get full details for a module. Params: `name` (required) |
+| `install_module` | Install a module. Params: `name` (required), `force` (optional) |
+| `run_module` | Execute a module against a target. Params: `name`, `target` (required), `options` (optional dict) |
+
+MCP tools internally call the same Python functions as the CLI, not subprocess.
+
+### 6. Tool Plugin Migration
+
+The existing `ToolPlugin` classes in `runners/local.py` (BrutusPlugin, NucleiPlugin, etc.) remain for now — they handle argument building nuances that can't be captured in a simple `args_template`.
+
+Migration path:
+1. Registry `args_template` handles simple tools (most of them).
+2. Custom plugins override `args_template` when needed (Brutus protocol detection, etc.).
+3. Plugin code stays in `runners/local.py` but is loaded dynamically by name from the registry rather than a hardcoded dict.
+
+The `TOOL_PLUGINS` dict becomes auto-built: registry entry has plugin? Use it. Has `args_template`? Generate a plugin. Neither? Use default passthrough.
+
+### 7. Backward Compatibility
+
+| Old Command | New Canonical | Behavior |
+|-------------|---------------|----------|
+| `guard run install <name>` | `guard module install <name>` | Alias, both work |
+| `guard run installed` | `guard module installed` | Alias, both work |
+| `guard run list` | `guard module list` | Alias, both work |
+| `guard run tool <name> <target>` | `guard run tool <name> <target>` | Unchanged |
+| Console `install`, `installed` | Console `install`, `installed` | Unchanged |
+
+`INSTALLABLE_TOOLS` and `TOOL_ALIASES` dicts are replaced by functions that read from the cached registry. Import sites that reference these dicts get the same interface (dict-like access) via a lazy-loading wrapper.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `modules/registry.json` | **New.** Module registry manifest. |
+| `praetorian_cli/registry.py` | **New.** Registry loader: fetch, cache, parse, lazy dict interface. |
+| `praetorian_cli/handlers/module.py` | **New.** `guard module` CLI subcommand group. |
+| `praetorian_cli/ui/console/commands/tools.py` | **Modified.** Add `search`, `info`, `options`, `update` console commands. Wire to registry. |
+| `praetorian_cli/runners/local.py` | **Modified.** `INSTALLABLE_TOOLS` becomes `get_installable_tools()` reading from registry. Version tracking on install. |
+| `praetorian_cli/handlers/run.py` | **Modified.** `TOOL_ALIASES`/`FRIENDLY_NAMES` read from registry. `install`/`installed` become aliases to `module` commands. |
+| `praetorian_cli/handlers/chariot.py` | **Modified.** Register `module` subcommand group. |
+
+## Testing
+
+- Unit tests for registry parsing, caching, and staleness logic.
+- Unit tests for `search` filtering (name, category, tag, description substring).
+- Integration test: `guard module install` + `guard module installed` + `guard module info` round-trip.
+- Console tests: `search`, `info`, `options` render correctly.
+- Backward compat: existing `guard run install`/`guard run list` still work.
+- Offline: CLI works with bundled registry when network fetch fails.

--- a/docs/superpowers/plans/2026-05-19-module-system.md
+++ b/docs/superpowers/plans/2026-05-19-module-system.md
@@ -1,0 +1,2047 @@
+# Guard CLI Module System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded tool definitions in the Guard CLI with a dynamic registry file, add msf-style `search`/`info`/`options`/`update` commands, version tracking, and MCP tools for Claude integration.
+
+**Architecture:** A JSON registry file (`modules/registry.json`) becomes the single source of truth for tool metadata. A new `registry.py` module handles fetching, caching (at `~/.praetorian/registry.json`), and serving this data through a dict-like interface. Existing `INSTALLABLE_TOOLS` and `TOOL_ALIASES` are replaced by functions reading from this registry. New `guard module` CLI commands and console commands expose search/info/update UX, all with `--json` support. MCP tools wrap the same Python functions.
+
+**Tech Stack:** Python 3.10+, Click 8.x (CLI framework), Rich (console rendering), prompt_toolkit (interactive console), mcp 1.12+ (MCP server)
+
+**Repo:** `praetorian-inc/praetorian-cli` at `/Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli/`
+**Branch:** `feat/module-system`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `modules/registry.json` | **New.** Source-of-truth module manifest. All 17 existing tools + metadata. |
+| `praetorian_cli/registry.py` | **New.** Fetch, cache, parse registry. Lazy dict interface replacing `INSTALLABLE_TOOLS`. Version tracking read/write. |
+| `praetorian_cli/handlers/module.py` | **New.** `guard module` Click subcommand group: search, info, options, install, uninstall, update, installed, list. |
+| `praetorian_cli/runners/local.py` | **Modified.** Remove hardcoded `INSTALLABLE_TOOLS` dict, replace with `get_installable_tools()` from registry. Add version recording on install. |
+| `praetorian_cli/handlers/run.py` | **Modified.** `TOOL_ALIASES`/`FRIENDLY_NAMES` read from registry. |
+| `praetorian_cli/main.py` | **Modified.** Import and register `module` handler. |
+| `praetorian_cli/ui/console/commands/tools.py` | **Modified.** Wire `search`, `info`, `update` console commands to registry. |
+| `praetorian_cli/ui/console/console.py` | **Modified.** Add `update`, `module` to `CONSOLE_COMMANDS` list and dispatch table. |
+| `praetorian_cli/sdk/mcp_server.py` | **Modified.** Add explicit module management MCP tools. |
+| `MANIFEST.in` | **Modified.** Include `modules/registry.json` in package. |
+| `praetorian_cli/sdk/test/test_registry.py` | **New.** Unit tests for registry module. |
+| `praetorian_cli/sdk/test/test_module_cli.py` | **New.** Unit tests for `guard module` CLI commands. |
+| `praetorian_cli/sdk/test/ui/test_console_modules.py` | **New.** Unit tests for console module commands. |
+
+---
+
+### Task 1: Create the Registry JSON File
+
+**Files:**
+- Create: `modules/registry.json`
+
+This is the source-of-truth manifest. Seed it with all 17 tools currently hardcoded in `runners/local.py` `INSTALLABLE_TOOLS` and the agent metadata from `handlers/run.py` `FRIENDLY_NAMES`.
+
+- [ ] **Step 1: Create registry.json with all existing tools**
+
+```json
+{
+  "version": 1,
+  "modules": {
+    "brutus": {
+      "repo": "praetorian-inc/brutus",
+      "description": "Credential attacks across 20+ protocols (SSH, RDP, FTP, SMB, etc.)",
+      "category": "credential",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "protocol": {"type": "string", "description": "Target protocol (auto-detected from port)", "required": false},
+        "usernames": {"type": "string", "description": "Username file or comma-separated list", "required": false},
+        "passwords": {"type": "string", "description": "Password file or comma-separated list", "required": false}
+      },
+      "args_template": ["--target", "{target}"],
+      "tags": ["brute-force", "password", "network"]
+    },
+    "julius": {
+      "repo": "praetorian-inc/julius",
+      "description": "LLM/AI service fingerprinting",
+      "category": "ai",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["llm", "ai", "fingerprint"]
+    },
+    "augustus": {
+      "repo": "praetorian-inc/augustus",
+      "description": "LLM jailbreak & prompt injection attacks (190+ probes)",
+      "category": "ai",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "-t", "{target}"],
+      "tags": ["llm", "ai", "jailbreak", "injection"]
+    },
+    "titus": {
+      "repo": "praetorian-inc/titus",
+      "description": "Secret scanning & credential leak detection (487 rules)",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "validation": {"type": "string", "description": "Enable secret validation (true/false)", "required": false}
+      },
+      "args_template": ["scan", "{target}"],
+      "tags": ["secrets", "credentials", "leak"]
+    },
+    "trajan": {
+      "repo": "praetorian-inc/trajan",
+      "description": "CI/CD pipeline security scanning",
+      "category": "cicd",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "token": {"type": "string", "description": "GitHub/GitLab token for API access", "required": false}
+      },
+      "args_template": ["scan", "{target}"],
+      "tags": ["cicd", "pipeline", "github", "gitlab"]
+    },
+    "cato": {
+      "repo": "praetorian-inc/cato",
+      "description": "Injection scanner (SQLi, SSRF, SSTI, XXE)",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["injection", "sqli", "ssrf", "ssti", "xxe"]
+    },
+    "nerva": {
+      "repo": "praetorian-inc/nerva",
+      "description": "Service fingerprinting (120+ protocols)",
+      "category": "recon",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["fingerprint", "service", "protocol"]
+    },
+    "vespasian": {
+      "repo": "praetorian-inc/vespasian",
+      "description": "API discovery from traffic",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["api", "discovery", "traffic"]
+    },
+    "nuclei": {
+      "repo": "praetorian-inc/nuclei",
+      "description": "Vulnerability scanner with template engine",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "templates": {"type": "string", "description": "Template directory or file", "required": false}
+      },
+      "args_template": ["-u", "{target}", "-jsonl"],
+      "tags": ["vulnerability", "templates", "cve"]
+    },
+    "gato": {
+      "repo": "praetorian-inc/gato",
+      "description": "GitHub Actions pipeline scanner",
+      "category": "cicd",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "token": {"type": "string", "description": "GitHub token", "required": false}
+      },
+      "args_template": ["enumerate", "-t", "{target}"],
+      "tags": ["github", "actions", "pipeline"]
+    },
+    "constantine": {
+      "repo": "praetorian-inc/constantine",
+      "description": "Repository security analysis",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["repository", "code", "security"]
+    },
+    "aurelian": {
+      "repo": "praetorian-inc/aurelian",
+      "description": "Cloud security reconnaissance (AWS/Azure/GCP)",
+      "category": "cloud",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["cloud", "aws", "azure", "gcp", "recon"]
+    },
+    "pius": {
+      "repo": "praetorian-inc/pius",
+      "description": "Organizational asset discovery",
+      "category": "recon",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["discovery", "org", "asset"]
+    },
+    "florian": {
+      "repo": "praetorian-inc/florian",
+      "description": "Authentication flow testing",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["auth", "authentication", "flow"]
+    },
+    "caligula": {
+      "repo": "praetorian-inc/caligula",
+      "description": "Supply chain security scanner",
+      "category": "supply-chain",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["supply-chain", "dependency", "sbom"]
+    },
+    "hadrian": {
+      "repo": "praetorian-inc/hadrian",
+      "description": "API security testing",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["api", "security", "testing"]
+    },
+    "nero": {
+      "repo": "praetorian-inc/nero",
+      "description": "Default credential scanner",
+      "category": "credential",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["default", "credentials", "scanner"]
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Update MANIFEST.in to include registry**
+
+In `MANIFEST.in`, add:
+```
+include modules/registry.json
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modules/registry.json MANIFEST.in
+git commit -m "feat(modules): add registry.json manifest with all 17 tools"
+```
+
+---
+
+### Task 2: Create the Registry Module (`registry.py`)
+
+**Files:**
+- Create: `praetorian_cli/sdk/test/test_registry.py`
+- Create: `praetorian_cli/registry.py`
+
+Core module: fetch, cache, parse registry.json. Provides `get_modules()`, `get_module(name)`, `search_modules(query, category)`, and version tracking via `~/.praetorian/versions.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `praetorian_cli/sdk/test/test_registry.py`:
+
+```python
+"""Unit tests for the module registry."""
+import json
+import os
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from praetorian_cli.registry import (
+    ModuleRegistry,
+    CACHE_PATH,
+    VERSIONS_PATH,
+    BUNDLED_REGISTRY_PATH,
+)
+
+
+SAMPLE_REGISTRY = {
+    "version": 1,
+    "modules": {
+        "brutus": {
+            "repo": "praetorian-inc/brutus",
+            "description": "Credential attacks across 20+ protocols",
+            "category": "credential",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {
+                "protocol": {"type": "string", "description": "Target protocol", "required": False},
+            },
+            "args_template": ["--target", "{target}"],
+            "tags": ["brute-force", "password"],
+        },
+        "nuclei": {
+            "repo": "praetorian-inc/nuclei",
+            "description": "Vulnerability scanner with template engine",
+            "category": "scanner",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {},
+            "args_template": ["-u", "{target}", "-jsonl"],
+            "tags": ["vulnerability", "cve"],
+        },
+        "julius": {
+            "repo": "praetorian-inc/julius",
+            "description": "LLM/AI service fingerprinting",
+            "category": "ai",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {},
+            "args_template": ["-t", "{target}"],
+            "tags": ["llm", "ai"],
+        },
+    },
+}
+
+
+@pytest.fixture
+def tmp_home(tmp_path, monkeypatch):
+    """Redirect registry cache and versions to a temp dir."""
+    cache = tmp_path / "registry.json"
+    versions = tmp_path / "versions.json"
+    monkeypatch.setattr("praetorian_cli.registry.CACHE_PATH", str(cache))
+    monkeypatch.setattr("praetorian_cli.registry.VERSIONS_PATH", str(versions))
+    return tmp_path
+
+
+@pytest.fixture
+def seeded_cache(tmp_home):
+    """Write SAMPLE_REGISTRY into the cache file."""
+    cache = tmp_home / "registry.json"
+    cache.write_text(json.dumps(SAMPLE_REGISTRY))
+    return tmp_home
+
+
+class TestRegistryLoading:
+    def test_loads_from_cache(self, seeded_cache):
+        reg = ModuleRegistry()
+        modules = reg.get_modules()
+        assert "brutus" in modules
+        assert "nuclei" in modules
+        assert modules["brutus"]["category"] == "credential"
+
+    def test_falls_back_to_bundled(self, tmp_home):
+        """When cache is missing, loads the bundled registry."""
+        reg = ModuleRegistry()
+        modules = reg.get_modules()
+        assert len(modules) > 0
+
+    def test_get_module_by_name(self, seeded_cache):
+        reg = ModuleRegistry()
+        mod = reg.get_module("brutus")
+        assert mod is not None
+        assert mod["repo"] == "praetorian-inc/brutus"
+
+    def test_get_module_unknown_returns_none(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg.get_module("nonexistent") is None
+
+    def test_get_module_case_insensitive(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg.get_module("BRUTUS") is not None
+        assert reg.get_module("Brutus") is not None
+
+
+class TestRegistrySearch:
+    def test_search_by_name(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("brut")
+        assert any(r["name"] == "brutus" for r in results)
+
+    def test_search_by_category(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules(category="credential")
+        names = [r["name"] for r in results]
+        assert "brutus" in names
+        assert "nuclei" not in names
+
+    def test_search_by_tag(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("llm")
+        assert any(r["name"] == "julius" for r in results)
+
+    def test_search_by_description(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("template")
+        assert any(r["name"] == "nuclei" for r in results)
+
+    def test_search_no_query_returns_all(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules()
+        assert len(results) == 3
+
+    def test_search_combined_query_and_category(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("brut", category="scanner")
+        assert len(results) == 0  # brutus is credential, not scanner
+
+
+class TestRegistryCacheStaleness:
+    def test_fresh_cache_is_not_stale(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg._is_cache_stale() is False
+
+    def test_old_cache_is_stale(self, seeded_cache):
+        cache = seeded_cache / "registry.json"
+        old_time = time.time() - 90000  # 25 hours ago
+        os.utime(str(cache), (old_time, old_time))
+        reg = ModuleRegistry()
+        assert reg._is_cache_stale() is True
+
+
+class TestVersionTracking:
+    def test_record_and_get_version(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.2.3", "/path/to/brutus")
+        info = reg.get_version("brutus")
+        assert info["version"] == "v1.2.3"
+        assert info["path"] == "/path/to/brutus"
+        assert "installed_at" in info
+
+    def test_get_version_uninstalled_returns_none(self, tmp_home):
+        reg = ModuleRegistry()
+        assert reg.get_version("nonexistent") is None
+
+    def test_get_all_versions(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.0.0", "/a")
+        reg.record_version("nuclei", "v3.0.0", "/b")
+        versions = reg.get_all_versions()
+        assert "brutus" in versions
+        assert "nuclei" in versions
+
+    def test_remove_version(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.0.0", "/a")
+        reg.remove_version("brutus")
+        assert reg.get_version("brutus") is None
+
+
+class TestRegistryAsInstallableTools:
+    def test_get_installable_tools_dict(self, seeded_cache):
+        """get_installable_tools returns a dict compatible with the old INSTALLABLE_TOOLS."""
+        reg = ModuleRegistry()
+        tools = reg.get_installable_tools()
+        assert "brutus" in tools
+        assert tools["brutus"]["repo"] == "praetorian-inc/brutus"
+        assert "description" in tools["brutus"]
+
+    def test_get_tool_aliases_dict(self, seeded_cache):
+        """get_tool_aliases returns a dict compatible with the old TOOL_ALIASES."""
+        reg = ModuleRegistry()
+        aliases = reg.get_tool_aliases()
+        assert "brutus" in aliases
+        assert "target_type" in aliases["brutus"]
+        assert "description" in aliases["brutus"]
+        assert "capability" in aliases["brutus"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_registry.py -v --tb=short 2>&1 | head -30`
+
+Expected: ImportError — `praetorian_cli.registry` does not exist yet.
+
+- [ ] **Step 3: Implement registry.py**
+
+Create `praetorian_cli/registry.py`:
+
+```python
+"""Module registry: fetch, cache, parse, and query the tool manifest."""
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_PRAETORIAN_DIR = os.path.join(os.path.expanduser("~"), ".praetorian")
+CACHE_PATH = os.path.join(_PRAETORIAN_DIR, "registry.json")
+VERSIONS_PATH = os.path.join(_PRAETORIAN_DIR, "versions.json")
+BUNDLED_REGISTRY_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "modules", "registry.json"
+)
+
+CACHE_TTL_SECONDS = 86400  # 24 hours
+
+REGISTRY_URL = (
+    "https://raw.githubusercontent.com/praetorian-inc/praetorian-cli"
+    "/main/modules/registry.json"
+)
+
+
+class ModuleRegistry:
+    def __init__(self):
+        self._data: Optional[Dict] = None
+
+    def _load(self) -> Dict:
+        if self._data is not None:
+            return self._data
+
+        # Try cache first
+        if os.path.isfile(CACHE_PATH):
+            try:
+                with open(CACHE_PATH) as f:
+                    self._data = json.load(f)
+                return self._data
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # Fallback to bundled
+        if os.path.isfile(BUNDLED_REGISTRY_PATH):
+            try:
+                with open(BUNDLED_REGISTRY_PATH) as f:
+                    self._data = json.load(f)
+                return self._data
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        self._data = {"version": 1, "modules": {}}
+        return self._data
+
+    def _is_cache_stale(self) -> bool:
+        if not os.path.isfile(CACHE_PATH):
+            return True
+        mtime = os.path.getmtime(CACHE_PATH)
+        return (time.time() - mtime) > CACHE_TTL_SECONDS
+
+    def refresh(self, force: bool = False) -> bool:
+        if not force and not self._is_cache_stale():
+            return False
+        try:
+            import urllib.request
+            req = urllib.request.Request(REGISTRY_URL, headers={"User-Agent": "guard-cli"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode())
+            os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+            with open(CACHE_PATH, "w") as f:
+                json.dump(data, f, indent=2)
+            self._data = data
+            return True
+        except Exception:
+            return False
+
+    def get_modules(self) -> Dict[str, Dict]:
+        return self._load().get("modules", {})
+
+    def get_module(self, name: str) -> Optional[Dict]:
+        modules = self.get_modules()
+        mod = modules.get(name.lower())
+        if mod is not None:
+            return mod
+        for key, val in modules.items():
+            if key.lower() == name.lower():
+                return val
+        return None
+
+    def search_modules(
+        self,
+        query: str = "",
+        category: str = "",
+    ) -> List[Dict[str, Any]]:
+        modules = self.get_modules()
+        results = []
+        q = query.lower()
+
+        for name, mod in modules.items():
+            if category and mod.get("category", "") != category:
+                continue
+            if q:
+                searchable = " ".join([
+                    name,
+                    mod.get("description", ""),
+                    mod.get("category", ""),
+                    " ".join(mod.get("tags", [])),
+                ]).lower()
+                if q not in searchable:
+                    continue
+            results.append({"name": name, **mod})
+
+        results.sort(key=lambda r: r["name"])
+        return results
+
+    # -- Version tracking --
+
+    def _load_versions(self) -> Dict:
+        if os.path.isfile(VERSIONS_PATH):
+            try:
+                with open(VERSIONS_PATH) as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+        return {}
+
+    def _save_versions(self, versions: Dict):
+        os.makedirs(os.path.dirname(VERSIONS_PATH), exist_ok=True)
+        with open(VERSIONS_PATH, "w") as f:
+            json.dump(versions, f, indent=2)
+
+    def record_version(self, name: str, version: str, path: str):
+        versions = self._load_versions()
+        versions[name] = {
+            "version": version,
+            "path": path,
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._save_versions(versions)
+
+    def get_version(self, name: str) -> Optional[Dict]:
+        return self._load_versions().get(name)
+
+    def get_all_versions(self) -> Dict:
+        return self._load_versions()
+
+    def remove_version(self, name: str):
+        versions = self._load_versions()
+        versions.pop(name, None)
+        self._save_versions(versions)
+
+    # -- Backward-compat dict interfaces --
+
+    def get_installable_tools(self) -> Dict[str, Dict]:
+        modules = self.get_modules()
+        return {
+            name: {"repo": mod["repo"], "description": mod["description"]}
+            for name, mod in modules.items()
+        }
+
+    def get_tool_aliases(self) -> Dict[str, Dict]:
+        modules = self.get_modules()
+        return {
+            name: {
+                "capability": name,
+                "agent": name,
+                "target_type": mod.get("target_type", "asset"),
+                "description": mod["description"],
+            }
+            for name, mod in modules.items()
+        }
+
+
+_registry = None
+
+
+def get_registry() -> ModuleRegistry:
+    global _registry
+    if _registry is None:
+        _registry = ModuleRegistry()
+    return _registry
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_registry.py -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/registry.py praetorian_cli/sdk/test/test_registry.py
+git commit -m "feat(modules): registry module with fetch, cache, search, version tracking"
+```
+
+---
+
+### Task 3: Wire `runners/local.py` to the Registry
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py:12-34` (replace `INSTALLABLE_TOOLS` dict)
+- Modify: `praetorian_cli/runners/local.py:110-188` (add version recording in `install_tool`)
+
+Replace the hardcoded `INSTALLABLE_TOOLS` dict with a function that reads from the registry. Record version on install.
+
+- [ ] **Step 1: Run existing local runner tests to confirm they pass before changes**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+
+Expected: All existing tests PASS.
+
+- [ ] **Step 2: Replace INSTALLABLE_TOOLS with registry-backed function**
+
+In `praetorian_cli/runners/local.py`, replace lines 16-34 (the `INSTALLABLE_TOOLS` dict) with:
+
+```python
+def _get_installable_tools():
+    from praetorian_cli.registry import get_registry
+    return get_registry().get_installable_tools()
+
+
+# Lazy property for backward compat — code that does `from runners.local import INSTALLABLE_TOOLS`
+# gets a dict-like object that loads on first access.
+class _LazyTools:
+    def __init__(self):
+        self._loaded = None
+
+    def _ensure(self):
+        if self._loaded is None:
+            self._loaded = _get_installable_tools()
+        return self._loaded
+
+    def __contains__(self, key):
+        return key in self._ensure()
+
+    def __getitem__(self, key):
+        return self._ensure()[key]
+
+    def __iter__(self):
+        return iter(self._ensure())
+
+    def __len__(self):
+        return len(self._ensure())
+
+    def items(self):
+        return self._ensure().items()
+
+    def keys(self):
+        return self._ensure().keys()
+
+    def values(self):
+        return self._ensure().values()
+
+    def get(self, key, default=None):
+        return self._ensure().get(key, default)
+
+
+INSTALLABLE_TOOLS = _LazyTools()
+```
+
+- [ ] **Step 3: Add version recording to install_tool**
+
+In `praetorian_cli/runners/local.py`, inside the `install_tool` function, after `os.chmod(binary_path, 0o755)` and before the cleanup section, add:
+
+```python
+    # Record version
+    try:
+        from praetorian_cli.registry import get_registry
+        ver_result = subprocess.run(
+            ['gh', 'release', 'view', '--repo', repo, '--json', 'tagName', '-q', '.tagName'],
+            capture_output=True, text=True, timeout=15,
+        )
+        version_tag = ver_result.stdout.strip() if ver_result.returncode == 0 else 'unknown'
+        get_registry().record_version(tool_name, version_tag, binary_path)
+    except Exception:
+        pass
+```
+
+- [ ] **Step 4: Run existing tests to confirm backward compat**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_local_runner.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+
+Expected: All existing tests still PASS. The `_LazyTools` wrapper is dict-compatible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py
+git commit -m "refactor(modules): replace hardcoded INSTALLABLE_TOOLS with registry-backed loader"
+```
+
+---
+
+### Task 4: Wire `handlers/run.py` to the Registry
+
+**Files:**
+- Modify: `praetorian_cli/handlers/run.py:1-30` (replace `FRIENDLY_NAMES`/`TOOL_ALIASES`)
+
+Replace the hardcoded dicts with registry-backed equivalents.
+
+- [ ] **Step 1: Run existing run CLI tests**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_run_cli.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 2: Replace FRIENDLY_NAMES and TOOL_ALIASES**
+
+In `handlers/run.py`, replace the `FRIENDLY_NAMES` dict and `TOOL_ALIASES` construction (lines ~10-30) with:
+
+```python
+def _get_tool_aliases():
+    from praetorian_cli.registry import get_registry
+    return get_registry().get_tool_aliases()
+
+
+class _LazyAliases:
+    """Lazy-loading dict wrapper so `from handlers.run import TOOL_ALIASES` still works."""
+    def __init__(self):
+        self._loaded = None
+
+    def _ensure(self):
+        if self._loaded is None:
+            self._loaded = _get_tool_aliases()
+        return self._loaded
+
+    def __contains__(self, key):
+        return key in self._ensure()
+
+    def __getitem__(self, key):
+        return self._ensure()[key]
+
+    def __setitem__(self, key, value):
+        self._ensure()[key] = value
+
+    def __iter__(self):
+        return iter(self._ensure())
+
+    def __len__(self):
+        return len(self._ensure())
+
+    def items(self):
+        return self._ensure().items()
+
+    def keys(self):
+        return self._ensure().keys()
+
+    def values(self):
+        return self._ensure().values()
+
+    def get(self, key, default=None):
+        return self._ensure().get(key, default)
+
+
+TOOL_ALIASES = _LazyAliases()
+```
+
+Remove the `FRIENDLY_NAMES` dict entirely (it was only used to seed `TOOL_ALIASES`).
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_run_cli.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add praetorian_cli/handlers/run.py
+git commit -m "refactor(modules): replace hardcoded TOOL_ALIASES with registry-backed loader"
+```
+
+---
+
+### Task 5: Create `guard module` CLI Commands
+
+**Files:**
+- Create: `praetorian_cli/sdk/test/test_module_cli.py`
+- Create: `praetorian_cli/handlers/module.py`
+- Modify: `praetorian_cli/main.py`
+
+New `guard module` subcommand group with search, info, options, install, uninstall, update, installed, list.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `praetorian_cli/sdk/test/test_module_cli.py`:
+
+```python
+"""Unit tests for `guard module` CLI commands."""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    return sdk
+
+
+SAMPLE_MODULES = {
+    "brutus": {
+        "repo": "praetorian-inc/brutus",
+        "description": "Credential attacks across 20+ protocols",
+        "category": "credential",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {
+            "protocol": {"type": "string", "description": "Target protocol", "required": False},
+        },
+        "tags": ["brute-force", "password"],
+    },
+    "nuclei": {
+        "repo": "praetorian-inc/nuclei",
+        "description": "Vulnerability scanner",
+        "category": "scanner",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {},
+        "tags": ["vulnerability"],
+    },
+}
+
+
+def _invoke(runner, fake_sdk, argv):
+    obj = {"keychain": MagicMock(), "proxy": ""}
+    with patch("praetorian_cli.sdk.chariot.Chariot", return_value=fake_sdk), \
+         patch("praetorian_cli.handlers.cli_decorators.upgrade_check", lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, catch_exceptions=False)
+
+
+class TestModuleSearch:
+    def test_search_no_args_lists_all(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+        assert "nuclei" in result.output
+
+    def test_search_with_query(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "credential"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+
+    def test_search_with_category_filter(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "--category", "scanner"])
+        assert result.exit_code == 0
+        assert "nuclei" in result.output
+
+    def test_search_json_output(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+
+class TestModuleInfo:
+    def test_info_existing_module(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            result = _invoke(runner, fake_sdk, ["module", "info", "brutus"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+        assert "credential" in result.output.lower() or "Credential" in result.output
+
+    def test_info_unknown_module(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "info", "nonexistent"])
+        assert result.exit_code != 0
+
+    def test_info_json_output(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            result = _invoke(runner, fake_sdk, ["module", "info", "brutus", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["name"] == "brutus"
+
+
+class TestModuleInstalled:
+    def test_installed_lists_tools(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={"brutus": "/path/brutus"}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_all_versions", return_value={
+                 "brutus": {"version": "v1.2.3", "path": "/path/brutus"}
+             }):
+            result = _invoke(runner, fake_sdk, ["module", "installed"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_module_cli.py -v --tb=short 2>&1 | head -20`
+
+Expected: ImportError or "No such command 'module'" errors.
+
+- [ ] **Step 3: Implement handlers/module.py**
+
+Create `praetorian_cli/handlers/module.py`:
+
+```python
+"""guard module — Metasploit-style module management commands."""
+
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error, print_json
+
+
+@chariot.group()
+def module():
+    """Manage security tool modules
+
+    \b
+    Metasploit-style module management: search, inspect, install, and
+    update security tools from the Guard module registry.
+    """
+    pass
+
+
+@module.command("search")
+@cli_handler
+@click.argument("query", default="")
+@click.option("--category", "-c", default="", help="Filter by category")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def search(sdk, query, category, as_json):
+    """Search available modules by name, category, or keyword
+
+    \b
+    Example usages:
+        guard module search
+        guard module search credential
+        guard module search --category scanner
+        guard module search llm --json
+    """
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+
+    reg = get_registry()
+    results = reg.search_modules(query, category=category)
+    installed = list_installed()
+
+    if as_json:
+        for r in results:
+            r["installed"] = r["name"] in installed
+            ver = reg.get_version(r["name"])
+            r["version"] = ver["version"] if ver else None
+        print_json(results)
+        return
+
+    if not results:
+        click.echo("No modules match the query.")
+        return
+
+    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
+
+    for r in results:
+        name = r["name"]
+        cat = r.get("category", "")
+        desc = r.get("description", "")
+        if len(desc) > 48:
+            desc = desc[:47] + "…"
+        ver = reg.get_version(name)
+        if name in installed:
+            status = ver["version"] if ver else "yes"
+        else:
+            status = "—"
+        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
+
+    click.echo(f"\n{len(results)} modules")
+
+
+@module.command("list")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def list_modules(sdk, as_json):
+    """List all available modules (alias for search with no query)"""
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+
+    reg = get_registry()
+    results = reg.search_modules()
+    installed = list_installed()
+
+    if as_json:
+        for r in results:
+            r["installed"] = r["name"] in installed
+            ver = reg.get_version(r["name"])
+            r["version"] = ver["version"] if ver else None
+        print_json(results)
+        return
+
+    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
+    for r in results:
+        name = r["name"]
+        cat = r.get("category", "")
+        desc = r.get("description", "")
+        if len(desc) > 48:
+            desc = desc[:47] + "…"
+        ver = reg.get_version(name)
+        if name in installed:
+            status = ver["version"] if ver else "yes"
+        else:
+            status = "—"
+        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
+    click.echo(f"\n{len(results)} modules")
+
+
+@module.command("info")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def info(sdk, name, as_json):
+    """Show full details for a module
+
+    \b
+    Example usages:
+        guard module info brutus
+        guard module info nuclei --json
+    """
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import is_installed, get_binary_path
+
+    reg = get_registry()
+    mod = reg.get_module(name)
+    if not mod:
+        error(f"Unknown module: {name}. Use 'guard module search' to find modules.")
+
+    ver_info = reg.get_version(name.lower())
+
+    if as_json:
+        out = {"name": name.lower(), **mod}
+        out["installed"] = is_installed(name.lower())
+        out["version"] = ver_info["version"] if ver_info else None
+        out["binary_path"] = get_binary_path(name.lower())
+        print_json(out)
+        return
+
+    installed_str = "not installed"
+    if is_installed(name.lower()):
+        path = get_binary_path(name.lower())
+        ver = ver_info["version"] if ver_info else "unknown"
+        installed_str = f"{ver} ({path})"
+
+    click.echo(f"\n  Name:        {name.lower()}")
+    click.echo(f"  Category:    {mod.get('category', '')}")
+    click.echo(f"  Author:      {mod.get('author', '')}")
+    click.echo(f"  Repository:  {mod.get('repo', '')}")
+    click.echo(f"  Installed:   {installed_str}")
+    click.echo(f"  Target:      {mod.get('target_type', 'asset')}")
+    click.echo(f"  Description: {mod.get('description', '')}")
+
+    tags = mod.get("tags", [])
+    if tags:
+        click.echo(f"  Tags:        {', '.join(tags)}")
+
+    options = mod.get("options", {})
+    if options:
+        click.echo(f"\n  Options:")
+        for opt_name, opt_info in options.items():
+            opt_type = opt_info.get("type", "string")
+            opt_desc = opt_info.get("description", "")
+            click.echo(f"    --{opt_name:<14} {opt_type:<8} {opt_desc}")
+
+    click.echo(f"\n  Usage:")
+    click.echo(f"    guard run tool {name.lower()} <target>")
+    click.echo()
+
+
+@module.command("options")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def options(sdk, name, as_json):
+    """Show configurable options for a module
+
+    \b
+    Example: guard module options brutus
+    """
+    from praetorian_cli.registry import get_registry
+
+    reg = get_registry()
+    mod = reg.get_module(name)
+    if not mod:
+        error(f"Unknown module: {name}")
+
+    opts = mod.get("options", {})
+
+    if as_json:
+        print_json(opts)
+        return
+
+    if not opts:
+        click.echo(f"{name}: no configurable options.")
+        return
+
+    click.echo(f'\n{"Option":<18} {"Type":<10} {"Required":<10} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 10} {"─" * 10} {"─" * 40}')
+    for opt_name, opt_info in opts.items():
+        click.echo(
+            f"--{opt_name:<16} {opt_info.get('type', 'string'):<10} "
+            f"{'yes' if opt_info.get('required') else 'no':<10} "
+            f"{opt_info.get('description', '')}"
+        )
+    click.echo()
+
+
+@module.command("install")
+@cli_handler
+@click.argument("name")
+@click.option("--force", is_flag=True, default=False, help="Reinstall even if present")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def install(sdk, name, force, as_json):
+    """Install a module binary from GitHub releases
+
+    \b
+    Example usages:
+        guard module install brutus
+        guard module install all
+        guard module install brutus --force
+    """
+    from praetorian_cli.runners.local import install_tool, INSTALLABLE_TOOLS, is_installed
+
+    if name == "all":
+        results = []
+        for tool_name in sorted(INSTALLABLE_TOOLS):
+            try:
+                if not force and is_installed(tool_name):
+                    if as_json:
+                        results.append({"name": tool_name, "status": "already_installed"})
+                    else:
+                        click.echo(f"{tool_name}: already installed")
+                else:
+                    if not as_json:
+                        click.echo(f"{tool_name}: installing...", nl=False)
+                    path = install_tool(tool_name, force=force)
+                    if as_json:
+                        results.append({"name": tool_name, "status": "installed", "path": path})
+                    else:
+                        click.echo(f" {path}")
+            except Exception as e:
+                if as_json:
+                    results.append({"name": tool_name, "status": "error", "error": str(e)})
+                else:
+                    click.echo(f" FAILED: {e}", err=True)
+        if as_json:
+            print_json(results)
+        return
+
+    try:
+        if not as_json:
+            click.echo(f"Installing {name}...")
+        path = install_tool(name, force=force)
+        if as_json:
+            print_json({"name": name, "status": "installed", "path": path})
+        else:
+            click.echo(f"Installed: {path}")
+    except Exception as e:
+        if as_json:
+            print_json({"name": name, "status": "error", "error": str(e)})
+        else:
+            error(str(e))
+
+
+@module.command("uninstall")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def uninstall(sdk, name, as_json):
+    """Remove an installed module binary
+
+    \b
+    Example: guard module uninstall brutus
+    """
+    import os
+    from praetorian_cli.runners.local import get_binary_path, INSTALL_DIR
+    from praetorian_cli.registry import get_registry
+
+    path = get_binary_path(name)
+    if not path:
+        if as_json:
+            print_json({"name": name, "status": "not_installed"})
+        else:
+            error(f"{name} is not installed.")
+        return
+
+    # Only remove from our install dir, not system binaries
+    if not path.startswith(INSTALL_DIR):
+        if as_json:
+            print_json({"name": name, "status": "error", "error": "System binary, not managed by guard"})
+        else:
+            error(f"{name} at {path} is a system binary, not managed by guard module install.")
+        return
+
+    os.remove(path)
+    get_registry().remove_version(name)
+
+    if as_json:
+        print_json({"name": name, "status": "uninstalled"})
+    else:
+        click.echo(f"Uninstalled: {name}")
+
+
+@module.command("update")
+@cli_handler
+@click.argument("name", default="all")
+@click.option("--registry", "update_registry", is_flag=True, default=False, help="Force refresh the registry")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def update(sdk, name, update_registry, as_json):
+    """Update installed modules to latest release
+
+    \b
+    Example usages:
+        guard module update
+        guard module update brutus
+        guard module update --registry
+    """
+    import subprocess
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
+
+    reg = get_registry()
+
+    if update_registry:
+        refreshed = reg.refresh(force=True)
+        if not as_json:
+            click.echo("Registry refreshed." if refreshed else "Registry refresh failed (using cached).")
+
+    tools_to_update = sorted(INSTALLABLE_TOOLS) if name == "all" else [name]
+    results = []
+
+    for tool_name in tools_to_update:
+        if not is_installed(tool_name):
+            if name != "all":
+                if as_json:
+                    results.append({"name": tool_name, "status": "not_installed"})
+                else:
+                    click.echo(f"{tool_name}: not installed")
+            continue
+
+        mod = reg.get_module(tool_name)
+        if not mod:
+            continue
+
+        current = reg.get_version(tool_name)
+        current_ver = current["version"] if current else "unknown"
+
+        # Check latest release
+        try:
+            ver_result = subprocess.run(
+                ["gh", "release", "view", "--repo", mod["repo"], "--json", "tagName", "-q", ".tagName"],
+                capture_output=True, text=True, timeout=15,
+            )
+            latest_ver = ver_result.stdout.strip() if ver_result.returncode == 0 else None
+        except Exception:
+            latest_ver = None
+
+        if not latest_ver:
+            if as_json:
+                results.append({"name": tool_name, "status": "error", "error": "Could not check latest version"})
+            else:
+                click.echo(f"{tool_name}: could not check latest version")
+            continue
+
+        if latest_ver == current_ver:
+            if as_json:
+                results.append({"name": tool_name, "status": "up_to_date", "version": current_ver})
+            elif name != "all":
+                click.echo(f"{tool_name}: up to date ({current_ver})")
+            continue
+
+        # Update
+        try:
+            if not as_json:
+                click.echo(f"{tool_name}: {current_ver} -> {latest_ver}...", nl=False)
+            path = install_tool(tool_name, force=True)
+            if as_json:
+                results.append({"name": tool_name, "status": "updated", "from": current_ver, "to": latest_ver, "path": path})
+            else:
+                click.echo(f" done")
+        except Exception as e:
+            if as_json:
+                results.append({"name": tool_name, "status": "error", "error": str(e)})
+            else:
+                click.echo(f" FAILED: {e}", err=True)
+
+    if as_json:
+        print_json(results)
+
+
+@module.command("installed")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def installed(sdk, as_json):
+    """List installed modules with versions"""
+    from praetorian_cli.runners.local import list_installed, INSTALLABLE_TOOLS
+    from praetorian_cli.registry import get_registry
+
+    reg = get_registry()
+    inst = list_installed()
+    versions = reg.get_all_versions()
+
+    if as_json:
+        result = []
+        for tool_name in sorted(INSTALLABLE_TOOLS):
+            entry = {"name": tool_name, "installed": tool_name in inst}
+            if tool_name in inst:
+                entry["path"] = inst[tool_name]
+                ver = versions.get(tool_name)
+                entry["version"] = ver["version"] if ver else None
+            result.append(entry)
+        print_json(result)
+        return
+
+    click.echo(f'\n{"Tool":<18} {"Status":<12} {"Version":<12} {"Path"}')
+    click.echo(f'{"─" * 18} {"─" * 12} {"─" * 12} {"─" * 50}')
+    for tool_name in sorted(INSTALLABLE_TOOLS):
+        if tool_name in inst:
+            ver = versions.get(tool_name, {}).get("version", "—")
+            click.echo(f"{tool_name:<18} {'installed':<12} {ver:<12} {inst[tool_name]}")
+        else:
+            click.echo(f"{tool_name:<18} {'—':<12} {'—':<12}")
+    click.echo()
+```
+
+- [ ] **Step 4: Register in main.py**
+
+In `praetorian_cli/main.py`, add after the existing handler imports (around line 14):
+
+```python
+import praetorian_cli.handlers.module
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_module_cli.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 6: Run all existing tests to confirm no regressions**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_run_cli.py praetorian_cli/sdk/test/test_local_runner.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add praetorian_cli/handlers/module.py praetorian_cli/main.py praetorian_cli/sdk/test/test_module_cli.py
+git commit -m "feat(modules): guard module CLI commands — search, info, options, install, uninstall, update"
+```
+
+---
+
+### Task 6: Add Console Commands (search, info, update)
+
+**Files:**
+- Create: `praetorian_cli/sdk/test/ui/test_console_modules.py`
+- Modify: `praetorian_cli/ui/console/commands/tools.py`
+- Modify: `praetorian_cli/ui/console/console.py`
+
+Add `search`, `info`, `update` console commands that wire to the registry.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `praetorian_cli/sdk/test/ui/test_console_modules.py`:
+
+```python
+"""Unit tests for console module commands (search, info, update)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praetorian_cli.ui.console.commands.tools import ToolCommands
+from praetorian_cli.sdk.test.ui_mocks import MockConsole as _BaseMockConsole
+
+pytestmark = pytest.mark.tui
+
+
+SAMPLE_MODULES = {
+    "brutus": {
+        "repo": "praetorian-inc/brutus",
+        "description": "Credential attacks across 20+ protocols",
+        "category": "credential",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {
+            "protocol": {"type": "string", "description": "Target protocol", "required": False},
+        },
+        "tags": ["brute-force", "password"],
+    },
+    "nuclei": {
+        "repo": "praetorian-inc/nuclei",
+        "description": "Vulnerability scanner",
+        "category": "scanner",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {},
+        "tags": ["vulnerability"],
+    },
+}
+
+
+class MockConsole(_BaseMockConsole):
+    def print(self, msg="", **kwargs):
+        self.lines.append(str(msg))
+
+
+class _FakeContext:
+    active_tool = None
+    account = "acct"
+    _last_job_key = ""
+
+    def apply_scope_to_message(self, msg):
+        return msg
+
+
+class _Harness(ToolCommands):
+    def __init__(self, sdk=None):
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FakeContext()
+        self.colors = {
+            "primary": "cyan", "accent": "magenta", "dim": "dim",
+            "info": "blue", "success": "green", "warning": "yellow", "error": "red",
+        }
+
+    def _send_to_marcus(self, message):
+        return ""
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+
+class TestConsoleSearch:
+    def test_search_lists_all_modules(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_search([])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+        assert "nuclei" in output
+
+    def test_search_filters_by_query(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_search(["credential"])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+
+
+class TestConsoleInfo:
+    def test_info_shows_module_details(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.is_installed", return_value=False), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_info(["brutus"])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+        assert "credential" in output.lower() or "Credential" in output
+
+    def test_info_unknown_module(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            h._cmd_module_info(["nonexistent"])
+        output = "\n".join(h.console.lines)
+        assert "unknown" in output.lower() or "not found" in output.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/ui/test_console_modules.py -v --tb=short 2>&1 | head -20`
+
+Expected: AttributeError — `_cmd_module_search` does not exist yet.
+
+- [ ] **Step 3: Add module console commands to tools.py**
+
+In `praetorian_cli/ui/console/commands/tools.py`, add these methods to the `ToolCommands` class (after the existing `_cmd_capabilities` method):
+
+```python
+    def _cmd_module_search(self, args):
+        """Search modules from the registry."""
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import list_installed
+
+        reg = get_registry()
+        query = args[0] if args else ''
+        category = ''
+        if '--category' in args:
+            idx = args.index('--category')
+            if idx + 1 < len(args):
+                category = args[idx + 1]
+                query = args[0] if args[0] != '--category' else ''
+
+        results = reg.search_modules(query, category=category)
+        installed = list_installed()
+
+        if not results:
+            self.console.print('[dim]No modules match the query.[/dim]')
+            return
+
+        table = Table(title=f'Modules ({len(results)})', border_style=self.colors['primary'])
+        table.add_column('#', style=self.colors['dim'], width=4)
+        table.add_column('Name', style=f'bold {self.colors["primary"]}', min_width=16)
+        table.add_column('Category', style=self.colors['accent'])
+        table.add_column('Installed', min_width=10)
+        table.add_column('Description')
+
+        self._module_list = []
+        for i, r in enumerate(results, 1):
+            name = r['name']
+            ver = reg.get_version(name)
+            if name in installed:
+                status = f'[success]{ver["version"]}[/success]' if ver else '[success]yes[/success]'
+            else:
+                status = '[dim]—[/dim]'
+            desc = r.get('description', '')
+            if len(desc) > 50:
+                desc = desc[:49] + '…'
+            table.add_row(str(i), name, r.get('category', ''), status, desc)
+            self._module_list.append(name)
+
+        self.console.print(table)
+        self.console.print(f'\n[dim]Use "info <name>" for details or "install <name>" to install.[/dim]')
+
+    def _cmd_module_info(self, args):
+        """Show full details for a module."""
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import is_installed, get_binary_path
+
+        if not args:
+            self.console.print('[dim]Usage: info <module_name>[/dim]')
+            return
+
+        name = args[0].lower()
+        reg = get_registry()
+        mod = reg.get_module(name)
+        if not mod:
+            self.console.print(f'[error]Unknown module: {name}. Use "search" to find modules.[/error]')
+            return
+
+        ver_info = reg.get_version(name)
+        installed_str = 'not installed'
+        if is_installed(name):
+            path = get_binary_path(name)
+            ver = ver_info['version'] if ver_info else 'unknown'
+            installed_str = f'{ver} ({path})'
+
+        info_text = Text()
+        info_text.append(f'Name:        ', style=self.colors['dim'])
+        info_text.append(f'{name}\n', style=f'bold {self.colors["primary"]}')
+        info_text.append(f'Category:    ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("category", "")}\n', style=self.colors['accent'])
+        info_text.append(f'Author:      ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("author", "")}\n')
+        info_text.append(f'Repository:  ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("repo", "")}\n')
+        info_text.append(f'Installed:   ', style=self.colors['dim'])
+        info_text.append(f'{installed_str}\n')
+        info_text.append(f'Target:      ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("target_type", "asset")}\n')
+        info_text.append(f'Description: ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("description", "")}\n')
+
+        tags = mod.get('tags', [])
+        if tags:
+            info_text.append(f'Tags:        ', style=self.colors['dim'])
+            info_text.append(f'{", ".join(tags)}\n')
+
+        from rich.panel import Panel
+        self.console.print(Panel(info_text, title=f'Module: {name}', border_style=self.colors['primary']))
+
+        options = mod.get('options', {})
+        if options:
+            opt_table = Table(title='Options', border_style=self.colors['dim'])
+            opt_table.add_column('Option', style=f'bold {self.colors["primary"]}')
+            opt_table.add_column('Type', style=self.colors['accent'])
+            opt_table.add_column('Required')
+            opt_table.add_column('Description')
+            for opt_name, opt_info in options.items():
+                opt_table.add_row(
+                    f'--{opt_name}',
+                    opt_info.get('type', 'string'),
+                    'yes' if opt_info.get('required') else 'no',
+                    opt_info.get('description', ''),
+                )
+            self.console.print(opt_table)
+
+    def _cmd_module_update(self, args):
+        """Update installed modules to latest release."""
+        import subprocess
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
+
+        if '--registry' in args:
+            reg = get_registry()
+            refreshed = reg.refresh(force=True)
+            self.console.print(
+                '[success]Registry refreshed.[/success]' if refreshed
+                else '[warning]Registry refresh failed (using cached).[/warning]'
+            )
+            return
+
+        reg = get_registry()
+        name = args[0].lower() if args else 'all'
+        tools = sorted(INSTALLABLE_TOOLS) if name == 'all' else [name]
+
+        updated = 0
+        for tool_name in tools:
+            if not is_installed(tool_name):
+                if name != 'all':
+                    self.console.print(f'[dim]{tool_name}: not installed[/dim]')
+                continue
+
+            mod = reg.get_module(tool_name)
+            if not mod:
+                continue
+
+            current = reg.get_version(tool_name)
+            current_ver = current['version'] if current else 'unknown'
+
+            try:
+                ver_result = subprocess.run(
+                    ['gh', 'release', 'view', '--repo', mod['repo'],
+                     '--json', 'tagName', '-q', '.tagName'],
+                    capture_output=True, text=True, timeout=15,
+                )
+                latest = ver_result.stdout.strip() if ver_result.returncode == 0 else None
+            except Exception:
+                latest = None
+
+            if not latest:
+                self.console.print(f'[warning]{tool_name}: could not check latest version[/warning]')
+                continue
+
+            if latest == current_ver:
+                if name != 'all':
+                    self.console.print(f'[dim]{tool_name}: up to date ({current_ver})[/dim]')
+                continue
+
+            try:
+                with self.console.status(f'Updating {tool_name} {current_ver} → {latest}...', spinner='dots'):
+                    install_tool(tool_name, force=True)
+                self.console.print(f'[success]{tool_name}: {current_ver} → {latest}[/success]')
+                updated += 1
+            except Exception as e:
+                self.console.print(f'[error]{tool_name}: {e}[/error]')
+
+        if name == 'all':
+            self.console.print(f'[dim]{updated} module(s) updated.[/dim]')
+```
+
+You'll also need to add the `Table` and `Text` imports at the top of `tools.py` if not already present. Check that `Table` and `Text` are imported from `rich.table` and `rich.text` respectively (they already are at lines 8-9).
+
+- [ ] **Step 4: Wire new commands in console.py dispatch table and CONSOLE_COMMANDS**
+
+In `praetorian_cli/ui/console/console.py`:
+
+Add to `CONSOLE_COMMANDS` list (around line 53, before `'help'`):
+```python
+    'update', 'module',
+```
+
+In the `_dispatch` method's `handlers` dict (around line 190), add:
+```python
+            'update': self._cmd_module_update,
+            'module': self._cmd_module_dispatch,
+```
+
+Also add a `_cmd_module_dispatch` method to the `GuardConsole` class:
+```python
+    def _cmd_module_dispatch(self, args):
+        """Route 'module <subcommand>' to the right handler."""
+        if not args:
+            self._cmd_module_search([])
+            return
+        sub = args[0].lower()
+        rest = args[1:]
+        routes = {
+            'search': self._cmd_module_search,
+            'info': self._cmd_module_info,
+            'update': self._cmd_module_update,
+            'install': self._cmd_install,
+            'installed': self._cmd_installed,
+            'options': self._cmd_options,
+            'list': self._cmd_module_search,
+        }
+        handler = routes.get(sub)
+        if handler:
+            handler(rest)
+        else:
+            self.console.print(f'[dim]Unknown: module {sub}. Try: search, info, install, installed, update, options[/dim]')
+```
+
+Also update the existing `_cmd_info` dispatch in `search.py` or `console.py` to route to `_cmd_module_info` when a module name is given (check which file owns `_cmd_info`).
+
+- [ ] **Step 5: Update help table**
+
+In `console.py` `_cmd_help`, in the `[section]Security Tools (Metasploit-style)[/section]` section, add:
+```python
+        help_table.add_row('search [query]', 'Search module registry (name, category, tag)')
+        help_table.add_row('info <module>', 'Show module details (options, version, author)')
+        help_table.add_row('update [module|all]', 'Update installed modules to latest')
+        help_table.add_row('module <subcmd>', 'Module management (search, info, install, update)')
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/ui/test_console_modules.py praetorian_cli/sdk/test/ui/test_console_tools.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/tools.py praetorian_cli/ui/console/console.py praetorian_cli/sdk/test/ui/test_console_modules.py
+git commit -m "feat(modules): console search, info, update commands wired to registry"
+```
+
+---
+
+### Task 7: Add MCP Tools for Claude Integration
+
+**Files:**
+- Modify: `praetorian_cli/sdk/mcp_server.py`
+
+Add explicit module management MCP tools: `list_modules`, `module_info`, `install_module`, `run_module`.
+
+- [ ] **Step 1: Add module MCP tools**
+
+In `praetorian_cli/sdk/mcp_server.py`, add a new method `_register_module_tools` and call it from `__init__` after `self._register_tools()`:
+
+```python
+    def __init__(self, chariot_instance, allowable_tools: Optional[List[str]] = None):
+        self.chariot = chariot_instance
+        self.allowable_tools = allowable_tools
+        self.server = Server("praetorian-cli")
+        self.discovered_tools = {}
+        self._discover_tools()
+        self._register_tools()
+        self._register_module_tools()
+```
+
+Then add the `_register_module_tools` method:
+
+```python
+    def _register_module_tools(self):
+        """Register explicit module management MCP tools."""
+
+        # Store module tool definitions for list_tools
+        self._module_tools = {}
+
+        self._module_tools["list_modules"] = Tool(
+            name="list_modules",
+            description="List all available Guard security modules with install status. "
+                        "Returns name, category, description, install status, and version for each module.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query (matches name, description, tags)"},
+                    "category": {"type": "string", "description": "Filter by category (scanner, credential, recon, cloud, cicd, ai, supply-chain, api)"},
+                },
+            },
+        )
+
+        self._module_tools["module_info"] = Tool(
+            name="module_info",
+            description="Get full details for a Guard security module including options, version, and install path.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name (e.g., brutus, nuclei, titus)"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["install_module"] = Tool(
+            name="install_module",
+            description="Install a Guard security module binary from GitHub releases to ~/.praetorian/bin/.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name to install, or 'all'"},
+                    "force": {"type": "boolean", "description": "Reinstall even if already present"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["run_module"] = Tool(
+            name="run_module",
+            description="Execute an installed Guard security module against a target. "
+                        "The module must be installed first (use install_module).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name"},
+                    "target": {"type": "string", "description": "Target (IP, domain, URL, or Guard key)"},
+                    "options": {"type": "object", "description": "Tool-specific options as key-value pairs"},
+                },
+                "required": ["name", "target"],
+            },
+        )
+
+        # Patch the list_tools handler to include module tools
+        original_list = self.server._tool_list_handler
+
+        @self.server.list_tools()
+        async def list_tools_with_modules() -> List[Tool]:
+            base_tools = await original_list()
+            return base_tools + list(self._module_tools.values())
+
+        # Patch call_tool to handle module tools
+        original_call = self._call_tool
+
+        async def call_tool_with_modules(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+            if name in self._module_tools:
+                return await self._handle_module_tool(name, arguments)
+            return await original_call(name, arguments)
+
+        self._call_tool = call_tool_with_modules
+
+    async def _handle_module_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        try:
+            if name == "list_modules":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import list_installed
+                reg = get_registry()
+                query = arguments.get("query", "")
+                category = arguments.get("category", "")
+                results = reg.search_modules(query, category=category)
+                installed = list_installed()
+                for r in results:
+                    r["installed"] = r["name"] in installed
+                    ver = reg.get_version(r["name"])
+                    r["version"] = ver["version"] if ver else None
+                return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
+            elif name == "module_info":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import is_installed, get_binary_path
+                reg = get_registry()
+                mod_name = arguments["name"].lower()
+                mod = reg.get_module(mod_name)
+                if not mod:
+                    return [TextContent(type="text", text=f"Unknown module: {mod_name}")]
+                ver = reg.get_version(mod_name)
+                out = {"name": mod_name, **mod}
+                out["installed"] = is_installed(mod_name)
+                out["version"] = ver["version"] if ver else None
+                out["binary_path"] = get_binary_path(mod_name)
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            elif name == "install_module":
+                from praetorian_cli.runners.local import install_tool, is_installed
+                mod_name = arguments["name"].lower()
+                force = arguments.get("force", False)
+                if not force and is_installed(mod_name):
+                    return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "already_installed"}))]
+                path = install_tool(mod_name, force=force)
+                return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "installed", "path": path}))]
+
+            elif name == "run_module":
+                from praetorian_cli.runners.local import LocalRunner, get_tool_plugin, is_installed
+                mod_name = arguments["name"].lower()
+                target = arguments["target"]
+                options = arguments.get("options", {})
+                if not is_installed(mod_name):
+                    return [TextContent(type="text", text=f"Module {mod_name} is not installed. Use install_module first.")]
+                plugin = get_tool_plugin(mod_name)
+                extra_config = json.dumps(options) if options else ""
+                args = plugin.build_args(target, extra_config)
+                runner = LocalRunner(mod_name)
+                result = runner.run(args, timeout=300)
+                out = {
+                    "name": mod_name,
+                    "target": target,
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            return [TextContent(type="text", text=f"Unknown module tool: {name}")]
+
+        except Exception as e:
+            return [TextContent(type="text", text=f"Error in {name}: {str(e)}")]
+```
+
+- [ ] **Step 2: Run existing MCP test to confirm no regression**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_mcp.py -v 2>&1 | tail -20`
+
+Expected: Existing tests PASS (or skip if they require a live server).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add praetorian_cli/sdk/mcp_server.py
+git commit -m "feat(modules): MCP tools for module management — list, info, install, run"
+```
+
+---
+
+### Task 8: Integration Test and Final Verification
+
+**Files:**
+- All previously created/modified files
+
+Final sweep: run the full test suite, manually verify CLI commands work, check backward compat.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli && python -m pytest praetorian_cli/sdk/test/test_registry.py praetorian_cli/sdk/test/test_module_cli.py praetorian_cli/sdk/test/test_local_runner.py praetorian_cli/sdk/test/test_run_cli.py praetorian_cli/sdk/test/ui/test_console_tools.py praetorian_cli/sdk/test/ui/test_console_modules.py -v`
+
+Expected: All PASS.
+
+- [ ] **Step 2: Verify CLI commands work (smoke test)**
+
+```bash
+cd /Users/ajman/Documents/Tools/praetorian-claude/guard-platform/guard-cli
+pip install -e . 2>/dev/null
+guard module search 2>&1 | head -20
+guard module info brutus 2>&1
+guard module installed 2>&1 | head -10
+guard module search --json 2>&1 | python -m json.tool | head -10
+guard module info brutus --json 2>&1 | python -m json.tool
+```
+
+Expected: All commands produce clean output matching the spec.
+
+- [ ] **Step 3: Verify backward compat**
+
+```bash
+guard run list 2>&1 | head -10
+guard run installed 2>&1 | head -10
+```
+
+Expected: Old commands still work identically.
+
+- [ ] **Step 4: Commit any fixes, then final commit**
+
+If any fixes were needed, commit them. Then:
+
+```bash
+git log --oneline feat/module-system --not main
+```
+
+Expected: Clean commit history showing the feature progression.

--- a/docs/superpowers/plans/2026-05-28-module-system-parity.md
+++ b/docs/superpowers/plans/2026-05-28-module-system-parity.md
@@ -1,0 +1,1034 @@
+# Module System — Live-API Parity + Metasploit UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the CLI module system reflect guard's live `/capabilities/` API as the single source of truth, reduce `registry.json` to a slim install-manifest, and deliver a streamlined Metasploit-grade discovery/install/run experience across CLI, console, and MCP.
+
+**Architecture:** A new `CapabilityCatalog` fetches and normalizes guard capabilities (live → cache → bundled snapshot). `registry.json` becomes an install-only manifest (`name → repo/binary_pattern/plugin`, plus `capability` alias and `local_only` flag). CLI/console/MCP all read the catalog through one interface and render through shared helpers.
+
+**Tech Stack:** Python 3.12, Click, Rich, prompt_toolkit, pytest. Existing SDK method `sdk.capabilities.list(name, target, executor)` returns `(list, offset)`.
+
+**Branch:** `feat/module-system` (PR #226). Base spec: `docs/superpowers/specs/2026-05-28-module-system-parity-design.md`.
+
+---
+
+## File Structure
+
+- Create: `praetorian_cli/catalog.py` — `CapabilityCatalog`, `Capability`, normalization, fuzzy search.
+- Create: `praetorian_cli/modules/capabilities_snapshot.json` — bundled offline snapshot.
+- Modify: `praetorian_cli/registry.py` — manifest v2 loader; `get_installable_tools`/`get_tool_aliases` honor `capability`/`binary_pattern`/`plugin`/`local_only`.
+- Modify: `modules/registry.json` — migrate to v2 slim install-manifest.
+- Modify: `praetorian_cli/runners/local.py` — `binary_pattern` from manifest; SHA-256 verify; `uninstall_tool`.
+- Modify: `praetorian_cli/handlers/module.py` — catalog-backed commands + `sync`/`uninstall`; Rich progress; parallel install.
+- Modify: `praetorian_cli/ui/console/commands/tools.py` — module subcommands via catalog + shared renderer; numbered results.
+- Modify: `praetorian_cli/ui/console/console.py` — tab-completion for module subcommands + names.
+- Modify: `praetorian_cli/sdk/mcp_server.py` — `list_modules`/`module_info` via catalog.
+- Modify: `MANIFEST.in` — include the snapshot.
+- Tests: `praetorian_cli/sdk/test/test_catalog.py`, extend `test_registry.py`, `test_module_cli.py`, `ui/test_console_modules.py`.
+
+---
+
+## Task 1: Capability normalization
+
+**Files:**
+- Create: `praetorian_cli/catalog.py`
+- Test: `praetorian_cli/sdk/test/test_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# praetorian_cli/sdk/test/test_catalog.py
+from praetorian_cli.catalog import Capability
+
+
+def test_capability_normalizes_agora_shape():
+    raw = {
+        'Name': 'brutus', 'Title': 'Brutus', 'Target': ['port'],
+        'Description': 'Credential testing', 'Category': ['credential'],
+        'Surface': 'external', 'RunsOn': 'any', 'Version': '0.2.0',
+        'Executor': 'chariot', 'Integration': False,
+        'Parameters': [{'Name': 'protocol', 'Description': 'svc', 'Type': 'string',
+                        'Default': '', 'Required': False, 'Options': ['ssh', 'rdp']}],
+    }
+    cap = Capability.from_api(raw)
+    assert cap.name == 'brutus'
+    assert cap.title == 'Brutus'
+    assert cap.target == ['port']
+    assert cap.category == ['credential']
+    assert cap.surface == 'external'
+    assert cap.version == '0.2.0'
+    assert cap.parameters[0].name == 'protocol'
+    assert cap.parameters[0].options == ['ssh', 'rdp']
+    assert cap.parameters[0].required is False
+
+
+def test_capability_handles_missing_and_scalar_fields():
+    cap = Capability.from_api({'Name': 'x', 'Category': 'recon', 'Target': 'port'})
+    assert cap.title == 'x'           # falls back to name
+    assert cap.category == ['recon']  # scalar coerced to list
+    assert cap.target == ['port']     # scalar coerced to list
+    assert cap.parameters == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -v`
+Expected: FAIL with `ModuleNotFoundError: praetorian_cli.catalog`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# praetorian_cli/catalog.py
+"""Capability catalog: guard's /capabilities API is the source of truth."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def _as_list(v) -> list:
+    if v is None or v == '':
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def _ci(raw: Dict[str, Any], *keys, default=None):
+    """Case-insensitive get across candidate keys (API uses PascalCase)."""
+    lowered = {k.lower(): v for k, v in raw.items()}
+    for k in keys:
+        if k.lower() in lowered and lowered[k.lower()] not in (None, ''):
+            return lowered[k.lower()]
+    return default
+
+
+@dataclass
+class Parameter:
+    name: str
+    description: str = ''
+    type: str = 'string'
+    default: str = ''
+    required: bool = False
+    options: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_api(cls, raw: Dict[str, Any]) -> 'Parameter':
+        return cls(
+            name=_ci(raw, 'Name', default=''),
+            description=_ci(raw, 'Description', default=''),
+            type=_ci(raw, 'Type', default='string'),
+            default=str(_ci(raw, 'Default', default='') or ''),
+            required=bool(_ci(raw, 'Required', default=False)),
+            options=_as_list(_ci(raw, 'Options', default=[])),
+        )
+
+
+@dataclass
+class Capability:
+    name: str
+    title: str = ''
+    target: List[str] = field(default_factory=list)
+    description: str = ''
+    category: List[str] = field(default_factory=list)
+    surface: str = ''
+    runs_on: str = ''
+    version: str = ''
+    executor: str = ''
+    integration: bool = False
+    parameters: List[Parameter] = field(default_factory=list)
+
+    @classmethod
+    def from_api(cls, raw: Dict[str, Any]) -> 'Capability':
+        name = _ci(raw, 'Name', default='')
+        return cls(
+            name=name,
+            title=_ci(raw, 'Title', default=name),
+            target=_as_list(_ci(raw, 'Target', default=[])),
+            description=_ci(raw, 'Description', default=''),
+            category=_as_list(_ci(raw, 'Category', default=[])),
+            surface=_ci(raw, 'Surface', default=''),
+            runs_on=_ci(raw, 'RunsOn', 'Runs_On', default=''),
+            version=_ci(raw, 'Version', default=''),
+            executor=_ci(raw, 'Executor', default=''),
+            integration=bool(_ci(raw, 'Integration', default=False)),
+            parameters=[Parameter.from_api(p) for p in _as_list(_ci(raw, 'Parameters', default=[]))],
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/catalog.py praetorian_cli/sdk/test/test_catalog.py
+git commit -m "feat(catalog): normalize guard AgoraCapability shape"
+```
+
+---
+
+## Task 2: Fuzzy ranked search + filters
+
+**Files:**
+- Modify: `praetorian_cli/catalog.py`
+- Test: `praetorian_cli/sdk/test/test_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from praetorian_cli.catalog import rank_search
+
+def _caps():
+    from praetorian_cli.catalog import Capability
+    return [
+        Capability.from_api({'Name': 'nuclei', 'Category': 'scanner', 'Surface': 'external',
+                             'Target': ['port'], 'Description': 'vuln scanner', 'Title': 'Nuclei'}),
+        Capability.from_api({'Name': 'nuclei_dast', 'Category': 'scanner', 'Surface': 'external',
+                             'Target': ['webapp'], 'Description': 'dast', 'Title': 'Nuclei DAST'}),
+        Capability.from_api({'Name': 'brutus', 'Category': 'credential', 'Surface': 'internal',
+                             'Target': ['port'], 'Description': 'creds', 'Title': 'Brutus'}),
+    ]
+
+def test_rank_search_exact_before_prefix_before_fuzzy():
+    out = rank_search(_caps(), 'nuclei')
+    assert out[0].name == 'nuclei'          # exact wins
+    assert out[1].name == 'nuclei_dast'     # prefix next
+
+def test_rank_search_typo_tolerant():
+    out = rank_search(_caps(), 'nuclie')    # transposed
+    assert out and out[0].name in ('nuclei', 'nuclei_dast')
+
+def test_rank_search_filters():
+    out = rank_search(_caps(), '', category='credential')
+    assert [c.name for c in out] == ['brutus']
+    out = rank_search(_caps(), '', surface='external', target='port')
+    assert [c.name for c in out] == ['nuclei']
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -k rank_search -v`
+Expected: FAIL with `ImportError: cannot import name 'rank_search'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `praetorian_cli/catalog.py`:
+
+```python
+from difflib import SequenceMatcher
+
+
+def _score(cap: 'Capability', q: str) -> Optional[float]:
+    """Higher is better; None means filtered out."""
+    if not q:
+        return 0.0
+    name = cap.name.lower()
+    hay = ' '.join([name, cap.title.lower(), cap.description.lower(),
+                    ' '.join(cap.category)]).lower()
+    if name == q:
+        return 100.0
+    if name.startswith(q):
+        return 90.0 - (len(name) - len(q)) * 0.1
+    if q in hay:
+        return 70.0
+    ratio = SequenceMatcher(None, q, name).ratio()
+    if ratio >= 0.6:
+        return 40.0 + ratio * 10
+    return None
+
+
+def rank_search(caps, query='', *, category='', surface='', target='', tag=''):
+    q = (query or '').lower().strip()
+    out = []
+    for cap in caps:
+        if category and category not in cap.category:
+            continue
+        if surface and cap.surface != surface:
+            continue
+        if target and target not in cap.target:
+            continue
+        if tag and tag not in cap.category and tag not in cap.target:
+            continue
+        s = _score(cap, q)
+        if s is None:
+            continue
+        out.append((s, cap))
+    out.sort(key=lambda t: (-t[0], t[1].name))
+    return [c for _, c in out]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -k rank_search -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/catalog.py praetorian_cli/sdk/test/test_catalog.py
+git commit -m "feat(catalog): fuzzy ranked search with category/surface/target/tag filters"
+```
+
+---
+
+## Task 3: Catalog resolution — live → cache → bundled
+
+**Files:**
+- Modify: `praetorian_cli/catalog.py`
+- Create: `praetorian_cli/modules/capabilities_snapshot.json`
+- Modify: `MANIFEST.in`
+- Test: `praetorian_cli/sdk/test/test_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import json
+from praetorian_cli.catalog import CapabilityCatalog
+
+class _FakeSDK:
+    def __init__(self, caps, fail=False):
+        self._caps = caps; self._fail = fail
+        class _C:
+            def list(inner, name='', target='', executor=''):
+                if self._fail:
+                    raise RuntimeError('network down')
+                return (self._caps, None)
+        self.capabilities = _C()
+
+def test_catalog_live_then_cache(tmp_path):
+    cache = tmp_path / 'cap-cache.json'
+    snap = tmp_path / 'snap.json'; snap.write_text('{"capabilities": []}')
+    sdk = _FakeSDK([{'Name': 'brutus', 'Category': 'credential'}])
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    caps = cat.all()
+    assert [c.name for c in caps] == ['brutus']
+    assert cat.source == 'live'
+    assert cache.exists()
+
+def test_catalog_falls_back_to_cache_when_api_fails(tmp_path):
+    cache = tmp_path / 'cap-cache.json'
+    cache.write_text(json.dumps({'capabilities': [{'Name': 'nuclei'}]}))
+    snap = tmp_path / 'snap.json'; snap.write_text('{"capabilities": []}')
+    sdk = _FakeSDK([], fail=True)
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    caps = cat.all()
+    assert [c.name for c in caps] == ['nuclei']
+    assert cat.source.startswith('cached')
+
+def test_catalog_falls_back_to_bundled(tmp_path):
+    cache = tmp_path / 'missing.json'
+    snap = tmp_path / 'snap.json'
+    snap.write_text(json.dumps({'capabilities': [{'Name': 'titus'}]}))
+    sdk = _FakeSDK([], fail=True)
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    assert [c.name for c in cat.all()] == ['titus']
+    assert cat.source == 'bundled'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -k catalog -v`
+Expected: FAIL with `ImportError: cannot import name 'CapabilityCatalog'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `praetorian_cli/catalog.py`:
+
+```python
+import os
+import time
+import tempfile
+
+_PRAETORIAN_DIR = os.path.join(os.path.expanduser('~'), '.praetorian')
+DEFAULT_CACHE_PATH = os.path.join(_PRAETORIAN_DIR, 'capabilities-cache.json')
+DEFAULT_BUNDLED_PATH = os.path.join(
+    os.path.dirname(__file__), 'modules', 'capabilities_snapshot.json')
+CACHE_TTL_SECONDS = 86400
+
+
+def _atomic_write_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+class CapabilityCatalog:
+    def __init__(self, sdk, cache_path=DEFAULT_CACHE_PATH, bundled_path=DEFAULT_BUNDLED_PATH):
+        self.sdk = sdk
+        self.cache_path = cache_path
+        self.bundled_path = bundled_path
+        self._caps: Optional[List[Capability]] = None
+        self.source = ''
+
+    def _cache_stale(self) -> bool:
+        if not os.path.isfile(self.cache_path):
+            return True
+        return (time.time() - os.path.getmtime(self.cache_path)) > CACHE_TTL_SECONDS
+
+    def refresh(self, force=False) -> bool:
+        if not force and not self._cache_stale():
+            return False
+        try:
+            raw, _ = self.sdk.capabilities.list()
+            caps = raw if isinstance(raw, list) else raw.get('capabilities', raw.get('data', []))
+            _atomic_write_json(self.cache_path, {'capabilities': caps})
+            self._caps = [Capability.from_api(c) for c in caps]
+            self.source = 'live'
+            return True
+        except Exception:
+            return False
+
+    def _load_file(self, path):
+        with open(path) as f:
+            data = json.load(f)
+        return data.get('capabilities', data) if isinstance(data, dict) else data
+
+    def all(self) -> List[Capability]:
+        if self._caps is not None:
+            return self._caps
+        if self.refresh():
+            return self._caps
+        # cache
+        if os.path.isfile(self.cache_path):
+            try:
+                age = int((time.time() - os.path.getmtime(self.cache_path)) / 3600)
+                self._caps = [Capability.from_api(c) for c in self._load_file(self.cache_path)]
+                self.source = f'cached ({age}h old)'
+                return self._caps
+            except (json.JSONDecodeError, OSError):
+                pass
+        # bundled
+        if os.path.isfile(self.bundled_path):
+            try:
+                self._caps = [Capability.from_api(c) for c in self._load_file(self.bundled_path)]
+                self.source = 'bundled'
+                return self._caps
+            except (json.JSONDecodeError, OSError):
+                pass
+        self._caps = []
+        self.source = 'empty'
+        return self._caps
+
+    def get(self, name: str) -> Optional[Capability]:
+        n = name.lower()
+        for c in self.all():
+            if c.name.lower() == n:
+                return c
+        return None
+
+    def search(self, query='', **filters) -> List[Capability]:
+        return rank_search(self.all(), query, **filters)
+```
+
+- [ ] **Step 4: Create the bundled snapshot**
+
+Run this to generate the snapshot from the live API (one-time, requires auth):
+
+```bash
+guard run capabilities --json > /tmp/caps.json 2>/dev/null || true
+python -c "import json,sys; d=json.load(open('/tmp/caps.json')); caps=d if isinstance(d,list) else d.get('capabilities',d.get('data',[])); json.dump({'capabilities':caps}, open('praetorian_cli/modules/capabilities_snapshot.json','w'), indent=2)"
+```
+
+If no auth is available, create a minimal valid placeholder so tests/packaging pass:
+
+```bash
+printf '{"capabilities": []}\n' > praetorian_cli/modules/capabilities_snapshot.json
+```
+
+- [ ] **Step 5: Add to MANIFEST.in**
+
+Add this line to `MANIFEST.in`:
+
+```
+include praetorian_cli/modules/capabilities_snapshot.json
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_catalog.py -v`
+Expected: PASS (all catalog tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add praetorian_cli/catalog.py praetorian_cli/modules/capabilities_snapshot.json MANIFEST.in praetorian_cli/sdk/test/test_catalog.py
+git commit -m "feat(catalog): live->cache->bundled resolution with graceful offline fallback"
+```
+
+---
+
+## Task 4: Migrate registry.json to v2 slim install-manifest
+
+**Files:**
+- Modify: `modules/registry.json`
+- Modify: `praetorian_cli/registry.py`
+- Test: `praetorian_cli/sdk/test/test_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to praetorian_cli/sdk/test/test_registry.py
+from praetorian_cli.registry import get_registry
+
+def test_manifest_exposes_capability_alias_and_local_only(monkeypatch, tmp_path):
+    import praetorian_cli.registry as reg_mod
+    manifest = tmp_path / 'registry.json'
+    manifest.write_text('''{
+      "version": 2,
+      "modules": {
+        "brutus": {"repo": "praetorian-inc/brutus", "binary_pattern": "brutus-{os}-{arch}*", "plugin": "brutus"},
+        "pius": {"repo": "praetorian-inc/pius", "capability": "pius_discovery"},
+        "titus": {"repo": "praetorian-inc/titus", "local_only": true}
+      }
+    }''')
+    monkeypatch.setattr(reg_mod, 'BUNDLED_REGISTRY_PATH', str(manifest))
+    monkeypatch.setattr(reg_mod, 'CACHE_PATH', str(tmp_path / 'cache-none.json'))
+    reg_mod._registry = None
+    reg = get_registry()
+    assert reg.get_capability_name('pius') == 'pius_discovery'
+    assert reg.get_capability_name('brutus') == 'brutus'   # defaults to name
+    assert reg.is_local_only('titus') is True
+    assert reg.is_local_only('brutus') is False
+    assert reg.get_binary_pattern('brutus') == 'brutus-{os}-{arch}*'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_registry.py -k manifest -v`
+Expected: FAIL with `AttributeError: 'ModuleRegistry' object has no attribute 'get_capability_name'`.
+
+- [ ] **Step 3: Add manifest accessors to registry.py**
+
+Add these methods to `ModuleRegistry` (after `get_module`):
+
+```python
+    def get_capability_name(self, name: str) -> str:
+        """The guard capability a module maps to (defaults to its own name)."""
+        mod = self.get_module(name) or {}
+        return mod.get('capability', name.lower())
+
+    def is_local_only(self, name: str) -> bool:
+        mod = self.get_module(name) or {}
+        return bool(mod.get('local_only', False))
+
+    def get_binary_pattern(self, name: str) -> Optional[str]:
+        mod = self.get_module(name) or {}
+        return mod.get('binary_pattern')
+
+    def get_plugin_name(self, name: str) -> Optional[str]:
+        mod = self.get_module(name) or {}
+        return mod.get('plugin')
+```
+
+Also update `get_installable_tools` to tolerate the slim manifest (no `description`):
+
+```python
+    def get_installable_tools(self) -> Dict[str, Dict]:
+        modules = self.get_modules()
+        return {
+            name: {"repo": mod.get("repo", ""), "description": mod.get("description", "")}
+            for name, mod in modules.items()
+        }
+```
+
+- [ ] **Step 4: Migrate `modules/registry.json` to v2**
+
+Rewrite `modules/registry.json` as the slim install-manifest. For each currently-listed tool, keep `repo`, add `binary_pattern` (default `{name}-{os}-{arch}*`), and `plugin` (the existing plugin key from `runners/local.py` `TOOL_PLUGINS`). Add `capability` only where the guard name differs (`pius` → `pius_discovery`). Tag the 8 non-guard tools (`titus, nerva, gato, cato, florian, aurelian, nero`, and `pius` if it has no capability) with `"local_only": true`. Example shape:
+
+```json
+{
+  "version": 2,
+  "modules": {
+    "brutus":   {"repo": "praetorian-inc/brutus",   "binary_pattern": "brutus-{os}-{arch}*",   "plugin": "brutus"},
+    "nuclei":   {"repo": "praetorian-inc/nuclei",   "binary_pattern": "nuclei-{os}-{arch}*",   "plugin": "nuclei"},
+    "trajan":   {"repo": "praetorian-inc/trajan",   "binary_pattern": "trajan-{os}-{arch}*",   "plugin": "trajan"},
+    "julius":   {"repo": "praetorian-inc/julius",   "binary_pattern": "julius-{os}-{arch}*",   "plugin": "julius"},
+    "augustus": {"repo": "praetorian-inc/augustus", "binary_pattern": "augustus-{os}-{arch}*", "plugin": "augustus"},
+    "hadrian":  {"repo": "praetorian-inc/hadrian",  "binary_pattern": "hadrian-{os}-{arch}*",  "plugin": "urltarget"},
+    "vespasian":{"repo": "praetorian-inc/vespasian","binary_pattern": "vespasian-{os}-{arch}*","plugin": "scantarget"},
+    "constantine":{"repo": "praetorian-inc/constantine","binary_pattern": "constantine-{os}-{arch}*","plugin": "scantarget"},
+    "caligula": {"repo": "praetorian-inc/caligula", "binary_pattern": "caligula-{os}-{arch}*", "plugin": "scantarget"},
+    "titus":    {"repo": "praetorian-inc/titus",    "binary_pattern": "titus-{os}-{arch}*",    "plugin": "titus", "local_only": true},
+    "nerva":    {"repo": "praetorian-inc/nerva",    "binary_pattern": "nerva-{os}-{arch}*",    "plugin": "nerva", "local_only": true},
+    "gato":     {"repo": "praetorian-inc/gato",     "binary_pattern": "gato-{os}-{arch}*",     "plugin": "gato", "local_only": true},
+    "cato":     {"repo": "praetorian-inc/cato",     "binary_pattern": "cato-{os}-{arch}*",     "plugin": "urltarget", "local_only": true},
+    "florian":  {"repo": "praetorian-inc/florian",  "binary_pattern": "florian-{os}-{arch}*",  "plugin": "urltarget", "local_only": true},
+    "aurelian": {"repo": "praetorian-inc/aurelian", "binary_pattern": "aurelian-{os}-{arch}*", "plugin": "scantarget", "local_only": true},
+    "nero":     {"repo": "praetorian-inc/nero",     "binary_pattern": "nero-{os}-{arch}*",     "plugin": "nerva", "local_only": true},
+    "pius":     {"repo": "praetorian-inc/pius",     "binary_pattern": "pius-{os}-{arch}*",     "plugin": "nerva", "capability": "pius_discovery"}
+  }
+}
+```
+
+Note: verify each `local_only` tool against guard before finalizing (grep guard for the name); if a tool turns out to be a real guard capability under a different name, give it a `capability` alias instead of `local_only`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_registry.py -v`
+Expected: PASS (new + existing registry tests). Fix any existing test that assumed `description` lives in the manifest — descriptions now come from the catalog.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modules/registry.json praetorian_cli/registry.py praetorian_cli/sdk/test/test_registry.py
+git commit -m "feat(registry): migrate registry.json to v2 slim install-manifest"
+```
+
+---
+
+## Task 5: SHA-256 verification + binary_pattern + uninstall in local runner
+
+**Files:**
+- Modify: `praetorian_cli/runners/local.py`
+- Test: `praetorian_cli/sdk/test/ui/` (new `test_local_runner.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# praetorian_cli/sdk/test/test_local_runner.py
+import os
+from praetorian_cli.runners import local
+
+def test_uninstall_removes_binary_and_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    binp = tmp_path / 'titus'
+    binp.write_text('#!/bin/sh\n'); os.chmod(binp, 0o755)
+    removed = {}
+    class _Reg:
+        def remove_version(self, n): removed['n'] = n
+    monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
+    assert local.uninstall_tool('titus') is True
+    assert not binp.exists()
+    assert removed['n'] == 'titus'
+
+def test_uninstall_missing_returns_false(tmp_path, monkeypatch):
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    class _Reg:
+        def remove_version(self, n): pass
+    monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
+    assert local.uninstall_tool('ghost') is False
+
+def test_verify_sha256_matches(tmp_path):
+    f = tmp_path / 'b'; f.write_bytes(b'hello')
+    import hashlib
+    digest = hashlib.sha256(b'hello').hexdigest()
+    assert local.verify_sha256(str(f), digest) is True
+    assert local.verify_sha256(str(f), 'deadbeef') is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: FAIL with `AttributeError: module ... has no attribute 'uninstall_tool'`.
+
+- [ ] **Step 3: Implement uninstall + verify in local.py**
+
+Add to `praetorian_cli/runners/local.py`:
+
+```python
+import hashlib
+
+
+def verify_sha256(path: str, expected: str) -> bool:
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            h.update(chunk)
+    return h.hexdigest() == (expected or '').lower().strip()
+
+
+def uninstall_tool(tool_name: str) -> bool:
+    """Remove an installed binary from INSTALL_DIR and its version record."""
+    from praetorian_cli.registry import get_registry
+    path = os.path.join(INSTALL_DIR, tool_name)
+    existed = os.path.isfile(path)
+    if existed:
+        os.remove(path)
+    get_registry().remove_version(tool_name)
+    return existed
+```
+
+Update `install_tool` to use the manifest `binary_pattern` when present (locate the `gh release download` pattern construction and replace the hardcoded `f'{tool_name}-{os}-{arch}*'` with):
+
+```python
+    from praetorian_cli.registry import get_registry
+    pattern = get_registry().get_binary_pattern(tool_name)
+    if pattern:
+        asset_pattern = pattern.replace('{os}', os_name).replace('{arch}', arch)
+    else:
+        asset_pattern = f'{tool_name}-{os_name}-{arch}*'
+```
+
+(Use the existing local variable names for os/arch returned by `_detect_platform()`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_local_runner.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/runners/local.py praetorian_cli/sdk/test/test_local_runner.py
+git commit -m "feat(local): uninstall_tool, sha256 verify, manifest-driven binary_pattern"
+```
+
+---
+
+## Task 6: Catalog-backed `guard module` CLI + sync/uninstall + parallel install
+
+**Files:**
+- Modify: `praetorian_cli/handlers/module.py`
+- Test: `praetorian_cli/sdk/test/test_module_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to praetorian_cli/sdk/test/test_module_cli.py
+from click.testing import CliRunner
+from unittest.mock import patch
+from praetorian_cli.handlers.chariot import chariot
+
+def _fake_caps():
+    return [{'Name': 'brutus', 'Title': 'Brutus', 'Category': ['credential'],
+             'Surface': 'external', 'Target': ['port'], 'Description': 'creds',
+             'Version': '0.2.0', 'Executor': 'chariot', 'Parameters': []}]
+
+@patch('praetorian_cli.catalog.CapabilityCatalog.all')
+def test_module_search_json_uses_catalog(mock_all):
+    from praetorian_cli.catalog import Capability
+    mock_all.return_value = [Capability.from_api(c) for c in _fake_caps()]
+    runner = CliRunner()
+    res = runner.invoke(chariot, ['module', 'search', 'brutus', '--json'],
+                        obj=_make_obj())
+    assert res.exit_code == 0
+    import json
+    data = json.loads(res.output)
+    assert data[0]['name'] == 'brutus'
+    assert data[0]['version'] == '0.2.0'
+```
+
+(Reuse the existing `_make_obj()` / SDK-mock helper already present in `test_module_cli.py`; if none exists, mirror the fixture pattern used by other CLI tests in that file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_module_cli.py -k catalog -v`
+Expected: FAIL (search still reads `get_registry().search_modules`, output shape differs / no `version` from catalog).
+
+- [ ] **Step 3: Rewrite module.py commands to use the catalog**
+
+In `praetorian_cli/handlers/module.py`, replace the registry-driven `search`, `list`, `info`, `options` bodies with catalog-driven equivalents. Construct the catalog once per command:
+
+```python
+def _catalog(sdk):
+    from praetorian_cli.catalog import CapabilityCatalog
+    return CapabilityCatalog(sdk)
+```
+
+Rewrite `search` to merge catalog results with install status + local-only tagging:
+
+```python
+@module.command("search")
+@cli_handler
+@click.argument("query", default="")
+@click.option("--category", "-c", default="")
+@click.option("--surface", default="")
+@click.option("--target", default="")
+@click.option("--tag", default="")
+@click.option("--installed", is_flag=True, default=False)
+@click.option("--json", "as_json", is_flag=True, default=False)
+def search(sdk, query, category, surface, target, tag, installed, as_json):
+    """Search available modules (fuzzy, ranked)."""
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+    cat = _catalog(sdk)
+    reg = get_registry()
+    results = cat.search(query, category=category, surface=surface, target=target, tag=tag)
+    inst = list_installed()
+    rows = []
+    for c in results:
+        name = c.name
+        ver = reg.get_version(name)
+        is_inst = name in inst
+        if installed and not is_inst:
+            continue
+        rows.append({
+            "name": name, "title": c.title, "category": c.category,
+            "surface": c.surface, "target": c.target, "description": c.description,
+            "version": c.version, "executor": c.executor,
+            "installed": is_inst, "local_only": reg.is_local_only(name),
+            "installed_version": ver["version"] if ver else None,
+        })
+    if as_json:
+        print_json(rows)
+        return
+    if cat.source and cat.source != 'live':
+        click.echo(f"(catalog: {cat.source})", err=True)
+    _render_module_table(rows)
+```
+
+Add a shared table renderer `_render_module_table(rows)` (plain `click.echo` columns, marking `[local-only]` where `row['local_only']`). Rewrite `info`/`options`/`list` analogously (info pulls `c.parameters` for the options table). Add two new commands:
+
+```python
+@module.command("uninstall")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False)
+def uninstall(sdk, name, as_json):
+    """Remove an installed module binary."""
+    from praetorian_cli.runners.local import uninstall_tool
+    removed = uninstall_tool(name.lower())
+    if as_json:
+        print_json({"name": name.lower(), "removed": removed})
+    else:
+        click.echo(f"{name}: {'removed' if removed else 'not installed'}")
+
+
+@module.command("sync")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False)
+def sync(sdk, as_json):
+    """Force-refresh the capability catalog from the backend."""
+    cat = _catalog(sdk)
+    ok = cat.refresh(force=True)
+    n = len(cat.all())
+    if as_json:
+        print_json({"refreshed": ok, "count": n, "source": cat.source})
+    else:
+        click.echo(f"Catalog {'refreshed' if ok else 'unchanged'}: {n} capabilities ({cat.source}).")
+```
+
+Make `install all` parallel with a Rich progress bar:
+
+```python
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+    # inside the `name == "all"` branch, replace the sequential loop:
+    targets = [t for t in sorted(INSTALLABLE_TOOLS) if force or not is_installed(t)]
+    with Progress(SpinnerColumn(), TextColumn("{task.description}")) as prog:
+        tasks = {t: prog.add_task(f"{t}: queued", total=None) for t in targets}
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futs = {pool.submit(install_tool, t, force): t for t in targets}
+            for fut in as_completed(futs):
+                t = futs[fut]
+                try:
+                    path = fut.result()
+                    prog.update(tasks[t], description=f"{t}: installed")
+                    results.append({"name": t, "status": "installed", "path": path})
+                except Exception as e:
+                    prog.update(tasks[t], description=f"{t}: FAILED {e}")
+                    results.append({"name": t, "status": "error", "error": str(e)})
+```
+
+(Guard the Rich import path so `--json` mode stays quiet: when `as_json`, skip the Progress context and just run the pool.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_module_cli.py -v`
+Expected: PASS. Update any existing module-CLI test that asserted the old registry-based output shape.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/handlers/module.py praetorian_cli/sdk/test/test_module_cli.py
+git commit -m "feat(module): catalog-backed search/info/options + sync/uninstall + parallel install"
+```
+
+---
+
+## Task 7: Console module commands + numbered results via shared catalog
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/commands/tools.py`
+- Test: `praetorian_cli/sdk/test/ui/test_console_modules.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to praetorian_cli/sdk/test/ui/test_console_modules.py
+def test_console_module_info_accepts_result_number(console, capsys):
+    # console fixture mirrors existing tests in this file
+    console._cmd_module_search(['scanner', '--category', 'scanner'])
+    # after a search, "info 1" resolves to the first result
+    console._cmd_module_info(['1'])
+    out = capsys.readouterr().out
+    assert 'Category' in out  # info panel rendered, no "Unknown module"
+```
+
+(Use the same `console` fixture and Rich-capture pattern already in `test_console_modules.py`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_modules.py -k result_number -v`
+Expected: FAIL ("Unknown module: 1") — numbered lookup not wired.
+
+- [ ] **Step 3: Wire catalog + numbered results into console**
+
+In `tools.py`, change `_cmd_module_search`/`_cmd_module_info`/`_cmd_module_update` to build a `CapabilityCatalog(self.sdk)` and use `cat.search(...)`/`cat.get(...)`. Persist ordered names in `self._module_list` during search. At the top of `_cmd_module_info`, resolve a numeric arg:
+
+```python
+        if args and args[0].isdigit():
+            idx = int(args[0]) - 1
+            if 0 <= idx < len(getattr(self, '_module_list', [])):
+                args = [self._module_list[idx]] + list(args[1:])
+```
+
+Render the info panel from the `Capability` fields (title/version/surface/target/executor/description) and a parameters table from `cap.parameters` (name/type/required/default/options). Tag `[local-only]` rows in search using `get_registry().is_local_only(name)`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_modules.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/tools.py praetorian_cli/sdk/test/ui/test_console_modules.py
+git commit -m "feat(console): catalog-backed module commands with numbered-result lookup"
+```
+
+---
+
+## Task 8: Metasploit use/set/options/run with live params + tab-completion
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/console.py`
+- Modify: `praetorian_cli/ui/console/commands/tools.py`
+- Test: `praetorian_cli/sdk/test/ui/test_console_modules.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_options_populated_from_live_params(console, capsys):
+    console._cmd_use(['brutus'])
+    console._cmd_options([])
+    out = capsys.readouterr().out
+    assert 'protocol' in out          # param name from live capability
+    assert 'required' in out.lower()  # required column rendered
+
+def test_set_rejects_unknown_param(console, capsys):
+    console._cmd_use(['brutus'])
+    console._cmd_set(['nonsense', 'x'])
+    out = capsys.readouterr().out
+    assert 'unknown' in out.lower() or 'no such option' in out.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_modules.py -k "options_populated or rejects_unknown" -v`
+Expected: FAIL (options not sourced from live params; set not validated).
+
+- [ ] **Step 3: Source params from the catalog in use/options/set**
+
+In `_cmd_use`, store the resolved `Capability` (`self._selected_cap = cat.get(name)`) alongside the existing selection state. In `_cmd_options`, render `self._selected_cap.parameters`. In `_cmd_set`, validate the key against `{p.name for p in self._selected_cap.parameters}` and against `p.options` (enum) when non-empty; print an error otherwise.
+
+- [ ] **Step 4: Extend tab-completion**
+
+In `console.py`, replace the flat `WordCompleter(CONSOLE_COMMANDS)` with a `NestedCompleter` (from `prompt_toolkit.completion`) that maps `module` → `{search, info, options, install, uninstall, update, sync, list, installed}` and `use`/`info`/`install`/`uninstall` → live module names. Build the name list lazily from `CapabilityCatalog(self.sdk).all()` (guard with try/except so completion never crashes the prompt; fall back to `CONSOLE_COMMANDS`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_modules.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add praetorian_cli/ui/console/console.py praetorian_cli/ui/console/commands/tools.py praetorian_cli/sdk/test/ui/test_console_modules.py
+git commit -m "feat(console): live-param options/set validation + nested tab-completion"
+```
+
+---
+
+## Task 9: MCP list_modules/module_info via catalog
+
+**Files:**
+- Modify: `praetorian_cli/sdk/mcp_server.py`
+- Test: `praetorian_cli/sdk/test/` (extend an existing MCP test or add `test_mcp_modules.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# praetorian_cli/sdk/test/test_mcp_modules.py
+import asyncio
+from unittest.mock import patch
+from praetorian_cli.catalog import Capability
+
+def test_list_modules_returns_all_capabilities():
+    caps = [Capability.from_api({'Name': 'brutus', 'Category': ['credential']}),
+            Capability.from_api({'Name': 'nuclei', 'Category': ['scanner']})]
+    with patch('praetorian_cli.catalog.CapabilityCatalog.all', return_value=caps):
+        from praetorian_cli.sdk.mcp_server import _handle_module_tool  # adjust import to actual symbol
+        result = asyncio.get_event_loop().run_until_complete(
+            _handle_module_tool('list_modules', {}, sdk=_mcp_sdk_stub()))
+        names = [m['name'] for m in result]
+        assert set(names) == {'brutus', 'nuclei'}
+```
+
+(Adjust the import/signature to match the real `_handle_module_tool` in `mcp_server.py`; reuse any existing MCP sdk stub.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/test_mcp_modules.py -v`
+Expected: FAIL (still reads `reg.search_modules`, returns only manifest entries).
+
+- [ ] **Step 3: Switch the MCP module handlers to the catalog**
+
+In `mcp_server.py`, change the `list_modules` and `module_info` branches of `_handle_module_tool` to build `CapabilityCatalog(sdk)` and use `cat.search(...)` / `cat.get(...)`, merging install status from `list_installed()` and version from `get_registry().get_version()`. Leave `install_module`/`run_module` unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/test_mcp_modules.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/sdk/mcp_server.py praetorian_cli/sdk/test/test_mcp_modules.py
+git commit -m "feat(mcp): list_modules/module_info reflect live guard capabilities"
+```
+
+---
+
+## Task 10: Backward-compat + full suite
+
+**Files:**
+- Test only.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pytest praetorian_cli/sdk/test/ -q`
+Expected: all green. Investigate any failure where an existing test assumed registry-sourced descriptions; update it to source from the catalog (descriptions now live in the catalog, not the manifest).
+
+- [ ] **Step 2: Manual smoke (requires auth)**
+
+```bash
+guard run list                 # unchanged output, install status intact
+guard module sync              # refreshes catalog
+guard module search scanner    # fuzzy/filtered, shows local-only tags
+guard module info brutus       # live params table
+guard module install all --json | head
+```
+
+- [ ] **Step 3: Commit any test fixups**
+
+```bash
+git add -A && git commit -m "test: align suite with catalog-sourced metadata"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** three-layer resolution (Task 3), slim manifest + local_only + capability alias (Task 4), all `guard module` commands incl. sync/uninstall + parallel + sha256 (Tasks 5–6), console + Metasploit flow + completion (Tasks 7–8), MCP parity (Task 9), backward compat (Task 10). SHA-256 wiring into `install_tool` depends on releases publishing checksums; if absent, `verify_sha256` is exposed but skipped with a warning (noted in Task 5 — extend `install_tool` to call it only when a checksum asset is found).
+- **Type consistency:** `Capability`/`Parameter` fields and `CapabilityCatalog.{all,get,search,refresh,source}` are used identically across Tasks 1–9.
+- **No placeholders:** real code/tests in each step; manifest values to be verified against guard in Task 4 Step 4.

--- a/docs/superpowers/specs/2026-05-28-module-system-parity-design.md
+++ b/docs/superpowers/specs/2026-05-28-module-system-parity-design.md
@@ -1,0 +1,171 @@
+# Module System — Live-API Parity + Metasploit-grade UX
+
+**Date:** 2026-05-28
+**Branch:** `feat/module-system` (PR #226)
+**Linear:** 10T-277 (follow-up)
+**Status:** Design — pending implementation plan
+
+## Problem
+
+The CLI ships a hand-curated `modules/registry.json` of 17 Roman-emperor-named
+tools. Guard's backend defines **63 capabilities** canonically
+(`backend/pkg/tasks/loader.go` + `pkg/compute/registries/agora.go`), with a
+richer schema (`AgoraCapability`). The two have drifted:
+
+- **Match (9):** brutus, nuclei, trajan, julius, augustus, hadrian, vespasian,
+  constantine, caligula.
+- **In CLI but not a guard capability (8):** titus, nerva, gato, cato, florian,
+  aurelian, nero, pius (guard has `pius_discovery`).
+- **Schema mismatch:** CLI stores `{repo, options{type,description,required}}`;
+  guard exposes `AgoraCapability` (Title, Target[], Category, Surface, RunsOn,
+  Version, Executor, Integration, Parameters[]).
+
+Hand-maintaining the registry guarantees ongoing drift. The CLI should reflect
+what guard actually offers, and the module UX should be as polished and
+streamlined ("Metasploit-grade") as possible.
+
+## Goals
+
+1. **1:1 parity with guard** for capability metadata — guard's backend is the
+   single source of truth.
+2. **Streamlined discovery/install/run UX** across CLI, interactive console, and
+   MCP, all backed by one catalog and one renderer.
+3. **Backward compatibility** — existing `guard run install/tool/list/installed`
+   keep working.
+4. **Graceful offline behavior** — module metadata commands answer even with no
+   network / no auth.
+
+## Non-Goals (YAGNI)
+
+- Inter-tool dependency resolution.
+- Per-engagement module profiles / workspaces.
+- GPG signing of binaries (SHA-256 checksum only).
+- Auto-run on install.
+
+## Architecture
+
+### Data sources — three-layer resolution
+
+```
+live API (sdk.capabilities.list)
+   → ~/.praetorian/capabilities-cache.json  (TTL, e.g. 24h)
+   → bundled snapshot shipped with the CLI
+```
+
+**`CapabilityCatalog`** (new, replaces the metadata role of `registry.py`):
+
+- `refresh(force=False) -> bool` — fetch all capabilities via
+  `sdk.capabilities.list()`, normalize the `AgoraCapability` shape, write the
+  cache atomically (reuse the atomic-write pattern already in `registry.py`).
+- `all() -> list[Capability]` — resolve from cache; refresh if stale; fall back
+  to bundled snapshot when API + cache are both unavailable.
+- `get(name) -> Capability | None` — case-insensitive lookup.
+- `search(query, *, category, surface, target, tag, installed) -> list` —
+  fuzzy + ranked matching with filters (see UX below).
+- Normalized `Capability` fields mirror guard: `name`, `title`, `target` (list),
+  `description`, `category`, `surface`, `runs_on`, `version`, `executor`,
+  `integration`, `parameters` (each: `name`, `description`, `type`, `default`,
+  `required`, `options`/enum).
+
+Offline detection: a failed/!ok API call or missing auth → use cache, then
+bundled snapshot, and annotate the result source (`live` / `cached (age)` /
+`bundled`) so commands can warn the user (to stderr; never pollutes `--json`).
+
+### Install source — slim install-manifest
+
+The API carries no repo/binary field, so install source stays local.
+`modules/registry.json` shrinks to a pure **install-manifest**:
+
+```json
+{
+  "version": 2,
+  "modules": {
+    "brutus":   { "repo": "praetorian-inc/brutus",   "binary_pattern": "brutus-{os}-{arch}*",   "plugin": "brutus" },
+    "pius":     { "repo": "praetorian-inc/pius", "capability": "pius_discovery", "local_only": false },
+    "titus":    { "repo": "praetorian-inc/titus",     "local_only": true },
+    "nerva":    { "repo": "praetorian-inc/nerva",     "local_only": true }
+  }
+}
+```
+
+- `repo` / `binary_pattern` / `plugin` — install + arg-building info only.
+- `capability` (optional) — maps an install name to its guard capability when
+  they differ (`pius` → `pius_discovery`).
+- `local_only: true` — tools with no guard capability (titus, nerva, gato, cato,
+  florian, aurelian, nero, and pius if it has no capability). Each is verified
+  against guard before tagging; listings mark them `[local-only]`.
+
+### Merge model
+
+Listings = **union** of (a) live guard capabilities and (b) install-manifest
+entries, keyed by name (via `capability` alias where present). Each row carries:
+metadata source (guard vs local-only), install status + version (from
+`~/.praetorian/versions.json`), and installability (has a manifest entry).
+
+## CLI / Console commands
+
+Both surfaces call the same `CapabilityCatalog` and a shared renderer so output
+is identical.
+
+| Command | Behavior |
+|---|---|
+| `search [query]` | Fuzzy + ranked, typo-tolerant. Filters: `--category --surface --target --tag --installed`. Numbered results referencable by `#`. |
+| `info <name\|#>` | Rich panel: title, version, surface, target types, executor, full parameter table (type/default/required/enum) from live API. Accepts a result number from the last search. |
+| `options <name>` | Parameter table only. |
+| `list` | All capabilities (search with empty query). |
+| `installed` | Locally installed binaries + versions. |
+| `install <name\|all> [--force]` | Rich progress bars; **parallel** for `all`; optional **SHA-256** verification of the downloaded asset; post-install summary. |
+| `uninstall <name>` | Remove binary + version record (`registry.remove_version`). |
+| `update [name\|all]` | Compare installed vs latest release tag; reinstall if newer; show `old → new`. |
+| `sync` | Force-refresh the capability catalog from the API; report staleness. |
+
+- `--json` on every command; notices/progress to stderr so JSON stays clean.
+- Fuzzy ranking: exact name > prefix > substring > fuzzy (bounded edit distance),
+  tie-broken by name. Pure-Python, no new heavy dependency.
+
+## Metasploit interactive flow (console)
+
+Polish the existing `use`/`set`/`options`/`run`/`back` (`console.py:192-199`,
+selected-tool mode at `:263`):
+
+- `use <module|#>` enters module context; prompt shows `guard (brutus) >`.
+- `options` / `show options` auto-populated from **live API parameters** —
+  required flagged, defaults shown, enum hints listed.
+- `set <param> <value>` / `unset` — validated against the parameter's type/enum.
+- `run` / `exploit` — execute with set options; local if installed, else remote.
+- **Tab-completion** extended to subcommands and live module names (currently
+  only top-level verbs complete via the hardcoded `CONSOLE_COMMANDS`).
+
+## MCP parity
+
+`list_modules` / `module_info` resolve through `CapabilityCatalog`, so Claude
+sees all guard capabilities (not 17). `install_module` / `run_module` keep their
+current contract.
+
+## Error handling
+
+- API/network failures degrade to cache → bundled snapshot with a clear source
+  annotation, never an opaque crash.
+- Install failures (missing `gh`, no matching asset, checksum mismatch) produce
+  specific, actionable messages; `install all` reports per-tool status and never
+  aborts the batch on one failure.
+
+## Testing
+
+- `CapabilityCatalog`: live/cache/bundled resolution, staleness, normalization,
+  fuzzy ranking, filters. Mock `sdk.capabilities.list`.
+- Install-manifest: merge with live caps, `local_only` tagging, `capability`
+  aliasing (`pius` → `pius_discovery`).
+- CLI commands: `--json` shape, numbered-result resolution, parallel install
+  status aggregation, SHA-256 mismatch path.
+- Console: module subcommand dispatch, `use/set/options/run` with API params,
+  tab-completion sources.
+- Backward compat: `guard run list/installed/tool` unchanged.
+
+## Migration / compatibility
+
+- `registry.py` keeps `record_version/get_version/remove_version` and the
+  install-manifest loader; its metadata responsibilities move to
+  `CapabilityCatalog`. `INSTALLABLE_TOOLS` / `TOOL_ALIASES` now derive from the
+  manifest + catalog.
+- Bump `registry.json` `version` to 2; ship a bundled capability snapshot.

--- a/modules/registry.json
+++ b/modules/registry.json
@@ -1,187 +1,96 @@
 {
-  "version": 1,
+  "version": 2,
   "modules": {
     "brutus": {
       "repo": "praetorian-inc/brutus",
-      "description": "Credential attacks across 20+ protocols (SSH, RDP, FTP, SMB, etc.)",
-      "category": "credential",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {
-        "protocol": {"type": "string", "description": "Target protocol (auto-detected from port)", "required": false},
-        "usernames": {"type": "string", "description": "Username file or comma-separated list", "required": false},
-        "passwords": {"type": "string", "description": "Password file or comma-separated list", "required": false}
-      },
-      "args_template": ["--target", "{target}"],
-      "tags": ["brute-force", "password", "network"]
+      "binary_pattern": "brutus-{os}-{arch}*",
+      "plugin": "brutus"
     },
     "julius": {
       "repo": "praetorian-inc/julius",
-      "description": "LLM/AI service fingerprinting",
-      "category": "ai",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["-t", "{target}"],
-      "tags": ["llm", "ai", "fingerprint"]
+      "binary_pattern": "julius-{os}-{arch}*",
+      "plugin": "julius"
     },
     "augustus": {
       "repo": "praetorian-inc/augustus",
-      "description": "LLM jailbreak & prompt injection attacks (190+ probes)",
-      "category": "ai",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "-t", "{target}"],
-      "tags": ["llm", "ai", "jailbreak", "injection"]
+      "binary_pattern": "augustus-{os}-{arch}*",
+      "plugin": "augustus"
     },
     "titus": {
       "repo": "praetorian-inc/titus",
-      "description": "Secret scanning & credential leak detection (487 rules)",
-      "category": "scanner",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {
-        "validation": {"type": "string", "description": "Enable secret validation (true/false)", "required": false}
-      },
-      "args_template": ["scan", "{target}"],
-      "tags": ["secrets", "credentials", "leak"]
+      "binary_pattern": "titus-{os}-{arch}*",
+      "plugin": "titus",
+      "local_only": true
     },
     "trajan": {
       "repo": "praetorian-inc/trajan",
-      "description": "CI/CD pipeline security scanning",
-      "category": "cicd",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {
-        "token": {"type": "string", "description": "GitHub/GitLab token for API access", "required": false}
-      },
-      "args_template": ["scan", "{target}"],
-      "tags": ["cicd", "pipeline", "github", "gitlab"]
+      "binary_pattern": "trajan-{os}-{arch}*",
+      "plugin": "trajan"
     },
     "cato": {
       "repo": "praetorian-inc/cato",
-      "description": "Injection scanner (SQLi, SSRF, SSTI, XXE)",
-      "category": "scanner",
-      "author": "Praetorian",
-      "target_type": "webpage",
-      "options": {},
-      "args_template": ["scan", "-u", "{target}"],
-      "tags": ["injection", "sqli", "ssrf", "ssti", "xxe"]
+      "binary_pattern": "cato-{os}-{arch}*",
+      "plugin": "cato",
+      "local_only": true
     },
     "nerva": {
       "repo": "praetorian-inc/nerva",
-      "description": "Service fingerprinting (120+ protocols)",
-      "category": "recon",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["-t", "{target}"],
-      "tags": ["fingerprint", "service", "protocol"]
+      "binary_pattern": "nerva-{os}-{arch}*",
+      "plugin": "nerva",
+      "local_only": true
     },
     "vespasian": {
       "repo": "praetorian-inc/vespasian",
-      "description": "API discovery from traffic",
-      "category": "api",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "{target}"],
-      "tags": ["api", "discovery", "traffic"]
+      "binary_pattern": "vespasian-{os}-{arch}*",
+      "plugin": "vespasian"
     },
     "nuclei": {
       "repo": "praetorian-inc/nuclei",
-      "description": "Vulnerability scanner with template engine",
-      "category": "scanner",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {
-        "templates": {"type": "string", "description": "Template directory or file", "required": false}
-      },
-      "args_template": ["-u", "{target}", "-jsonl"],
-      "tags": ["vulnerability", "templates", "cve"]
+      "binary_pattern": "nuclei-{os}-{arch}*",
+      "plugin": "nuclei"
     },
     "gato": {
       "repo": "praetorian-inc/gato",
-      "description": "GitHub Actions pipeline scanner",
-      "category": "cicd",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {
-        "token": {"type": "string", "description": "GitHub token", "required": false}
-      },
-      "args_template": ["enumerate", "-t", "{target}"],
-      "tags": ["github", "actions", "pipeline"]
+      "binary_pattern": "gato-{os}-{arch}*",
+      "plugin": "gato",
+      "local_only": true
     },
     "constantine": {
       "repo": "praetorian-inc/constantine",
-      "description": "Repository security analysis",
-      "category": "scanner",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "{target}"],
-      "tags": ["repository", "code", "security"]
+      "binary_pattern": "constantine-{os}-{arch}*",
+      "plugin": "constantine"
     },
     "aurelian": {
       "repo": "praetorian-inc/aurelian",
-      "description": "Cloud security reconnaissance (AWS/Azure/GCP)",
-      "category": "cloud",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "{target}"],
-      "tags": ["cloud", "aws", "azure", "gcp", "recon"]
+      "binary_pattern": "aurelian-{os}-{arch}*",
+      "local_only": true
     },
     "pius": {
       "repo": "praetorian-inc/pius",
-      "description": "Organizational asset discovery",
-      "category": "recon",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "{target}"],
-      "tags": ["discovery", "org", "asset"]
+      "binary_pattern": "pius-{os}-{arch}*",
+      "capability": "pius_discovery"
     },
     "florian": {
       "repo": "praetorian-inc/florian",
-      "description": "Authentication flow testing",
-      "category": "api",
-      "author": "Praetorian",
-      "target_type": "webpage",
-      "options": {},
-      "args_template": ["scan", "-u", "{target}"],
-      "tags": ["auth", "authentication", "flow"]
+      "binary_pattern": "florian-{os}-{arch}*",
+      "plugin": "florian",
+      "local_only": true
     },
     "caligula": {
       "repo": "praetorian-inc/caligula",
-      "description": "Supply chain security scanner",
-      "category": "supply-chain",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["scan", "{target}"],
-      "tags": ["supply-chain", "dependency", "sbom"]
+      "binary_pattern": "caligula-{os}-{arch}*",
+      "plugin": "caligula"
     },
     "hadrian": {
       "repo": "praetorian-inc/hadrian",
-      "description": "API security testing",
-      "category": "api",
-      "author": "Praetorian",
-      "target_type": "webpage",
-      "options": {},
-      "args_template": ["scan", "-u", "{target}"],
-      "tags": ["api", "security", "testing"]
+      "binary_pattern": "hadrian-{os}-{arch}*",
+      "plugin": "hadrian"
     },
     "nero": {
       "repo": "praetorian-inc/nero",
-      "description": "Default credential scanner",
-      "category": "credential",
-      "author": "Praetorian",
-      "target_type": "asset",
-      "options": {},
-      "args_template": ["-t", "{target}"],
-      "tags": ["default", "credentials", "scanner"]
+      "binary_pattern": "nero-{os}-{arch}*",
+      "plugin": "nero",
+      "local_only": true
     }
   }
 }

--- a/modules/registry.json
+++ b/modules/registry.json
@@ -1,0 +1,187 @@
+{
+  "version": 1,
+  "modules": {
+    "brutus": {
+      "repo": "praetorian-inc/brutus",
+      "description": "Credential attacks across 20+ protocols (SSH, RDP, FTP, SMB, etc.)",
+      "category": "credential",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "protocol": {"type": "string", "description": "Target protocol (auto-detected from port)", "required": false},
+        "usernames": {"type": "string", "description": "Username file or comma-separated list", "required": false},
+        "passwords": {"type": "string", "description": "Password file or comma-separated list", "required": false}
+      },
+      "args_template": ["--target", "{target}"],
+      "tags": ["brute-force", "password", "network"]
+    },
+    "julius": {
+      "repo": "praetorian-inc/julius",
+      "description": "LLM/AI service fingerprinting",
+      "category": "ai",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["llm", "ai", "fingerprint"]
+    },
+    "augustus": {
+      "repo": "praetorian-inc/augustus",
+      "description": "LLM jailbreak & prompt injection attacks (190+ probes)",
+      "category": "ai",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "-t", "{target}"],
+      "tags": ["llm", "ai", "jailbreak", "injection"]
+    },
+    "titus": {
+      "repo": "praetorian-inc/titus",
+      "description": "Secret scanning & credential leak detection (487 rules)",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "validation": {"type": "string", "description": "Enable secret validation (true/false)", "required": false}
+      },
+      "args_template": ["scan", "{target}"],
+      "tags": ["secrets", "credentials", "leak"]
+    },
+    "trajan": {
+      "repo": "praetorian-inc/trajan",
+      "description": "CI/CD pipeline security scanning",
+      "category": "cicd",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "token": {"type": "string", "description": "GitHub/GitLab token for API access", "required": false}
+      },
+      "args_template": ["scan", "{target}"],
+      "tags": ["cicd", "pipeline", "github", "gitlab"]
+    },
+    "cato": {
+      "repo": "praetorian-inc/cato",
+      "description": "Injection scanner (SQLi, SSRF, SSTI, XXE)",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["injection", "sqli", "ssrf", "ssti", "xxe"]
+    },
+    "nerva": {
+      "repo": "praetorian-inc/nerva",
+      "description": "Service fingerprinting (120+ protocols)",
+      "category": "recon",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["fingerprint", "service", "protocol"]
+    },
+    "vespasian": {
+      "repo": "praetorian-inc/vespasian",
+      "description": "API discovery from traffic",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["api", "discovery", "traffic"]
+    },
+    "nuclei": {
+      "repo": "praetorian-inc/nuclei",
+      "description": "Vulnerability scanner with template engine",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "templates": {"type": "string", "description": "Template directory or file", "required": false}
+      },
+      "args_template": ["-u", "{target}", "-jsonl"],
+      "tags": ["vulnerability", "templates", "cve"]
+    },
+    "gato": {
+      "repo": "praetorian-inc/gato",
+      "description": "GitHub Actions pipeline scanner",
+      "category": "cicd",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {
+        "token": {"type": "string", "description": "GitHub token", "required": false}
+      },
+      "args_template": ["enumerate", "-t", "{target}"],
+      "tags": ["github", "actions", "pipeline"]
+    },
+    "constantine": {
+      "repo": "praetorian-inc/constantine",
+      "description": "Repository security analysis",
+      "category": "scanner",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["repository", "code", "security"]
+    },
+    "aurelian": {
+      "repo": "praetorian-inc/aurelian",
+      "description": "Cloud security reconnaissance (AWS/Azure/GCP)",
+      "category": "cloud",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["cloud", "aws", "azure", "gcp", "recon"]
+    },
+    "pius": {
+      "repo": "praetorian-inc/pius",
+      "description": "Organizational asset discovery",
+      "category": "recon",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["discovery", "org", "asset"]
+    },
+    "florian": {
+      "repo": "praetorian-inc/florian",
+      "description": "Authentication flow testing",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["auth", "authentication", "flow"]
+    },
+    "caligula": {
+      "repo": "praetorian-inc/caligula",
+      "description": "Supply chain security scanner",
+      "category": "supply-chain",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["scan", "{target}"],
+      "tags": ["supply-chain", "dependency", "sbom"]
+    },
+    "hadrian": {
+      "repo": "praetorian-inc/hadrian",
+      "description": "API security testing",
+      "category": "api",
+      "author": "Praetorian",
+      "target_type": "webpage",
+      "options": {},
+      "args_template": ["scan", "-u", "{target}"],
+      "tags": ["api", "security", "testing"]
+    },
+    "nero": {
+      "repo": "praetorian-inc/nero",
+      "description": "Default credential scanner",
+      "category": "credential",
+      "author": "Praetorian",
+      "target_type": "asset",
+      "options": {},
+      "args_template": ["-t", "{target}"],
+      "tags": ["default", "credentials", "scanner"]
+    }
+  }
+}

--- a/modules/registry.json
+++ b/modules/registry.json
@@ -63,6 +63,7 @@
     "aurelian": {
       "repo": "praetorian-inc/aurelian",
       "binary_pattern": "aurelian-{os}-{arch}*",
+      "capability": "aurelian",
       "local_only": true
     },
     "pius": {

--- a/praetorian_cli/catalog.py
+++ b/praetorian_cli/catalog.py
@@ -1,5 +1,9 @@
 """Capability catalog: guard's /capabilities API is the source of truth."""
 
+import json
+import os
+import tempfile
+import time
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional
@@ -110,3 +114,91 @@ def rank_search(caps, query='', *, category='', surface='', target='', tag=''):
         out.append((s, cap))
     out.sort(key=lambda t: (-t[0], t[1].name))
     return [c for _, c in out]
+
+
+_PRAETORIAN_DIR = os.path.join(os.path.expanduser('~'), '.praetorian')
+DEFAULT_CACHE_PATH = os.path.join(_PRAETORIAN_DIR, 'capabilities-cache.json')
+DEFAULT_BUNDLED_PATH = os.path.join(
+    os.path.dirname(__file__), 'modules', 'capabilities_snapshot.json')
+CACHE_TTL_SECONDS = 86400
+
+
+def _atomic_write_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+class CapabilityCatalog:
+    def __init__(self, sdk, cache_path=DEFAULT_CACHE_PATH, bundled_path=DEFAULT_BUNDLED_PATH):
+        self.sdk = sdk
+        self.cache_path = cache_path
+        self.bundled_path = bundled_path
+        self._caps = None
+        self.source = ''
+
+    def _cache_stale(self) -> bool:
+        if not os.path.isfile(self.cache_path):
+            return True
+        return (time.time() - os.path.getmtime(self.cache_path)) > CACHE_TTL_SECONDS
+
+    def refresh(self, force=False) -> bool:
+        if not force and not self._cache_stale():
+            return False
+        try:
+            raw, _ = self.sdk.capabilities.list()
+            caps = raw if isinstance(raw, list) else raw.get('capabilities', raw.get('data', []))
+            _atomic_write_json(self.cache_path, {'capabilities': caps})
+            self._caps = [Capability.from_api(c) for c in caps]
+            self.source = 'live'
+            return True
+        except Exception:
+            return False
+
+    def _load_file(self, path):
+        with open(path) as f:
+            data = json.load(f)
+        return data.get('capabilities', data) if isinstance(data, dict) else data
+
+    def all(self):
+        if self._caps is not None:
+            return self._caps
+        if self.refresh():
+            return self._caps
+        if os.path.isfile(self.cache_path):
+            try:
+                age = int((time.time() - os.path.getmtime(self.cache_path)) / 3600)
+                self._caps = [Capability.from_api(c) for c in self._load_file(self.cache_path)]
+                self.source = f'cached ({age}h old)'
+                return self._caps
+            except (json.JSONDecodeError, OSError):
+                pass
+        if os.path.isfile(self.bundled_path):
+            try:
+                self._caps = [Capability.from_api(c) for c in self._load_file(self.bundled_path)]
+                self.source = 'bundled'
+                return self._caps
+            except (json.JSONDecodeError, OSError):
+                pass
+        self._caps = []
+        self.source = 'empty'
+        return self._caps
+
+    def get(self, name: str):
+        n = name.lower()
+        for c in self.all():
+            if c.name.lower() == n:
+                return c
+        return None
+
+    def search(self, query='', **filters):
+        return rank_search(self.all(), query, **filters)

--- a/praetorian_cli/catalog.py
+++ b/praetorian_cli/catalog.py
@@ -1,6 +1,7 @@
 """Capability catalog: guard's /capabilities API is the source of truth."""
 
 from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional
 
 
@@ -70,3 +71,42 @@ class Capability:
             integration=bool(_ci(raw, 'Integration', default=False)),
             parameters=[Parameter.from_api(p) for p in _as_list(_ci(raw, 'Parameters', default=[]))],
         )
+
+
+def _score(cap: 'Capability', q: str) -> Optional[float]:
+    """Higher is better; None means filtered out."""
+    if not q:
+        return 0.0
+    name = cap.name.lower()
+    hay = ' '.join([name, cap.title.lower(), cap.description.lower(),
+                    ' '.join(cap.category)]).lower()
+    if name == q:
+        return 100.0
+    if name.startswith(q):
+        return 90.0 - (len(name) - len(q)) * 0.1
+    if q in hay:
+        return 70.0
+    ratio = SequenceMatcher(None, q, name).ratio()
+    if ratio >= 0.6:
+        return 40.0 + ratio * 10
+    return None
+
+
+def rank_search(caps, query='', *, category='', surface='', target='', tag=''):
+    q = (query or '').lower().strip()
+    out = []
+    for cap in caps:
+        if category and category not in cap.category:
+            continue
+        if surface and cap.surface != surface:
+            continue
+        if target and target not in cap.target:
+            continue
+        if tag and tag not in cap.category and tag not in cap.target:
+            continue
+        s = _score(cap, q)
+        if s is None:
+            continue
+        out.append((s, cap))
+    out.sort(key=lambda t: (-t[0], t[1].name))
+    return [c for _, c in out]

--- a/praetorian_cli/catalog.py
+++ b/praetorian_cli/catalog.py
@@ -1,0 +1,72 @@
+"""Capability catalog: guard's /capabilities API is the source of truth."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def _as_list(v) -> list:
+    if v is None or v == '':
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def _ci(raw: Dict[str, Any], *keys, default=None):
+    """Case-insensitive get across candidate keys (API uses PascalCase)."""
+    lowered = {k.lower(): v for k, v in raw.items()}
+    for k in keys:
+        if k.lower() in lowered and lowered[k.lower()] not in (None, ''):
+            return lowered[k.lower()]
+    return default
+
+
+@dataclass
+class Parameter:
+    name: str
+    description: str = ''
+    type: str = 'string'
+    default: str = ''
+    required: bool = False
+    options: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_api(cls, raw: Dict[str, Any]) -> 'Parameter':
+        return cls(
+            name=_ci(raw, 'Name', default=''),
+            description=_ci(raw, 'Description', default=''),
+            type=_ci(raw, 'Type', default='string'),
+            default=str(_ci(raw, 'Default', default='') or ''),
+            required=bool(_ci(raw, 'Required', default=False)),
+            options=_as_list(_ci(raw, 'Options', default=[])),
+        )
+
+
+@dataclass
+class Capability:
+    name: str
+    title: str = ''
+    target: List[str] = field(default_factory=list)
+    description: str = ''
+    category: List[str] = field(default_factory=list)
+    surface: str = ''
+    runs_on: str = ''
+    version: str = ''
+    executor: str = ''
+    integration: bool = False
+    parameters: List[Parameter] = field(default_factory=list)
+
+    @classmethod
+    def from_api(cls, raw: Dict[str, Any]) -> 'Capability':
+        name = _ci(raw, 'Name', default='')
+        return cls(
+            name=name,
+            title=_ci(raw, 'Title', default=name),
+            target=_as_list(_ci(raw, 'Target', default=[])),
+            description=_ci(raw, 'Description', default=''),
+            category=_as_list(_ci(raw, 'Category', default=[])),
+            surface=_ci(raw, 'Surface', default=''),
+            runs_on=_ci(raw, 'RunsOn', 'Runs_On', default=''),
+            version=_ci(raw, 'Version', default=''),
+            executor=_ci(raw, 'Executor', default=''),
+            integration=bool(_ci(raw, 'Integration', default=False)),
+            parameters=[Parameter.from_api(p) for p in _as_list(_ci(raw, 'Parameters', default=[]))],
+        )

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -51,17 +51,17 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except click.ClickException:
+            raise
         except click.Abort:
             raise
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
-        except click.ClickException:
         except click.exceptions.Exit:
+            raise
         except CancelledError:
+            raise
         except Exception as exc:
             if _debug_enabled(ctx):
+                raise
             raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -288,7 +288,7 @@ def uninstall(sdk, name, as_json):
             error(f"{name} is not installed.")
         return
 
-    if not path.startswith(INSTALL_DIR):
+    if os.path.commonpath([path, INSTALL_DIR]) != INSTALL_DIR:
         if as_json:
             print_json({"name": name, "status": "error", "error": "System binary, not managed by guard"})
         else:

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -173,12 +173,12 @@ def info(sdk, name, as_json):
     from praetorian_cli.registry import get_registry
     from praetorian_cli.runners.local import is_installed, get_binary_path
 
+    reg = get_registry()
     cat = _catalog(sdk)
-    c = cat.get(name)
+    c = cat.get(name) or cat.get(reg.get_capability_name(name))
     if c is None:
         error(f"Unknown module: {name}. Use 'guard module search' to find modules.")
 
-    reg = get_registry()
     ver_info = reg.get_version(c.name)
 
     if as_json:
@@ -232,8 +232,10 @@ def options(sdk, name, as_json):
     \b
     Example: guard module options brutus
     """
+    from praetorian_cli.registry import get_registry
+
     cat = _catalog(sdk)
-    c = cat.get(name)
+    c = cat.get(name) or cat.get(get_registry().get_capability_name(name))
     if c is None:
         error(f"Unknown module: {name}")
 

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -1,0 +1,424 @@
+"""guard module — Metasploit-style module management commands."""
+
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error, print_json
+
+
+@chariot.group()
+def module():
+    """Manage security tool modules
+
+    \b
+    Metasploit-style module management: search, inspect, install, and
+    update security tools from the Guard module registry.
+    """
+    pass
+
+
+@module.command("search")
+@cli_handler
+@click.argument("query", default="")
+@click.option("--category", "-c", default="", help="Filter by category")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def search(sdk, query, category, as_json):
+    """Search available modules by name, category, or keyword
+
+    \b
+    Example usages:
+        guard module search
+        guard module search credential
+        guard module search --category scanner
+        guard module search llm --json
+    """
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+
+    reg = get_registry()
+    results = reg.search_modules(query, category=category)
+    installed = list_installed()
+
+    if as_json:
+        for r in results:
+            r["installed"] = r["name"] in installed
+            ver = reg.get_version(r["name"])
+            r["version"] = ver["version"] if ver else None
+        print_json(results)
+        return
+
+    if not results:
+        click.echo("No modules match the query.")
+        return
+
+    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
+
+    for r in results:
+        name = r["name"]
+        cat = r.get("category", "")
+        desc = r.get("description", "")
+        if len(desc) > 48:
+            desc = desc[:47] + "…"
+        ver = reg.get_version(name)
+        if name in installed:
+            status = ver["version"] if ver else "yes"
+        else:
+            status = "—"
+        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
+
+    click.echo(f"\n{len(results)} modules")
+
+
+@module.command("list")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def list_modules(sdk, as_json):
+    """List all available modules (alias for search with no query)"""
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+
+    reg = get_registry()
+    results = reg.search_modules()
+    installed = list_installed()
+
+    if as_json:
+        for r in results:
+            r["installed"] = r["name"] in installed
+            ver = reg.get_version(r["name"])
+            r["version"] = ver["version"] if ver else None
+        print_json(results)
+        return
+
+    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
+    for r in results:
+        name = r["name"]
+        cat = r.get("category", "")
+        desc = r.get("description", "")
+        if len(desc) > 48:
+            desc = desc[:47] + "…"
+        ver = reg.get_version(name)
+        if name in installed:
+            status = ver["version"] if ver else "yes"
+        else:
+            status = "—"
+        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
+    click.echo(f"\n{len(results)} modules")
+
+
+@module.command("info")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def info(sdk, name, as_json):
+    """Show full details for a module
+
+    \b
+    Example usages:
+        guard module info brutus
+        guard module info nuclei --json
+    """
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import is_installed, get_binary_path
+
+    reg = get_registry()
+    mod = reg.get_module(name)
+    if not mod:
+        error(f"Unknown module: {name}. Use 'guard module search' to find modules.")
+
+    ver_info = reg.get_version(name.lower())
+
+    if as_json:
+        out = {"name": name.lower(), **mod}
+        out["installed"] = is_installed(name.lower())
+        out["version"] = ver_info["version"] if ver_info else None
+        out["binary_path"] = get_binary_path(name.lower())
+        print_json(out)
+        return
+
+    installed_str = "not installed"
+    if is_installed(name.lower()):
+        path = get_binary_path(name.lower())
+        ver = ver_info["version"] if ver_info else "unknown"
+        installed_str = f"{ver} ({path})"
+
+    click.echo(f"\n  Name:        {name.lower()}")
+    click.echo(f"  Category:    {mod.get('category', '')}")
+    click.echo(f"  Author:      {mod.get('author', '')}")
+    click.echo(f"  Repository:  {mod.get('repo', '')}")
+    click.echo(f"  Installed:   {installed_str}")
+    click.echo(f"  Target:      {mod.get('target_type', 'asset')}")
+    click.echo(f"  Description: {mod.get('description', '')}")
+
+    tags = mod.get("tags", [])
+    if tags:
+        click.echo(f"  Tags:        {', '.join(tags)}")
+
+    options = mod.get("options", {})
+    if options:
+        click.echo(f"\n  Options:")
+        for opt_name, opt_info in options.items():
+            opt_type = opt_info.get("type", "string")
+            opt_desc = opt_info.get("description", "")
+            click.echo(f"    --{opt_name:<14} {opt_type:<8} {opt_desc}")
+
+    click.echo(f"\n  Usage:")
+    click.echo(f"    guard run tool {name.lower()} <target>")
+    click.echo()
+
+
+@module.command("options")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def options(sdk, name, as_json):
+    """Show configurable options for a module
+
+    \b
+    Example: guard module options brutus
+    """
+    from praetorian_cli.registry import get_registry
+
+    reg = get_registry()
+    mod = reg.get_module(name)
+    if not mod:
+        error(f"Unknown module: {name}")
+
+    opts = mod.get("options", {})
+
+    if as_json:
+        print_json(opts)
+        return
+
+    if not opts:
+        click.echo(f"{name}: no configurable options.")
+        return
+
+    click.echo(f'\n{"Option":<18} {"Type":<10} {"Required":<10} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 10} {"─" * 10} {"─" * 40}')
+    for opt_name, opt_info in opts.items():
+        click.echo(
+            f"--{opt_name:<16} {opt_info.get('type', 'string'):<10} "
+            f"{'yes' if opt_info.get('required') else 'no':<10} "
+            f"{opt_info.get('description', '')}"
+        )
+    click.echo()
+
+
+@module.command("install")
+@cli_handler
+@click.argument("name")
+@click.option("--force", is_flag=True, default=False, help="Reinstall even if present")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def install(sdk, name, force, as_json):
+    """Install a module binary from GitHub releases
+
+    \b
+    Example usages:
+        guard module install brutus
+        guard module install all
+        guard module install brutus --force
+    """
+    from praetorian_cli.runners.local import install_tool, INSTALLABLE_TOOLS, is_installed
+
+    if name == "all":
+        results = []
+        for tool_name in sorted(INSTALLABLE_TOOLS):
+            try:
+                if not force and is_installed(tool_name):
+                    if as_json:
+                        results.append({"name": tool_name, "status": "already_installed"})
+                    else:
+                        click.echo(f"{tool_name}: already installed")
+                else:
+                    if not as_json:
+                        click.echo(f"{tool_name}: installing...", nl=False)
+                    path = install_tool(tool_name, force=force)
+                    if as_json:
+                        results.append({"name": tool_name, "status": "installed", "path": path})
+                    else:
+                        click.echo(f" {path}")
+            except Exception as e:
+                if as_json:
+                    results.append({"name": tool_name, "status": "error", "error": str(e)})
+                else:
+                    click.echo(f" FAILED: {e}", err=True)
+        if as_json:
+            print_json(results)
+        return
+
+    try:
+        if not as_json:
+            click.echo(f"Installing {name}...")
+        path = install_tool(name, force=force)
+        if as_json:
+            print_json({"name": name, "status": "installed", "path": path})
+        else:
+            click.echo(f"Installed: {path}")
+    except Exception as e:
+        if as_json:
+            print_json({"name": name, "status": "error", "error": str(e)})
+        else:
+            error(str(e))
+
+
+@module.command("uninstall")
+@cli_handler
+@click.argument("name")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def uninstall(sdk, name, as_json):
+    """Remove an installed module binary
+
+    \b
+    Example: guard module uninstall brutus
+    """
+    import os
+    from praetorian_cli.runners.local import get_binary_path, INSTALL_DIR
+    from praetorian_cli.registry import get_registry
+
+    path = get_binary_path(name)
+    if not path:
+        if as_json:
+            print_json({"name": name, "status": "not_installed"})
+        else:
+            error(f"{name} is not installed.")
+        return
+
+    if not path.startswith(INSTALL_DIR):
+        if as_json:
+            print_json({"name": name, "status": "error", "error": "System binary, not managed by guard"})
+        else:
+            error(f"{name} at {path} is a system binary, not managed by guard module install.")
+        return
+
+    os.remove(path)
+    get_registry().remove_version(name)
+
+    if as_json:
+        print_json({"name": name, "status": "uninstalled"})
+    else:
+        click.echo(f"Uninstalled: {name}")
+
+
+@module.command("update")
+@cli_handler
+@click.argument("name", default="all")
+@click.option("--registry", "update_registry", is_flag=True, default=False, help="Force refresh the registry")
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def update(sdk, name, update_registry, as_json):
+    """Update installed modules to latest release
+
+    \b
+    Example usages:
+        guard module update
+        guard module update brutus
+        guard module update --registry
+    """
+    import subprocess
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
+
+    reg = get_registry()
+
+    if update_registry:
+        refreshed = reg.refresh(force=True)
+        if not as_json:
+            click.echo("Registry refreshed." if refreshed else "Registry refresh failed (using cached).")
+
+    tools_to_update = sorted(INSTALLABLE_TOOLS) if name == "all" else [name]
+    results = []
+
+    for tool_name in tools_to_update:
+        if not is_installed(tool_name):
+            if name != "all":
+                if as_json:
+                    results.append({"name": tool_name, "status": "not_installed"})
+                else:
+                    click.echo(f"{tool_name}: not installed")
+            continue
+
+        mod = reg.get_module(tool_name)
+        if not mod:
+            continue
+
+        current = reg.get_version(tool_name)
+        current_ver = current["version"] if current else "unknown"
+
+        try:
+            ver_result = subprocess.run(
+                ["gh", "release", "view", "--repo", mod["repo"], "--json", "tagName", "-q", ".tagName"],
+                capture_output=True, text=True, timeout=15,
+            )
+            latest_ver = ver_result.stdout.strip() if ver_result.returncode == 0 else None
+        except Exception:
+            latest_ver = None
+
+        if not latest_ver:
+            if as_json:
+                results.append({"name": tool_name, "status": "error", "error": "Could not check latest version"})
+            else:
+                click.echo(f"{tool_name}: could not check latest version")
+            continue
+
+        if latest_ver == current_ver:
+            if as_json:
+                results.append({"name": tool_name, "status": "up_to_date", "version": current_ver})
+            elif name != "all":
+                click.echo(f"{tool_name}: up to date ({current_ver})")
+            continue
+
+        try:
+            if not as_json:
+                click.echo(f"{tool_name}: {current_ver} -> {latest_ver}...", nl=False)
+            path = install_tool(tool_name, force=True)
+            if as_json:
+                results.append({"name": tool_name, "status": "updated", "from": current_ver, "to": latest_ver, "path": path})
+            else:
+                click.echo(f" done")
+        except Exception as e:
+            if as_json:
+                results.append({"name": tool_name, "status": "error", "error": str(e)})
+            else:
+                click.echo(f" FAILED: {e}", err=True)
+
+    if as_json:
+        print_json(results)
+
+
+@module.command("installed")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def installed(sdk, as_json):
+    """List installed modules with versions"""
+    from praetorian_cli.runners.local import list_installed, INSTALLABLE_TOOLS
+    from praetorian_cli.registry import get_registry
+
+    reg = get_registry()
+    inst = list_installed()
+    versions = reg.get_all_versions()
+
+    if as_json:
+        result = []
+        for tool_name in sorted(INSTALLABLE_TOOLS):
+            entry = {"name": tool_name, "installed": tool_name in inst}
+            if tool_name in inst:
+                entry["path"] = inst[tool_name]
+                ver = versions.get(tool_name)
+                entry["version"] = ver["version"] if ver else None
+            result.append(entry)
+        print_json(result)
+        return
+
+    click.echo(f'\n{"Tool":<18} {"Status":<12} {"Version":<12} {"Path"}')
+    click.echo(f'{"─" * 18} {"─" * 12} {"─" * 12} {"─" * 50}')
+    for tool_name in sorted(INSTALLABLE_TOOLS):
+        if tool_name in inst:
+            ver = versions.get(tool_name, {}).get("version", "—")
+            click.echo(f"{tool_name:<18} {'installed':<12} {ver:<12} {inst[tool_name]}")
+        else:
+            click.echo(f"{tool_name:<18} {'—':<12} {'—':<12}")
+    click.echo()

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -9,6 +9,71 @@ from praetorian_cli.handlers.cli_decorators import cli_handler
 from praetorian_cli.handlers.utils import error, print_json
 
 
+def _catalog(sdk):
+    from praetorian_cli.catalog import CapabilityCatalog
+    return CapabilityCatalog(sdk)
+
+
+def _join(v):
+    """Render a list-or-string catalog field as a comma-joined string."""
+    if isinstance(v, (list, tuple)):
+        return ", ".join(v)
+    return v or ""
+
+
+def _render_module_table(rows):
+    """Plain-text table for module search/list output."""
+    if not rows:
+        click.echo("No modules match the query.")
+        return
+
+    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
+    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
+
+    for r in rows:
+        name = r["name"]
+        cat = _join(r.get("category", ""))
+        if len(cat) > 14:
+            cat = cat[:13] + "…"
+        desc = r.get("description", "") or ""
+        if r.get("local_only"):
+            desc = f"[local-only] {desc}"
+        if len(desc) > 48:
+            desc = desc[:47] + "…"
+        if r.get("installed"):
+            status = r.get("installed_version") or "yes"
+        else:
+            status = "—"
+        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
+
+    click.echo(f"\n{len(rows)} modules")
+
+
+def _search_rows(sdk, query="", *, category="", surface="", target="", tag="", installed_only=False):
+    """Shared catalog query: returns (rows, catalog) for search/list."""
+    from praetorian_cli.registry import get_registry
+    from praetorian_cli.runners.local import list_installed
+
+    cat = _catalog(sdk)
+    reg = get_registry()
+    results = cat.search(query, category=category, surface=surface, target=target, tag=tag)
+    inst = list_installed()
+    rows = []
+    for c in results:
+        ver = reg.get_version(c.name)
+        is_inst = c.name in inst
+        if installed_only and not is_inst:
+            continue
+        rows.append({
+            "name": c.name, "title": c.title, "category": c.category,
+            "surface": c.surface, "target": c.target, "description": c.description,
+            "version": c.version, "executor": c.executor,
+            "installed": is_inst, "local_only": reg.is_local_only(c.name),
+            "installed_version": ver["version"] if ver else None,
+        })
+    return rows, cat
+
+
 @chariot.group()
 def module():
     """Manage security tool modules
@@ -24,9 +89,13 @@ def module():
 @cli_handler
 @click.argument("query", default="")
 @click.option("--category", "-c", default="", help="Filter by category")
+@click.option("--surface", default="", help="Filter by surface")
+@click.option("--target", default="", help="Filter by target type")
+@click.option("--tag", default="", help="Filter by tag")
+@click.option("--installed", "installed_only", is_flag=True, default=False, help="Only installed modules")
 @click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
-def search(sdk, query, category, as_json):
-    """Search available modules by name, category, or keyword
+def search(sdk, query, category, surface, target, tag, installed_only, as_json):
+    """Search available modules (fuzzy, ranked)
 
     \b
     Example usages:
@@ -35,42 +104,18 @@ def search(sdk, query, category, as_json):
         guard module search --category scanner
         guard module search llm --json
     """
-    from praetorian_cli.registry import get_registry
-    from praetorian_cli.runners.local import list_installed
-
-    reg = get_registry()
-    results = reg.search_modules(query, category=category)
-    installed = list_installed()
+    rows, cat = _search_rows(
+        sdk, query, category=category, surface=surface, target=target,
+        tag=tag, installed_only=installed_only,
+    )
 
     if as_json:
-        for r in results:
-            r["installed"] = r["name"] in installed
-            ver = reg.get_version(r["name"])
-            r["version"] = ver["version"] if ver else None
-        print_json(results)
+        print_json(rows)
         return
 
-    if not results:
-        click.echo("No modules match the query.")
-        return
-
-    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
-    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
-
-    for r in results:
-        name = r["name"]
-        cat = r.get("category", "")
-        desc = r.get("description", "")
-        if len(desc) > 48:
-            desc = desc[:47] + "…"
-        ver = reg.get_version(name)
-        if name in installed:
-            status = ver["version"] if ver else "yes"
-        else:
-            status = "—"
-        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
-
-    click.echo(f"\n{len(results)} modules")
+    if cat.source and cat.source != 'live':
+        click.echo(f"(catalog: {cat.source})", err=True)
+    _render_module_table(rows)
 
 
 @module.command("list")
@@ -78,36 +123,39 @@ def search(sdk, query, category, as_json):
 @click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
 def list_modules(sdk, as_json):
     """List all available modules (alias for search with no query)"""
-    from praetorian_cli.registry import get_registry
-    from praetorian_cli.runners.local import list_installed
-
-    reg = get_registry()
-    results = reg.search_modules()
-    installed = list_installed()
+    rows, cat = _search_rows(sdk)
 
     if as_json:
-        for r in results:
-            r["installed"] = r["name"] in installed
-            ver = reg.get_version(r["name"])
-            r["version"] = ver["version"] if ver else None
-        print_json(results)
+        print_json(rows)
         return
 
-    click.echo(f'\n{"Name":<18} {"Category":<14} {"Installed":<12} {"Description"}')
-    click.echo(f'{"─" * 18} {"─" * 14} {"─" * 12} {"─" * 48}')
-    for r in results:
-        name = r["name"]
-        cat = r.get("category", "")
-        desc = r.get("description", "")
-        if len(desc) > 48:
-            desc = desc[:47] + "…"
-        ver = reg.get_version(name)
-        if name in installed:
-            status = ver["version"] if ver else "yes"
-        else:
-            status = "—"
-        click.echo(f"{name:<18} {cat:<14} {status:<12} {desc}")
-    click.echo(f"\n{len(results)} modules")
+    if cat.source and cat.source != 'live':
+        click.echo(f"(catalog: {cat.source})", err=True)
+    _render_module_table(rows)
+
+
+def _params_json(c):
+    return [
+        {"name": p.name, "type": p.type, "required": p.required,
+         "default": p.default, "options": p.options, "description": p.description}
+        for p in c.parameters
+    ]
+
+
+def _render_params(parameters):
+    if not parameters:
+        click.echo("  (no configurable parameters)")
+        return
+    click.echo(f'\n  {"Option":<18} {"Type":<10} {"Required":<10} {"Default":<12} {"Description"}')
+    click.echo(f'  {"─" * 18} {"─" * 10} {"─" * 10} {"─" * 12} {"─" * 30}')
+    for p in parameters:
+        desc = p.description or ""
+        if p.options:
+            desc = f"{desc} [{', '.join(p.options)}]".strip()
+        click.echo(
+            f"  --{p.name:<16} {p.type:<10} "
+            f"{'yes' if p.required else 'no':<10} {(p.default or '—'):<12} {desc}"
+        )
 
 
 @module.command("info")
@@ -125,49 +173,52 @@ def info(sdk, name, as_json):
     from praetorian_cli.registry import get_registry
     from praetorian_cli.runners.local import is_installed, get_binary_path
 
-    reg = get_registry()
-    mod = reg.get_module(name)
-    if not mod:
+    cat = _catalog(sdk)
+    c = cat.get(name)
+    if c is None:
         error(f"Unknown module: {name}. Use 'guard module search' to find modules.")
 
-    ver_info = reg.get_version(name.lower())
+    reg = get_registry()
+    ver_info = reg.get_version(c.name)
 
     if as_json:
-        out = {"name": name.lower(), **mod}
-        out["installed"] = is_installed(name.lower())
-        out["version"] = ver_info["version"] if ver_info else None
-        out["binary_path"] = get_binary_path(name.lower())
+        out = {
+            "name": c.name, "title": c.title, "category": c.category,
+            "surface": c.surface, "target": c.target, "description": c.description,
+            "version": c.version, "executor": c.executor, "runs_on": c.runs_on,
+            "integration": c.integration, "parameters": _params_json(c),
+        }
+        out["installed"] = is_installed(c.name)
+        out["local_only"] = reg.is_local_only(c.name)
+        out["installed_version"] = ver_info["version"] if ver_info else None
+        out["binary_path"] = get_binary_path(c.name)
         print_json(out)
         return
 
     installed_str = "not installed"
-    if is_installed(name.lower()):
-        path = get_binary_path(name.lower())
+    if is_installed(c.name):
+        path = get_binary_path(c.name)
         ver = ver_info["version"] if ver_info else "unknown"
         installed_str = f"{ver} ({path})"
 
-    click.echo(f"\n  Name:        {name.lower()}")
-    click.echo(f"  Category:    {mod.get('category', '')}")
-    click.echo(f"  Author:      {mod.get('author', '')}")
-    click.echo(f"  Repository:  {mod.get('repo', '')}")
+    click.echo(f"\n  Name:        {c.name}")
+    click.echo(f"  Title:       {c.title}")
+    click.echo(f"  Category:    {_join(c.category)}")
+    click.echo(f"  Surface:     {c.surface}")
+    click.echo(f"  Target:      {_join(c.target)}")
+    click.echo(f"  Version:     {c.version or '—'}")
+    click.echo(f"  Executor:    {c.executor}")
     click.echo(f"  Installed:   {installed_str}")
-    click.echo(f"  Target:      {mod.get('target_type', 'asset')}")
-    click.echo(f"  Description: {mod.get('description', '')}")
+    if reg.is_local_only(c.name):
+        click.echo(f"  Local-only:  yes")
+    click.echo(f"  Description: {c.description}")
 
-    tags = mod.get("tags", [])
-    if tags:
-        click.echo(f"  Tags:        {', '.join(tags)}")
-
-    options = mod.get("options", {})
-    if options:
+    if c.parameters:
         click.echo(f"\n  Options:")
-        for opt_name, opt_info in options.items():
-            opt_type = opt_info.get("type", "string")
-            opt_desc = opt_info.get("description", "")
-            click.echo(f"    --{opt_name:<14} {opt_type:<8} {opt_desc}")
+        _render_params(c.parameters)
 
     click.echo(f"\n  Usage:")
-    click.echo(f"    guard run tool {name.lower()} <target>")
+    click.echo(f"    guard run tool {c.name} <target>")
     click.echo()
 
 
@@ -181,31 +232,20 @@ def options(sdk, name, as_json):
     \b
     Example: guard module options brutus
     """
-    from praetorian_cli.registry import get_registry
-
-    reg = get_registry()
-    mod = reg.get_module(name)
-    if not mod:
+    cat = _catalog(sdk)
+    c = cat.get(name)
+    if c is None:
         error(f"Unknown module: {name}")
 
-    opts = mod.get("options", {})
-
     if as_json:
-        print_json(opts)
+        print_json(_params_json(c))
         return
 
-    if not opts:
-        click.echo(f"{name}: no configurable options.")
+    if not c.parameters:
+        click.echo(f"{c.name}: no configurable options.")
         return
 
-    click.echo(f'\n{"Option":<18} {"Type":<10} {"Required":<10} {"Description"}')
-    click.echo(f'{"─" * 18} {"─" * 10} {"─" * 10} {"─" * 40}')
-    for opt_name, opt_info in opts.items():
-        click.echo(
-            f"--{opt_name:<16} {opt_info.get('type', 'string'):<10} "
-            f"{'yes' if opt_info.get('required') else 'no':<10} "
-            f"{opt_info.get('description', '')}"
-        )
+    _render_params(c.parameters)
     click.echo()
 
 
@@ -226,29 +266,38 @@ def install(sdk, name, force, as_json):
     from praetorian_cli.runners.local import install_tool, INSTALLABLE_TOOLS, is_installed
 
     if name == "all":
-        results = []
-        for tool_name in sorted(INSTALLABLE_TOOLS):
-            try:
-                if not force and is_installed(tool_name):
-                    if as_json:
-                        results.append({"name": tool_name, "status": "already_installed"})
-                    else:
-                        click.echo(f"{tool_name}: already installed")
-                else:
-                    if not as_json:
-                        click.echo(f"{tool_name}: installing...", nl=False)
-                    path = install_tool(tool_name, force=force)
-                    if as_json:
-                        results.append({"name": tool_name, "status": "installed", "path": path})
-                    else:
-                        click.echo(f" {path}")
-            except Exception as e:
-                if as_json:
-                    results.append({"name": tool_name, "status": "error", "error": str(e)})
-                else:
-                    click.echo(f" FAILED: {e}", err=True)
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        targets = [t for t in sorted(INSTALLABLE_TOOLS) if force or not is_installed(t)]
+
+        def _do(t):
+            return install_tool(t, force=force)
+
         if as_json:
+            results = []
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futs = {pool.submit(_do, t): t for t in targets}
+                for fut in as_completed(futs):
+                    t = futs[fut]
+                    try:
+                        results.append({"name": t, "status": "installed", "path": fut.result()})
+                    except Exception as e:
+                        results.append({"name": t, "status": "error", "error": str(e)})
             print_json(results)
+        else:
+            from rich.progress import Progress, SpinnerColumn, TextColumn
+            from rich.console import Console
+            console = Console()
+            with Progress(SpinnerColumn(), TextColumn("{task.description}"), console=console) as prog:
+                tasks = {t: prog.add_task(f"{t}: queued", total=None) for t in targets}
+                with ThreadPoolExecutor(max_workers=4) as pool:
+                    futs = {pool.submit(_do, t): t for t in targets}
+                    for fut in as_completed(futs):
+                        t = futs[fut]
+                        try:
+                            fut.result()
+                            prog.update(tasks[t], description=f"{t}: installed")
+                        except Exception as e:
+                            prog.update(tasks[t], description=f"{t}: FAILED {e}")
         return
 
     try:
@@ -276,32 +325,26 @@ def uninstall(sdk, name, as_json):
     \b
     Example: guard module uninstall brutus
     """
-    import os
-    from praetorian_cli.runners.local import get_binary_path, INSTALL_DIR
-    from praetorian_cli.registry import get_registry
-
-    path = get_binary_path(name)
-    if not path:
-        if as_json:
-            print_json({"name": name, "status": "not_installed"})
-        else:
-            error(f"{name} is not installed.")
-        return
-
-    if os.path.commonpath([path, INSTALL_DIR]) != INSTALL_DIR:
-        if as_json:
-            print_json({"name": name, "status": "error", "error": "System binary, not managed by guard"})
-        else:
-            error(f"{name} at {path} is a system binary, not managed by guard module install.")
-        return
-
-    os.remove(path)
-    get_registry().remove_version(name)
-
+    from praetorian_cli.runners.local import uninstall_tool
+    removed = uninstall_tool(name.lower())
     if as_json:
-        print_json({"name": name, "status": "uninstalled"})
+        print_json({"name": name.lower(), "removed": removed})
     else:
-        click.echo(f"Uninstalled: {name}")
+        click.echo(f"{name}: {'removed' if removed else 'not installed'}")
+
+
+@module.command("sync")
+@cli_handler
+@click.option("--json", "as_json", is_flag=True, default=False, help="JSON output")
+def sync(sdk, as_json):
+    """Force-refresh the capability catalog from the backend."""
+    cat = _catalog(sdk)
+    ok = cat.refresh(force=True)
+    n = len(cat.all())
+    if as_json:
+        print_json({"refreshed": ok, "count": n, "source": cat.source})
+    else:
+        click.echo(f"Catalog {'refreshed' if ok else 'unchanged'}: {n} capabilities ({cat.source}).")
 
 
 @module.command("update")

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -330,7 +330,7 @@ def uninstall(sdk, name, as_json):
     from praetorian_cli.runners.local import uninstall_tool
     try:
         removed = uninstall_tool(name.lower())
-    except OSError as e:
+    except (OSError, ValueError) as e:
         if as_json:
             print_json({"name": name.lower(), "removed": False, "error": str(e)})
         else:

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -328,7 +328,14 @@ def uninstall(sdk, name, as_json):
     Example: guard module uninstall brutus
     """
     from praetorian_cli.runners.local import uninstall_tool
-    removed = uninstall_tool(name.lower())
+    try:
+        removed = uninstall_tool(name.lower())
+    except OSError as e:
+        if as_json:
+            print_json({"name": name.lower(), "removed": False, "error": str(e)})
+        else:
+            error(f"Failed to remove {name}: {e}")
+        return
     if as_json:
         print_json({"name": name.lower(), "removed": removed})
     else:

--- a/praetorian_cli/handlers/module.py
+++ b/praetorian_cli/handlers/module.py
@@ -56,7 +56,13 @@ def _search_rows(sdk, query="", *, category="", surface="", target="", tag="", i
 
     cat = _catalog(sdk)
     reg = get_registry()
-    results = cat.search(query, category=category, surface=surface, target=target, tag=tag)
+    results = cat.search(
+        query,
+        category=category.lower() if category else category,
+        surface=surface.lower() if surface else surface,
+        target=target.lower() if target else target,
+        tag=tag.lower() if tag else tag,
+    )
     inst = list_installed()
     rows = []
     for c in results:
@@ -210,14 +216,14 @@ def info(sdk, name, as_json):
     click.echo(f"  Executor:    {c.executor}")
     click.echo(f"  Installed:   {installed_str}")
     if reg.is_local_only(c.name):
-        click.echo(f"  Local-only:  yes")
+        click.echo("  Local-only:  yes")
     click.echo(f"  Description: {c.description}")
 
     if c.parameters:
-        click.echo(f"\n  Options:")
+        click.echo("\n  Options:")
         _render_params(c.parameters)
 
-    click.echo(f"\n  Usage:")
+    click.echo("\n  Usage:")
     click.echo(f"    guard run tool {c.name} <target>")
     click.echo()
 
@@ -370,9 +376,12 @@ def update(sdk, name, update_registry, as_json):
         guard module update brutus
         guard module update --registry
     """
+    import re
     import subprocess
     from praetorian_cli.registry import get_registry
     from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
+
+    _repo_re = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
 
     reg = get_registry()
 
@@ -397,12 +406,16 @@ def update(sdk, name, update_registry, as_json):
         if not mod:
             continue
 
+        repo = mod.get("repo", "")
+        if not _repo_re.match(repo):
+            continue
+
         current = reg.get_version(tool_name)
         current_ver = current["version"] if current else "unknown"
 
         try:
             ver_result = subprocess.run(
-                ["gh", "release", "view", "--repo", mod["repo"], "--json", "tagName", "-q", ".tagName"],
+                ["gh", "release", "view", "--repo", repo, "--json", "tagName", "-q", ".tagName"],
                 capture_output=True, text=True, timeout=15,
             )
             latest_ver = ver_result.stdout.strip() if ver_result.returncode == 0 else None

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -8,33 +8,56 @@ from praetorian_cli.handlers.cli_decorators import cli_handler
 from praetorian_cli.handlers.utils import print_json, error
 
 
-# Friendly names for well-known agents — descriptions for the CLI help.
-# Also exported as TOOL_ALIASES for console compatibility. The console
-# dynamically adds capabilities resolved from the API at runtime.
-FRIENDLY_NAMES = {
-    'asset-analyzer': 'Deep-dive reconnaissance & risk mapping',
-    'brutus':         'Credential attacks (SSH, RDP, FTP, SMB)',
-    'julius':         'LLM/AI service fingerprinting',
-    'augustus':        'LLM jailbreak & prompt injection attacks',
-    'aurelius':       'Cloud infrastructure discovery (AWS/Azure/GCP)',
-    'trajan':         'CI/CD pipeline security scanning',
-    'priscus':        'Remediation retesting',
-    'seneca':         'CVE research & exploit intelligence',
-    'titus':          'Secret scanning & credential leak detection',
-}
+def _get_tool_aliases():
+    from praetorian_cli.registry import get_registry
+    return get_registry().get_tool_aliases()
 
-# TOOL_ALIASES: mutable dict used by the console. Seeded from FRIENDLY_NAMES,
-# dynamically extended when the console resolves capabilities from the API.
-TOOL_ALIASES = {
-    name: {'capability': name, 'agent': name, 'target_type': 'asset', 'description': desc}
-    for name, desc in FRIENDLY_NAMES.items()
-}
+
+class _LazyAliases:
+    """Lazy-loading dict wrapper so `from handlers.run import TOOL_ALIASES` still works."""
+    def __init__(self):
+        self._loaded = None
+
+    def _ensure(self):
+        if self._loaded is None:
+            self._loaded = _get_tool_aliases()
+        return self._loaded
+
+    def __contains__(self, key):
+        return key in self._ensure()
+
+    def __getitem__(self, key):
+        return self._ensure()[key]
+
+    def __setitem__(self, key, value):
+        self._ensure()[key] = value
+
+    def __iter__(self):
+        return iter(self._ensure())
+
+    def __len__(self):
+        return len(self._ensure())
+
+    def items(self):
+        return self._ensure().items()
+
+    def keys(self):
+        return self._ensure().keys()
+
+    def values(self):
+        return self._ensure().values()
+
+    def get(self, key, default=None):
+        return self._ensure().get(key, default)
+
+
+TOOL_ALIASES = _LazyAliases()
 
 
 def resolve_capability(sdk, name):
     """Resolve a capability name to its metadata from the backend API.
 
-    Checks FRIENDLY_NAMES for aliases, then queries the /capabilities/ endpoint.
+    Checks TOOL_ALIASES for aliases, then queries the /capabilities/ endpoint.
     Returns dict with at minimum: name, target, description. Or None.
     """
     # Check backend capabilities

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -60,6 +60,10 @@ def resolve_capability(sdk, name):
     Checks TOOL_ALIASES for aliases, then queries the /capabilities/ endpoint.
     Returns dict with at minimum: name, target, description. Or None.
     """
+    # Map an install/module name to its guard capability name (e.g. pius -> pius_discovery).
+    from praetorian_cli.registry import get_registry
+    name = get_registry().get_capability_name(name)
+
     # Check backend capabilities
     try:
         caps = sdk.capabilities.list(name=name)

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -12,6 +12,7 @@ import praetorian_cli.handlers.find
 import praetorian_cli.handlers.export
 import praetorian_cli.handlers.get
 import praetorian_cli.handlers.run
+import praetorian_cli.handlers.module
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.link
 import praetorian_cli.handlers.list

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -26,6 +26,7 @@ import praetorian_cli.handlers.hunt
 import praetorian_cli.handlers.knossos  # noqa: F401
 import praetorian_cli.handlers.run
 import praetorian_cli.handlers.schedule
+import praetorian_cli.handlers.module
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.leaderboard
 import praetorian_cli.handlers.link

--- a/praetorian_cli/modules/capabilities_snapshot.json
+++ b/praetorian_cli/modules/capabilities_snapshot.json
@@ -1,0 +1,1 @@
+{"capabilities": []}

--- a/praetorian_cli/modules/capabilities_snapshot.json
+++ b/praetorian_cli/modules/capabilities_snapshot.json
@@ -1,1 +1,5078 @@
-{"capabilities": []}
+{
+  "capabilities": [
+    {
+      "name": "smugchunks",
+      "title": "Smugchunks",
+      "target": [
+        "port"
+      ],
+      "description": "Detects HTTP request smuggling vulnerabilities using chunked transfer encoding.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "CHARIOT_HEADER",
+          "description": "Headers to send with the request",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "CHARIOT_USER_AGENT",
+          "description": "Headers to send with the request",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "linux-ad-umber-check",
+      "title": "Linux Umber AD Domain Check",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs Active Directory security checks using Umber. Evaluates domain configuration against security rules and best practices. Supports filtering by specific rules or categories to focus on particular security concerns.",
+      "category": "recon,ad",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Username for authentication.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for authentication.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Rules",
+          "description": "Comma-separated list of specific rules to run (e.g., 'rule1,rule2'). If empty, all rules are run unless Category is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Category",
+          "description": "Category of rules to run (e.g., 'passwords', 'privileges'). If empty, all categories are run unless Rules is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller address. If empty, auto-discovered via DNS.",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "cve-researcher-agent",
+      "title": "CVE Researcher Agent",
+      "target": [
+        "noinput"
+      ],
+      "description": "Query CISA KEV for CVEs, search for existing templates, and run vulnerability research pipeline",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "days",
+          "description": "Number of days to look back for CVEs",
+          "default": "1",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "cve_id",
+          "description": "Specific CVE ID to research (optional)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "format",
+          "description": "Output format (text, json, xml)",
+          "default": "text",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "detailed",
+          "description": "Include detailed CVE information",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "verbose",
+          "description": "Enable verbose output",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "run_pipeline",
+          "description": "Run the full CVE research pipeline",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "run_validation",
+          "description": "Run the full validation pipeline for each child account",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "create_prs",
+          "description": "Create PRs for new vulnerabilities",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "create_linear_ticket",
+          "description": "Create a linear ticket for new vulnerabilities",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "ldap-null-bind",
+      "title": "LDAP NULL Bind",
+      "target": [
+        "port"
+      ],
+      "description": "Checks LDAP servers for NULL bind authentication.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "cve-researcher-lite",
+      "title": "CVE Researcher Lite",
+      "target": [
+        "noinput"
+      ],
+      "description": "Generate Nuclei templates from CVE IDs using AI-powered research and template generation",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "cve_id",
+          "description": "CVE identifier (e.g., CVE-2021-44228)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "template_type",
+          "description": "Template type: detection, exploitation, or both",
+          "default": "detection",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "target_host",
+          "description": "Target host for template validation",
+          "default": "example.com",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "max_iterations",
+          "description": "Maximum fix iterations",
+          "default": "3",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "verbose",
+          "description": "Enable verbose logging",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "current_branch",
+          "description": "GitHub branch for template commit",
+          "default": "main",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "augustus",
+      "title": "Augustus",
+      "target": [
+        "webpage"
+      ],
+      "description": "scans LLM services for jailbreaks, prompt injection, and adversarial attacks",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "probes",
+          "description": "Probe patterns to run (glob supported, e.g. '*', 'dan.*')",
+          "default": "dan.*,goodside.SystemPromptConfusion,goodside.PayloadSplitting",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "timeout",
+          "description": "Per-request timeout (e.g. '60s', '2m')",
+          "default": "60s",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "goal",
+          "description": "Attack goal for adaptive attack phase",
+          "default": "Leak the system prompt",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "config_file",
+          "description": "Full Augustus YAML config file to override all other parameters (generators, probes, detectors, etc.)",
+          "required": false,
+          "type": "file"
+        },
+        {
+          "name": "generator_type",
+          "description": "Temporary generator type override (e.g. openai-compatible, ollama, rest)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_endpoint",
+          "description": "Temporary generator endpoint override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_model",
+          "description": "Temporary generator model override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_api_key",
+          "description": "Temporary generator API key override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_method",
+          "description": "Temporary generator HTTP method override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_response_path",
+          "description": "Temporary generator response path override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_response_type",
+          "description": "Temporary generator response type override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_timeout",
+          "description": "Temporary generator request timeout override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_proxy",
+          "description": "Temporary generator proxy override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_headers_json",
+          "description": "Temporary generator headers as a JSON object",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_body",
+          "description": "Temporary generator body override",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "generator_extra_json",
+          "description": "Temporary generator provider-specific extra config as a JSON object",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "collect-edgar",
+      "title": "EDGAR Filing Lookup",
+      "target": [
+        "preseed"
+      ],
+      "description": "collects EDGAR company information from SEC database",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "reverse-whois",
+      "title": "Reverse Whois",
+      "target": [
+        "preseed"
+      ],
+      "description": "performs reverse WHOIS lookups to find related domains",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-ad-smbsigning-dc",
+      "title": "Linux AD Domain Controller SMB Signing Check",
+      "target": [
+        "addomain"
+      ],
+      "description": "Executes NetExec (nxc) SMB signing check against target domain controllers to identify potential SMB signing vulnerabilities. This capability checks the SMB signing configuration of domain controllers to determine if they are vulnerable to SMB signing attacks. Supports both DNS-based discovery (external assessments) and credential-enhanced discovery (internal assessments) for maximum accuracy.",
+      "category": "recon",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username for enhanced DC discovery (optional - enables 99%+ accuracy vs 85-90% with DNS-only)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain password for enhanced DC discovery (optional - used with Username for authenticated LDAP queries)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "linux-gitlab-pat-scanner",
+      "title": "Linux Web GitLab PAT Scanner",
+      "target": [
+        "asset"
+      ],
+      "description": "Scans accessible GitLab projects for leaked Personal Access Tokens (glpat) using code search, validates discovered tokens via the GitLab API, and outputs a JSON report with metadata and occurrence details.",
+      "category": "recon",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "GitlabToken",
+          "description": "GitLab access token used to perform search across projects",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "NoVerifySSL",
+          "description": "Disable SSL certificate verification (use with caution for self-signed certificates)",
+          "default": "true",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "cve-2025-55182",
+      "title": "CVE-2025-55182",
+      "target": [
+        "webpage"
+      ],
+      "description": "Scans webpages for CVE-2025-55182",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "portscan",
+      "title": "Port Scan",
+      "target": [
+        "asset"
+      ],
+      "description": "scans IP addresses and CIDRs for open ports",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "webapp-discovery",
+      "title": "Web Application Discovery",
+      "target": [
+        "port"
+      ],
+      "description": "discovers web applications from port attributes with HTTP/HTTPS services",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "anon-ftps",
+      "title": "Anonymous FTPS",
+      "target": [
+        "port"
+      ],
+      "description": "Checks FTPS servers for anonymous access, supporting implied and explicit configurations.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "collect-favicon",
+      "title": "Favicon Lookup",
+      "target": [
+        "port"
+      ],
+      "description": "collects favicon images from web attributes for fingerprinting",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "github-repository",
+      "title": "GitHub Repository",
+      "target": [
+        "repository"
+      ],
+      "description": "monitors GitHub repositories for public exposure and recent changes",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "java-jmx-scanner",
+      "title": "Java JMX Scanner",
+      "target": [
+        "port"
+      ],
+      "description": "Scans for Java JMX services and detects exposed management interfaces without proper authentication.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "windows-web-nuclei",
+      "title": "Windows Web Nuclei",
+      "target": [
+        "attribute"
+      ],
+      "description": "Performs automated web application vulnerability scanning using Nuclei's extensive template library. Identifies security vulnerabilities, misconfigurations, exposed services, and potential attack vectors across web applications and services within the client's internal environment. Features comprehensive vulnerability detection including CVEs, exposed panels, default credentials, and security misconfigurations.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "TemplateFilter",
+          "description": "(Optional) Filter templates by tags (e.g., cves,exposures,network). Leave empty to run all templates. Common tags: cves, exposures, exposed-panels, default-logins, misconfiguration, vulnerabilities, network, ssl, dns",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "EnableAutoScan",
+          "description": "Enable automatic scan mode for comprehensive coverage",
+          "default": "true",
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional Nuclei arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "aurelian-azure-find-secrets",
+      "title": "Azure Find Secrets",
+      "target": [
+        "azureresource"
+      ],
+      "description": "Enumerates Azure resources via Resource Graph, extracts content likely to contain hardcoded secrets (VM user data, web app settings, automation variables, storage blobs, container env vars, Cosmos DB, APIM named values, Key Vault, and 30+ other sources), and scans with Titus.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "subscription-ids",
+          "description": "Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "db-path",
+          "description": "Path for Titus SQLite database",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "disabled-titus-rules",
+          "description": "Rule IDs to exclude from scanning",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "validate",
+          "description": "Validate detected secrets against their source APIs",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "ignore-file",
+          "description": "Path to gitignore-style file for skipping paths; when empty uses a default list",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ruleset",
+          "description": "Titus ruleset to apply; empty string disables ruleset filtering",
+          "default": "default",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "resource-id",
+          "description": "Azure resource ID(s) to scan directly, skipping enumeration",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "max-cosmos-doc-size",
+          "description": "Max individual Cosmos document size in bytes",
+          "default": "1048576",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "max-cosmos-doc-scan",
+          "description": "Max total Cosmos documents to scan per container",
+          "default": "50",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "burp-dast-scan",
+      "title": "Burp DAST Scan",
+      "target": [
+        "webapplication"
+      ],
+      "description": "initiates a single Burp DAST scan for a WebApplication target",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "burpsuite-internal",
+      "title": "BurpSuite Internal",
+      "target": [
+        "noinput"
+      ],
+      "description": "scans Burp Enterprise internal sites and retrieves vulnerability data",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "secrets",
+      "title": "secrets",
+      "target": [
+        "repository"
+      ],
+      "description": "scans repositories for sensitive information and secrets with titus",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "validation",
+          "description": "Validate discovered secrets against their source APIs (defaults to true)",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "rules",
+          "description": "Comma-separated list of rule IDs to scan for (defaults to all rules)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "full_history",
+          "description": "Scan full git history vs only HEAD (defaults to true)",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "priscus-agent",
+      "title": "Retest Validator",
+      "target": [
+        "risk"
+      ],
+      "description": "Specialized agent that validates remediation by retesting previously identified vulnerabilities, confirming fixes through targeted re-scans and evidence-based verification",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "collect-csp",
+      "title": "CSP Lookup",
+      "target": [
+        "port"
+      ],
+      "description": "collects Content Security Policy headers from HTTP responses",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "collect-tls",
+      "title": "TLS Lookup",
+      "target": [
+        "port"
+      ],
+      "description": "collects TLS certificates from HTTP endpoints",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "augustus-agent",
+      "title": "Augustus Agent",
+      "target": [
+        "webpage"
+      ],
+      "description": "Specialized agent that executes jailbreak detection, prompt injection testing, and adversarial attack simulation against fingerprinted LLM services to demonstrate AI security risks",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "edgar",
+      "title": "EDGAR Filings Extractor",
+      "target": [
+        "preseed"
+      ],
+      "description": "processes SEC EDGAR filings to extract subsidiary information",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "nfs-share",
+      "title": "NFS Share Enumerator",
+      "target": [
+        "port"
+      ],
+      "description": "",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "PROTOCOL",
+          "description": "The protocol -- UDP or TCP -- that we'd like to use. The most commonly encountered protocol for this module to run is UDP. If you are unsure which protocol to use, then leave as the default UDP. ",
+          "default": "udp",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "csp-mine",
+      "title": "CSP Extractor",
+      "target": [
+        "preseed"
+      ],
+      "description": "extracts domains from Content Security Policy directives",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "organization-enumeration",
+      "title": "Organization Enumeration",
+      "target": [
+        "asset"
+      ],
+      "description": "Enriches organization data using Apollo.io organizations/enrich API to gather company information, industry details, employee counts, and contact information",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "builtwith",
+      "title": "Web Tag Lookup",
+      "target": [
+        "preseed"
+      ],
+      "description": "looks up domains using the BuiltWith API based on analytics identifiers",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "tls-mine",
+      "title": "TLS Mine",
+      "target": [
+        "preseed"
+      ],
+      "description": "extracts domains from TLS certificates",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "titus-agent",
+      "title": "Repository Secret Scanner",
+      "target": [
+        "repository"
+      ],
+      "description": "Specialized agent that scans code repositories for leaked secrets, API keys, and credentials, validates them, and can orchestrate credential testing with Brutus",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "export",
+      "title": "Data Export",
+      "target": [
+        "noinput"
+      ],
+      "description": "Export assets, risks, seeds, technologies, or agents to CSV/JSON",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "java-rmi-scanner",
+      "title": "Java RMI Scanner (MSF)",
+      "target": [
+        "port"
+      ],
+      "description": "Scans for Java RMI services and detects exposed remote objects.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "login-detection",
+      "title": "Login Detection",
+      "target": [
+        "webpage"
+      ],
+      "description": "Login detection",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-web-nuclei",
+      "title": "Linux Web Nuclei",
+      "target": [
+        "attribute"
+      ],
+      "description": "Performs automated web application vulnerability scanning using Nuclei's extensive template library. Identifies security vulnerabilities, misconfigurations, exposed services, and potential attack vectors across web applications and services within the client's internal environment. Features comprehensive vulnerability detection including CVEs, exposed panels, default credentials, and security misconfigurations.",
+      "category": "recon",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "TemplateFilter",
+          "description": "(Optional) Filter templates by tags (e.g., cves,exposures,network). Leave empty to run all templates. Common tags: cves, exposures, exposed-panels, default-logins, misconfiguration, vulnerabilities, network, ssl, dns",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "EnableAutoScan",
+          "description": "Enable automatic scan mode for comprehensive coverage",
+          "default": "true",
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional Nuclei arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "windows-ad-pingcastle",
+      "title": "Windows AD PingCastle",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs comprehensive Active Directory security posture assessment using PingCastle's advanced health check algorithms. Analyzes AD configuration, identifies security vulnerabilities, weak authentication policies, privilege escalation paths, and provides detailed remediation recommendations with risk scoring across the client's domain infrastructure.",
+      "category": "recon,ad,windows",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Specify a domain controller to connect to",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ReportType",
+          "description": "Type of report to generate",
+          "default": "healthcheck",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "windows-network-nmap-s3support",
+      "title": "Windows Network Nmap with S3 Support",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs comprehensive network reconnaissance and port scanning from Windows environments using Nmap. Identifies open ports, running services, service versions, and potential vulnerabilities across target hosts within the client's network infrastructure. Includes service detection and vulnerability scanning capabilities to map the network attack surface.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "ports",
+          "description": "Port selection method",
+          "default": "Top100",
+          "required": true,
+          "type": "choices"
+        },
+        {
+          "name": "custom_ports",
+          "description": "Custom port specification when ports is set to 'Custom'. Examples: '80,443', '1-1000', '22,80-90,443'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "scan_flags",
+          "description": "Additional nmap flags for scanning options. The default value includes service detection, script scanning with default and vuln groups, and skipping Ping for checking if the target host responds.",
+          "default": "-sV -Pn",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "output_format",
+          "description": "Output format for Nmap results. Choose from xml (structured XML), text (normal text output), or grep (greppable format).",
+          "default": "xml",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "scanner-cve-2025-53770",
+      "title": "CVE-2025-53770",
+      "target": [
+        "port"
+      ],
+      "description": "Detect CVE-2025-53770 (Microsoft SharePoint Server ToolPane Unauthenticated Remote Code Execution) using Metasploit.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "timeout",
+          "description": "Connection timeout in seconds",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "linux-network-nerva",
+      "title": "Linux Network Nerva Service Scanner",
+      "target": [
+        "asset"
+      ],
+      "description": "Identifies services running on open ports using nerva, a fast service fingerprinting tool from Praetorian. Supports numerous protocols including HTTP, SSH, RDP, MySQL, PostgreSQL, SMB, LDAP, Kafka, and more. Accepts host:port pairs as input.",
+      "category": "recon,network",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Mode",
+          "description": "Execution mode",
+          "default": "nerva",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional nerva arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "aurelian-agent",
+      "title": "Cloud Resource Discovery",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Specialized agent that inventories and discovers cloud infrastructure across AWS, Azure, and GCP environments to map cloud attack surface and identify targets for security assessment",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "redirect",
+      "title": "Redirect",
+      "target": [
+        "port"
+      ],
+      "description": "analyzes a website's redirects and extracts associated assets",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "mongodb-login",
+      "title": "MongoDB Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks MongoDB servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "user_file",
+          "description": "",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "pass_file",
+          "description": "",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "workflow-whois-affiliation",
+      "title": "workflow-whois-affiliation",
+      "target": [
+        "noinput"
+      ],
+      "description": "Verify asset ownership via whois/RDAP records",
+      "version": "",
+      "executor": "litellm",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "asset",
+          "description": "IP address or domain to check",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "organization",
+          "description": "Target organization name to match against",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "config",
+          "description": "Path to YAML config file for LLM settings",
+          "required": false,
+          "type": "",
+          "options": [
+            "anthropic_opus",
+            "anthropic_sonnet",
+            "bedrock_claude_haiku",
+            "bedrock_claude_sonnet",
+            "bedrock_deepseek_r1_v1",
+            "bedrock_llama_3_1_8b",
+            "openai_gpt4o"
+          ]
+        },
+        {
+          "name": "output_dir",
+          "description": "Directory for output artifacts",
+          "required": false,
+          "type": ""
+        },
+        {
+          "name": "verbose",
+          "description": "Enable detailed logging (true/false)",
+          "required": false,
+          "type": ""
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "cisco-smart-install",
+      "title": "Cisco Smart Install Scanner",
+      "target": [
+        "port"
+      ],
+      "description": "Identifies Cisco Smart Install endpoints and determines if they speak the Smart Install Protocol. Exposure of SMI to untrusted networks can allow complete compromise of the switch.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "windows-ad-umber-collect",
+      "title": "Windows AD Umber Collect",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs comprehensive Active Directory enumeration and data collection using umber. Implements a SharpHound-style collection engine that enumerates all AD objects (users, computers, groups, GPOs, OUs, etc.) and collects their properties and relationships. Supports LDAP-only collection or extended collection including network sessions, local group membership, and user rights assignments via RPC.",
+      "category": "recon,ad",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Domain",
+          "description": "Domain where user credentials are valid. If empty, defaults to TargetDomain.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Username",
+          "description": "Username for authentication. If empty, uses current context.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for authentication. Required if Username is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller address. If empty, auto-discovered via DNS.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Threads",
+          "description": "Number of concurrent collection threads",
+          "default": "25",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "CollectAll",
+          "description": "Enable all computer collection methods (sessions, local groups, user rights via RPC). If false, only LDAP collection is performed.",
+          "default": "false",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "hackerone-submit",
+      "title": "HackerOne Submit",
+      "target": [
+        "risk"
+      ],
+      "description": "Submits vulnerability reports to HackerOne bug bounty programs",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "team_handle",
+          "description": "HackerOne program handle to submit the report to",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "title",
+          "description": "Override report title (defaults to finding title or risk name)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "vulnerability_information",
+          "description": "Override vulnerability details",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "impact",
+          "description": "Override impact statement",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "severity_rating",
+          "description": "Severity rating: none, low, medium, high, or critical",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "weakness_id",
+          "description": "HackerOne weakness ID",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "structured_scope_id",
+          "description": "HackerOne structured scope ID (asset identifier)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "attachment_s3_keys",
+          "description": "Comma-separated list of Guard S3 keys to upload as report attachments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "cloudbrute",
+      "title": "Cloudbrute",
+      "target": [
+        "asset"
+      ],
+      "description": "",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Janus Tools Directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "open-x11",
+      "title": "Open X11",
+      "target": [
+        "port"
+      ],
+      "description": "Checks for exposed openX11 displays.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "redis-login",
+      "title": "Redis Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks Redis servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "pass_file",
+          "description": "",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "julius-agent",
+      "title": "Julius Agent",
+      "target": [
+        "port"
+      ],
+      "description": "Specialized agent that fingerprints HTTP endpoints to detect AI/ML services (Ollama, OpenAI, LocalAI, vLLM) - required prerequisite before launching Augustus attacks",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "gato-artifacts",
+      "title": "Gato Artifact Scanner",
+      "target": [
+        "repository"
+      ],
+      "description": "Scans for hard-coded secrets in GitHub actions artifacts.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "outfile",
+          "description": "The JSON file to write the output to",
+          "default": "gato-artifacts.json",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "GH_TOKEN",
+          "description": "GitHub token to use for enumeration",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "imap-ntlm-info",
+      "title": "IMAP NTLM Enumerator",
+      "target": [
+        "port"
+      ],
+      "description": "Extracts NTLM information from IMAP servers using Nmap's imap-ntlm-info NSE script to identify Windows domain configurations and potential information disclosure vulnerabilities.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "windows-ad-umber-check",
+      "title": "Windows Umber AD Domain Check",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs Active Directory security checks using Umber. Evaluates domain configuration against security rules and best practices. Supports filtering by specific rules or categories to focus on particular security concerns.",
+      "category": "recon,ad",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Username for authentication. If empty, uses current context.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for authentication. Required if Username is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Rules",
+          "description": "Comma-separated list of specific rules to run (e.g., 'rule1,rule2'). If empty, all rules are run unless Category is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Category",
+          "description": "Category of rules to run (e.g., 'passwords', 'privileges'). If empty, all categories are run unless Rules is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller address. If empty, auto-discovered via DNS.",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "windows-ad-group3r-s3support",
+      "title": "Windows AD Group3r with S3 Support",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs security analysis of Active Directory Group Policy Objects (GPOs) to identify misconfigurations and vulnerabilities. Group3r examines GPO settings, ACLs, script paths, registry modifications, and privilege assignments to discover potential attack vectors, insecure configurations, and opportunities for privilege escalation within the client's AD Group Policy infrastructure.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Username (without domain, e.g., 'brandon.stark')",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for the specified username",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "TargetDomain",
+          "description": "Target domain to assess (e.g., 'north.sevenkingdoms.local')",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "DomainControllerIP",
+          "description": "IP address or hostname of a specific domain controller to connect to",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "aurelian-aws-org-policies",
+      "title": "AWS Organization Policies",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Collects AWS Organizations service control policies (SCPs) and resource control policies (RCPs), including the organizational hierarchy and policy-to-target mappings.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile",
+          "description": "AWS profile to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile-dir",
+          "description": "Set to override the default AWS profile directory",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opsec_level",
+          "description": "Operational security level for AWS operations",
+          "default": "none",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "research-gatekeeper",
+      "title": "CritFinder Adversarial Reviewer",
+      "target": [
+        "asset"
+      ],
+      "description": "Adversarial quality gate that filters vulnerability hypotheses \u2014 breaks bad hypotheses before they waste exploiter time",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "couchdb-login",
+      "title": "CouchDB Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks CouchDB servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "java-rmi-scanner-nse",
+      "title": "Java RMI Scanner (NSE)",
+      "target": [
+        "port"
+      ],
+      "description": "Enumerates Java RMI registries using Nmap's rmi-dumpregistry NSE script to identify exposed remote objects.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "workflow-exploit",
+      "title": "workflow-exploit",
+      "target": [
+        "noinput"
+      ],
+      "description": "Generate Nuclei exploit templates from CVE IDs (3-step: research \u2192 analyze \u2192 generate)",
+      "version": "",
+      "executor": "litellm",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "cve_id",
+          "description": "CVE identifier (e.g., CVE-2024-1234)",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "config",
+          "description": "Path to YAML config file for LLM settings",
+          "required": false,
+          "type": "",
+          "options": [
+            "anthropic_opus",
+            "anthropic_sonnet",
+            "bedrock_claude_haiku",
+            "bedrock_claude_sonnet",
+            "bedrock_deepseek_r1_v1",
+            "bedrock_llama_3_1_8b",
+            "openai_gpt4o"
+          ]
+        },
+        {
+          "name": "output_dir",
+          "description": "Directory for output artifacts (auto-generated if not specified)",
+          "required": false,
+          "type": ""
+        },
+        {
+          "name": "verbose",
+          "description": "Enable detailed logging - shows model calls and responses (true/false)",
+          "required": false,
+          "type": ""
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "workflow-generate",
+      "title": "workflow-generate",
+      "target": [
+        "noinput"
+      ],
+      "description": "Generate Nuclei detection templates from CVE IDs (2-step: research \u2192 generate)",
+      "version": "",
+      "executor": "litellm",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "cve_id",
+          "description": "CVE identifier (e.g., CVE-2024-1234)",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "config",
+          "description": "Path to YAML config file for LLM settings",
+          "required": false,
+          "type": "",
+          "options": [
+            "anthropic_opus",
+            "anthropic_sonnet",
+            "bedrock_claude_haiku",
+            "bedrock_claude_sonnet",
+            "bedrock_deepseek_r1_v1",
+            "bedrock_llama_3_1_8b",
+            "openai_gpt4o"
+          ]
+        },
+        {
+          "name": "output_dir",
+          "description": "Directory for output artifacts (auto-generated if not specified)",
+          "required": false,
+          "type": ""
+        },
+        {
+          "name": "template_type",
+          "description": "Template type: detection or exploitation (default: detection)",
+          "required": false,
+          "type": ""
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "ip",
+      "title": "WHOIS (IP)",
+      "target": [
+        "asset"
+      ],
+      "description": "resolves IP addresses or CIDRs to ASN, country, and AS name",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-ad-smbellum",
+      "title": "Linux AD SMBellum Share Scanner",
+      "target": [
+        "addomain"
+      ],
+      "description": "Scans SMB shares for sensitive data using Titus. Performs domain-wide share discovery and scanning with in-memory file analysis.",
+      "category": "recon,ad,smb",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username for authentication.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "DomainController",
+          "description": "Domain controller hostname/IP for AD share discovery (e.g., dc01.corp.local). If empty, auto-discovered via DNS.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Dns",
+          "description": "Custom DNS server IP for hostname resolution.",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "collect-cidr",
+      "title": "CIDR Lookup",
+      "target": [
+        "preseed"
+      ],
+      "description": "collects CIDR information from regional internet registries for organizations found in WHOIS data",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "github-device-code",
+      "title": "GitHub Device Code Phishing",
+      "target": [
+        "person"
+      ],
+      "description": "Executes GitHub OAuth 2.0 Device Authorization Grant phishing attack by sending device code via email and monitoring for authorization",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "reverse-csp",
+      "title": "Reverse CSP",
+      "target": [
+        "preseed"
+      ],
+      "description": "searches for websites with matching Content Security Policy headers",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "workflow-refine",
+      "title": "workflow-refine",
+      "target": [
+        "noinput"
+      ],
+      "description": "Refine existing Nuclei templates with CVE research (2-step: research \u2192 refine)",
+      "version": "",
+      "executor": "litellm",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "cve_id",
+          "description": "CVE identifier (e.g., CVE-2024-1234)",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "template",
+          "description": "Path to existing Nuclei template file to refine",
+          "required": true,
+          "type": ""
+        },
+        {
+          "name": "config",
+          "description": "Path to YAML config file for LLM settings",
+          "required": false,
+          "type": "",
+          "options": [
+            "anthropic_opus",
+            "anthropic_sonnet",
+            "bedrock_claude_haiku",
+            "bedrock_claude_sonnet",
+            "bedrock_deepseek_r1_v1",
+            "bedrock_llama_3_1_8b",
+            "openai_gpt4o"
+          ]
+        },
+        {
+          "name": "output_dir",
+          "description": "Directory for output artifacts (auto-generated if not specified)",
+          "required": false,
+          "type": ""
+        },
+        {
+          "name": "prompt",
+          "description": "Refinement guidance (e.g., 'reduce false positives')",
+          "required": false,
+          "type": ""
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "ab-benchmark",
+      "title": "Apache Benchmark",
+      "target": [
+        "asset"
+      ],
+      "description": "HTTP load testing using Apache Benchmark (ab) against a domain or IP address with verbose output logging",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "duration",
+          "description": "Duration in seconds (1\u20133600, max 60 minutes)",
+          "default": "300",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "concurrency",
+          "description": "Number of concurrent requests",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "requests",
+          "description": "Maximum total number of requests (0 = unlimited, time-based only)",
+          "default": "0",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "processes",
+          "description": "Number of concurrent ab processes to spawn (1\u201310)",
+          "default": "1",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "path",
+          "description": "URL path to benchmark",
+          "default": "/",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "method",
+          "description": "HTTP method (GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH)",
+          "default": "GET",
+          "required": false,
+          "type": "string",
+          "options": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "HEAD",
+            "OPTIONS",
+            "PATCH"
+          ]
+        },
+        {
+          "name": "headers",
+          "description": "Custom HTTP headers, one per line (e.g. Content-Type: application/json)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "description": "Request body to send (requires a non-GET method)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "scheme",
+          "description": "URL scheme",
+          "default": "https",
+          "required": false,
+          "type": "string",
+          "options": [
+            "https",
+            "http"
+          ]
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "bulk-action",
+      "title": "Bulk Action",
+      "target": [
+        "noinput"
+      ],
+      "description": "Apply an action to a bulk selection of items",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "snmp-community-strings",
+      "title": "SNMP Community Strings",
+      "target": [
+        "port"
+      ],
+      "description": "Checks SNMP servers for default/weak community strings",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "VERSION",
+          "description": "The version of SNMP (if known). Supplying the version can help reduce duplicates from Metasploit. Options are: (1,2c,all)",
+          "default": "all",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "windows-smb-snaffler",
+      "title": "Windows SMB Snaffler",
+      "target": [
+        "addomain"
+      ],
+      "description": "Discovers and analyzes sensitive files, credentials, and configuration data across SMB network shares in Windows AD environments. Supports running with the current computer/user context (no credentials required on domain-joined machines) or with explicit credentials. Snaffler automatically crawls accessible shares, identifies files containing passwords, API keys, certificates, and other high-value secrets that could be leveraged during lateral movement or privilege escalation attacks.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "VerbosityLevel",
+          "description": "Level of output verbosity from data (least verbose) to trace (most verbose)",
+          "default": "info",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "Username",
+          "description": "Domain username for authentication. If empty, uses the current computer/user context.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password. Required only if Username is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "DomainController",
+          "description": "Domain controller to connect to. Useful when auto-discovery fails.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "MaxSizeToScan",
+          "description": "(Optional) Maximum file size in bytes to scan for content (in bytes). Default: 10MB",
+          "default": "0",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "MaxThreads",
+          "description": "(Optional) Maximum number of concurrent threads to use. Don't set it below 4. Default: 60",
+          "default": "0",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "TargetHosts",
+          "description": "(Optional) Disable AD discovery and scan a list of hosts (e.g. 192.168.1.1,192.168.1.35)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "TargetPath",
+          "description": "(Optional) Disable AD discovery and scan specific shares (e.g. \\\\host.lol.domain\\share) or folders (e.g. C:\\)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "OptionalRuleSet",
+          "description": "(Optional) Load a custom ZIP file containing a folder with .toml files to use as ruleset instead of the default ones",
+          "default": "<nil>",
+          "required": false,
+          "type": "upload"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional Snaffler arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "brutus",
+      "title": "brutus",
+      "target": [
+        "port"
+      ],
+      "description": "credential testing against network services",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "usernames",
+          "description": "Comma-separated list of usernames to test (defaults to brutus-provided list)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "passwords",
+          "description": "Comma-separated list of passwords to test (defaults to brutus-provided list)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ratelimit",
+          "description": "Requests per second, supports fractional values like 0.5 (defaults to unlimited)",
+          "required": false,
+          "type": "float"
+        },
+        {
+          "name": "protocol",
+          "description": "The protocol to use (defaults to the protocol detected on this port)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "webpage-secrets",
+      "title": "Webpage Secrets",
+      "target": [
+        "webpage"
+      ],
+      "description": "detection of secrets in webpage responses",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "cato-agent",
+      "title": "Finding Validator",
+      "target": [
+        "risk"
+      ],
+      "description": "Specialized agent that validates triage security findings through evidence retrieval, asset attribution, deduplication, knowledge loading, validation, severity evaluation, evidence drafting, and risk proposal",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "person-enumeration",
+      "title": "Person Enumeration",
+      "target": [
+        "organization"
+      ],
+      "description": "Enumerates people associated with organizations using Apollo.io People Search API to discover employees and their contact information",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-web-gowitness",
+      "title": "Linux Web GoWitness",
+      "target": [
+        "attribute"
+      ],
+      "description": "Automates web reconnaissance and takes web screenshots of assets within the client's internal environment. GoWitness captures visual proof of web services, helping identify running applications, service banners, and potential security exposures through automated screenshot collection.",
+      "category": "recon",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Targets",
+          "description": "Target URLs (comma-separated). Examples: 'https://example.com', 'https://example.com/page1,https://example.com/page2'",
+          "default": "https://praetorian.com",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "cookie-monster",
+      "title": "Cookie Monster",
+      "target": [
+        "port"
+      ],
+      "description": "Finds weak session tokens in cookies.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "wordlist",
+          "description": "Path to custom wordlist file (base64 encoded entries, one per line)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "ipmi-cipher-zero",
+      "title": "IPMI Cipher Zero Authentication Bypass Scanner",
+      "target": [
+        "port"
+      ],
+      "description": "Identifies IPMI 2.0-compatible systems vulnerable to authentication bypass through cipher zero.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "HOME environment variable for Metasploit",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "telnet-login",
+      "title": "Telnet Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks Telnet servers for weak credentials",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "trajan-agent",
+      "title": "CI/CD Security Scanner",
+      "target": [
+        "repository"
+      ],
+      "description": "Specialized agent that scans CI/CD pipelines for security vulnerabilities including injection, supply chain poisoning, permission misconfigurations, and AI code review agent attacks across GitHub Actions, GitLab CI, Azure DevOps, Jenkins, and JFrog",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-network-naabu",
+      "title": "Linux Network Naabu Port Scanner",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs fast port scanning using Naabu, a high-speed port scanner from ProjectDiscovery. Identifies open ports across target hosts using SYN/CONNECT scans with configurable port ranges and rate limiting. For combined port scanning, service detection, and DNS resolution, use the Network Recon capability instead.",
+      "category": "recon,network",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Mode",
+          "description": "Execution mode",
+          "default": "naabu",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Ports",
+          "description": "Port selection mode",
+          "default": "Top100",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "CustomPorts",
+          "description": "Custom port specification when Ports is set to 'Custom'. Examples: '80,443', '1-1000', '22,80-90,443'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Rate",
+          "description": "Packets per second rate limit",
+          "default": "1000",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional naabu arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "oracle-database-login",
+      "title": "Oracle DB Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks Oracle Database servers for weak and default credentials",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "SID",
+          "description": "The SID for the Oracle Database. You need to know what the correct, unique SID is prior to running this script.",
+          "default": "XEPDB1",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "aurelian-azure-public-resources",
+      "title": "Azure Public Resources",
+      "target": [
+        "azureresource"
+      ],
+      "description": "Identifies publicly accessible Azure resources by executing Azure Resource Graph query templates against target subscriptions. Detects public storage accounts, databases, key vaults, web apps, and other resources exposed to the internet.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "subscription-ids",
+          "description": "Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "template-dir",
+          "description": "Optional directory with additional YAML query templates",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "asset-analyzer",
+      "title": "Asset Security Analyzer",
+      "target": [
+        "asset"
+      ],
+      "description": "Specialized agent that performs deep-dive security analysis of individual assets - maps risks, technologies, relationships, attack paths, and recommends targeted offensive capabilities",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "subdomain",
+      "title": "Subdomain",
+      "target": [
+        "asset"
+      ],
+      "description": "discovered subdomains of a domain using various public APIs",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "research-scanner",
+      "title": "CritFinder Vulnerability Scanner",
+      "target": [
+        "asset"
+      ],
+      "description": "Generates structured vulnerability hypotheses through attack surface analysis of Guard entities",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "discovery-triage-agent",
+      "title": "Discovery Triage",
+      "target": [
+        "asset"
+      ],
+      "description": "Specialized agent that triages pending assets and seeds by evaluating discovery confidence, origination data, and supplemental OSINT checks to approve or defer their activation",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "passive-recon",
+      "title": "passive-recon",
+      "target": [
+        "webapplication"
+      ],
+      "description": "discovers endpoints via passive URL enumeration (Wayback, CommonCrawl, OTX, URLScan) and emits live URLs as Webpage assets",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "collection-timeout",
+          "description": "Passive URL collection timeout in seconds",
+          "default": "600",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "probe-concurrency",
+          "description": "Number of concurrent liveness probe requests",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "dns-zone-transfer",
+      "title": "DNS Zone Transfer",
+      "target": [
+        "port"
+      ],
+      "description": "Checks if zone transfers are enabled for a DNS server",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-network-nmap",
+      "title": "Linux Network Nmap",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs comprehensive network reconnaissance by scanning target hosts to identify open ports, running services, service versions, and potential vulnerabilities. Uses Nmap's powerful scanning engine to map the network attack surface and gather intelligence on exposed services within the client's environment.",
+      "category": "recon,network",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "ports",
+          "description": "Port selection method",
+          "default": "Top100",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "custom_ports",
+          "description": "Custom port specification when Ports is set to 'Custom'. Examples: '80,443', '1-1000', '22,80-90,443', or '-' for all ports",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "scan_flags",
+          "description": "Additional nmap flags for scanning options",
+          "default": "-sV -Pn",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "aurelian-aws-graph",
+      "title": "AWS Graph Analysis",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Collects AWS IAM data (GAAD, resources, policies), evaluates permissions, and detects privilege escalation paths. Outputs JSON by default; use --neo4j-uri to populate graph database with relationships.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile",
+          "description": "AWS profile to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile-dir",
+          "description": "Set to override the default AWS profile directory",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opsec_level",
+          "description": "Operational security level for AWS operations",
+          "default": "none",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "regions",
+          "description": "AWS regions to scan",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-type",
+          "description": "AWS Cloud Control resource type",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-arn",
+          "description": "AWS target resource ARN",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "neo4j-uri",
+          "description": "Neo4j connection URI (e.g., bolt://localhost:7687)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "neo4j-username",
+          "description": "Neo4j username",
+          "default": "neo4j",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "neo4j-password",
+          "description": "Neo4j password",
+          "default": "neo4j",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "org-policies-file",
+          "description": "Path to Org Policies JSON file",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "caligula-ami",
+      "title": "Caligula AMI",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Scans Amazon Linux AMIs for OS-level vulnerabilities by peeling each AMI's EBS snapshot, extracting the RPM database, and matching against ALAS / EPSS / CISA KEV",
+      "version": "",
+      "executor": "chariot",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "min_severity",
+          "description": "Minimum severity threshold for findings",
+          "default": "low",
+          "required": false,
+          "type": "string",
+          "options": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        {
+          "name": "kev_only",
+          "description": "Only emit findings flagged in CISA KEV",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "max_ami_size_gb",
+          "description": "Skip AMIs whose root volume exceeds this many GB",
+          "default": "256",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "constantine",
+      "title": "Constantine",
+      "target": [
+        "repository"
+      ],
+      "description": "LLM-powered source code vulnerability scanner",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "pipeline",
+          "description": "Predefined pipeline to run (leave blank for auto-selection based on scan type)",
+          "required": false,
+          "type": "string",
+          "options": [
+            "premium",
+            "medium",
+            "basic"
+          ]
+        },
+        {
+          "name": "scan_mode",
+          "description": "Scan mode: auto (skip when HEAD unchanged, delta-scan when possible), full (entire repo), diff (last_scanned_commit..HEAD only)",
+          "default": "auto",
+          "required": false,
+          "type": "string",
+          "options": [
+            "auto",
+            "full",
+            "diff"
+          ]
+        },
+        {
+          "name": "custom_pipeline",
+          "description": "Custom pipeline YAML file (overrides pipeline param)",
+          "required": false,
+          "type": "file"
+        },
+        {
+          "name": "goal",
+          "description": "Goal to inject into all LLM system prompts (e.g. 'Focus on SQL injection vulnerabilities')",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "aurelian-azure-list-all",
+      "title": "Azure List All Resources",
+      "target": [
+        "azureresource"
+      ],
+      "description": "List all Azure resources across subscriptions using Azure Resource Graph. Supports scanning specific subscriptions or all accessible subscriptions.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "subscription-ids",
+          "description": "Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "ipmi-hash-extraction",
+      "title": "IPMI Hash Extraction",
+      "target": [
+        "port"
+      ],
+      "description": "Detects vulnerable IPMI interfaces and extracts password hashes from discovered IPMI services.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "HOME environment variable for Metasploit",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "linux-ad-certipy",
+      "title": "Linux AD Certipy Certificate Template Vulnerability Scanner",
+      "target": [
+        "addomain"
+      ],
+      "description": "Executes Certipy to find vulnerable Active Directory Certificate Services (ADCS) certificate templates and outputs results in JSON format. This capability identifies certificate templates that may be vulnerable to various attacks including ESC1, ESC2, ESC3, and other certificate-based privilege escalation techniques. Requires domain credentials and domain controller IP for authenticated enumeration.",
+      "category": "recon",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller IP address or hostname (optional - will auto-discover if not provided)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "aurelian-aws-public-resources",
+      "title": "AWS Public Resources",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Finds publicly accessible AWS resources through policy evaluation, property inspection, and enrichment. Combines resource listing, enrichment, policy fetching, and public access evaluation to identify resources that are exposed to the internet or allow anonymous access.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile",
+          "description": "AWS profile to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile-dir",
+          "description": "Set to override the default AWS profile directory",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opsec_level",
+          "description": "Operational security level for AWS operations",
+          "default": "none",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "regions",
+          "description": "AWS regions to scan",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-type",
+          "description": "AWS Cloud Control resource type",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-arn",
+          "description": "AWS target resource ARN",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "org-policies-file",
+          "description": "Path to Org Policies JSON file",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "favicon",
+      "title": "Favicon Extractor",
+      "target": [
+        "preseed"
+      ],
+      "description": "searches for websites with matching favicons using Shodan",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "aurelian-azure-subdomain-takeover",
+      "title": "Azure Subdomain Takeover",
+      "target": [
+        "azureresource"
+      ],
+      "description": "Scan for dangling DNS records in Azure DNS zones that could enable subdomain takeover. Checks CNAME records for unclaimed App Service, Blob Storage, CDN, and Traffic Manager names; A/AAAA records for orphaned public IPs; and NS delegations to non-existent Azure DNS zones.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "subscription-ids",
+          "description": "Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Number of concurrent checker goroutines",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "romulus-agent",
+      "title": "Web Exploiter",
+      "target": [
+        "webapplication"
+      ],
+      "description": "Browser-driven web exploiter for SPA / auth-walled targets. Navigates rendered pages, harvests endpoints from network traffic, then tests them directly with curl/python. Files Risks directly via report_new_risk when a chain lands.",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "smb-userenum",
+      "title": "SMB User Enumeration",
+      "target": [
+        "port"
+      ],
+      "description": "Enumerates users on exposed SMB servers",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "caligula",
+      "title": "caligula",
+      "target": [
+        "repository"
+      ],
+      "description": "scans software dependencies for known vulnerabilities, malicious packages, typosquatting, code obfuscation, and supply chain integrity issues",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "mod",
+          "description": "Modules to run: all, deps, malware, iac",
+          "default": "all",
+          "required": false,
+          "type": "string",
+          "options": [
+            "all",
+            "deps",
+            "malware",
+            "iac"
+          ]
+        },
+        {
+          "name": "min_severity",
+          "description": "Minimum severity threshold for findings",
+          "default": "low",
+          "required": false,
+          "type": "string",
+          "options": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        {
+          "name": "aws_region",
+          "description": "AWS region for AMI peel calls (mod=iac)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "no_peel",
+          "description": "Discovery only: skip AMI peel + advisory match (mod=iac)",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "kev_only_gate",
+          "description": "Exit non-zero only on KEV findings (mod=iac)",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "rpm_manifest",
+          "description": "Path to rpm -qa output file for Amazon Linux scanning",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "dir",
+          "description": "Local clone path",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "windows-smb-powerhuntshares",
+      "title": "Windows SMB PowerHuntShares",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs comprehensive SMB share enumeration and access analysis across Active Directory environments. PowerHuntShares discovers accessible network shares, analyzes permissions, identifies potentially sensitive directories, and maps the SMB attack surface within the client's internal network infrastructure.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "(Optional) Domain username (without domain prefix)",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "(Optional) Domain user password",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "DomainController",
+          "description": "(Optional) Specify domain controller to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Threads",
+          "description": "Number of threads to use",
+          "default": "100",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "RunSpaceTimeOut",
+          "description": "Timeout for runspaces in seconds",
+          "default": "10",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "Additional PowerHuntShares arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "gowitness",
+      "title": "Gowitness",
+      "target": [
+        "webpage"
+      ],
+      "description": "takes screenshots of webpages",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "finger-username-enumeration",
+      "title": "Finger Username Enumeration",
+      "target": [
+        "port"
+      ],
+      "description": "Enumerates usernames on a finger server",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "The JANUS_TOOLS environment variable that maps the path to the janus/tools/ directory.",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "windows-database-powerupsql-audit",
+      "title": "Windows Database PowerUpSQL Audit",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs comprehensive SQL Server security auditing using PowerUpSQL's Invoke-SQLAudit functionality. Identifies SQL Server vulnerabilities, misconfigurations, excessive privileges, weak authentication, and security gaps across discovered SQL instances within the client's Active Directory environment. Can audit individual instances or automatically discover and audit all SQL servers in the domain.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Instance",
+          "description": "SQL Server instance to audit (e.g., SQLServer1\\Instance1). Not required when using DiscoverAndAuditAll.",
+          "default": "SQLSERVER01\\MSSQLSERVER",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "DiscoverAndAuditAll",
+          "description": "Discover all SQL Server instances (local, AD, and linked servers) and audit them all. When enabled, Instance parameter is ignored.",
+          "default": "false",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Username",
+          "description": "Domain username for authentication (optional)",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password (optional)",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "brutus-agent",
+      "title": "Credential Security Tester",
+      "target": [
+        "port"
+      ],
+      "description": "Specialized agent that discovers authentication services (SSH, RDP, FTP, SMB, etc.) and tests for weak, default, or compromised credentials to demonstrate unauthorized access",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "chain-correlator",
+      "title": "Exploit Chain Correlator",
+      "target": [
+        "noinput"
+      ],
+      "description": "Correlates customer CVE inventories against curated database of in-the-wild desktop exploit chains",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "nuclei-dast",
+      "title": "nuclei-dast",
+      "target": [
+        "webpage"
+      ],
+      "description": "runs Nuclei DAST and generic vulnerability templates against a discovered webpage and emits risks for findings",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "nuclei-rate-limit",
+          "description": "Nuclei requests per second rate limit",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "trajan",
+      "title": "trajan",
+      "target": [
+        "repository"
+      ],
+      "description": "Scans CI/CD pipelines for security vulnerabilities including injection, supply chain, and permission misconfigurations",
+      "version": "",
+      "executor": "chariot",
+      "surface": "repository",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "token",
+          "description": "Authentication token for the CI/CD platform API",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "platform",
+          "description": "CI/CD platform override (auto-detected from URL if omitted). Required for self-hosted platforms: jenkins, jfrog",
+          "required": false,
+          "type": "string",
+          "options": [
+            "github",
+            "gitlab",
+            "azuredevops",
+            "bitbucket",
+            "jenkins",
+            "jfrog",
+            "circleci"
+          ]
+        },
+        {
+          "name": "base_url",
+          "description": "Base URL for self-hosted platforms (e.g., https://jenkins.corp.com). Required when platform=jenkins or platform=jfrog",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "active_mode",
+          "description": "Enable active attack execution (disabled by default)",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "attack_plugins",
+          "description": "Attack plugins to execute",
+          "required": false,
+          "type": "[]string",
+          "options": [
+            "azuredevops/ado-agent-exec",
+            "azuredevops/ado-ai-probe",
+            "azuredevops/ado-extract-connections",
+            "azuredevops/ado-extract-securefiles",
+            "azuredevops/ado-persistence",
+            "azuredevops/ado-pipeline-injection",
+            "azuredevops/ado-pr-attack",
+            "azuredevops/ado-privesc",
+            "azuredevops/ado-secrets-dump",
+            "github/ai-probe",
+            "github/ai-prompt-injection",
+            "github/c2-setup",
+            "github/interactive-shell",
+            "github/persistence",
+            "github/pr-attack",
+            "github/runner-on-runner",
+            "github/secrets-dump",
+            "github/workflow-injection",
+            "gitlab/ai-probe"
+          ]
+        },
+        {
+          "name": "dry_run",
+          "description": "Simulate attacks without making changes",
+          "default": "true",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "attack_timeout",
+          "description": "Timeout in seconds for attack execution",
+          "default": "300",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "c2_repo",
+          "description": "C2 repository for interactive shell and runner-on-runner attacks (e.g., owner/repo)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "target_os",
+          "description": "Target runner OS for runner-on-runner attacks",
+          "required": false,
+          "type": "string",
+          "options": [
+            "linux",
+            "win",
+            "macos"
+          ]
+        },
+        {
+          "name": "target_arch",
+          "description": "Target runner architecture for runner-on-runner attacks",
+          "required": false,
+          "type": "string",
+          "options": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "name": "runner_labels",
+          "description": "Comma-separated runner labels for targeting specific runners",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "delivery",
+          "description": "Delivery method for AI prompt injection attacks",
+          "required": false,
+          "type": "string",
+          "options": [
+            "pr",
+            "issue",
+            "comment"
+          ]
+        },
+        {
+          "name": "persistence_method",
+          "description": "Persistence method for persistence attacks",
+          "required": false,
+          "type": "string",
+          "options": [
+            "workflow",
+            "action",
+            "package"
+          ]
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "mssql-login",
+      "title": "MSSQL Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks MSSQL servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "The JANUS_TOOLS environment variable that maps the path to the janus/tools/ directory.",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "linux-ad-bloodhound",
+      "title": "Linux AD BloodHound Data Collector",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs Active Directory data collection using BloodHound.py",
+      "category": "recon,ad",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username for authentication",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "CollectionMethod",
+          "description": "Data collection method to use. Multiple methods can be comma-separated (e.g., Group,LocalAdmin)",
+          "default": "All",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller IP address or hostname (optional - will auto-discover if not provided)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "subdomain-test",
+      "title": "",
+      "target": [
+        "asset"
+      ],
+      "description": "Test agent for subdomain capability tool validation",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "unauth-mqtt-broker",
+      "title": "Unauthenticated MQTT Broker",
+      "target": [
+        "port"
+      ],
+      "description": "Checks MQTT servers for unauthenticated access",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "integration-affiliation",
+      "title": "Integration Affiliation Agent",
+      "target": [
+        "asset"
+      ],
+      "description": "Determines whether an integration-originated asset still belongs to the user.",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "aurelian-aws-list-all",
+      "title": "AWS List All Resources",
+      "target": [
+        "awsresource"
+      ],
+      "description": "List resources in an AWS account using CloudControl API. Supports 'full' scan for all resources or 'summary' scan for key services. Can scan multiple regions concurrently.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile",
+          "description": "AWS profile to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile-dir",
+          "description": "Set to override the default AWS profile directory",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opsec_level",
+          "description": "Operational security level for AWS operations",
+          "default": "none",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "regions",
+          "description": "AWS regions to scan",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-type",
+          "description": "AWS Cloud Control resource type",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-arn",
+          "description": "AWS target resource ARN",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "scan-type",
+          "description": "Scan type - 'full' for all resources or 'summary' for key services",
+          "default": "full",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "crawler",
+      "title": "Crawler",
+      "target": [
+        "webapplication"
+      ],
+      "description": "Crawls web applications to discover content, enumerate directories, and identify authentication mechanisms",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "nuclei",
+      "title": "Nuclei",
+      "target": [
+        "port"
+      ],
+      "description": "scans services for vulnerabilities using nuclei templates across HTTP, TCP, DNS, SSL, and other protocols",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "test",
+          "description": "Nuclei template ID to run (passed to -id). Leave blank to run the default template set.",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "postgres-login",
+      "title": "Postgres Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks PostgreSQL servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "correlation-engine",
+      "title": "Batch Correlation Engine",
+      "target": [
+        "noinput"
+      ],
+      "description": "pages through all correlatable assets and cross-references them against integrated service providers",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "vespasian",
+      "title": "vespasian",
+      "target": [
+        "webapplication"
+      ],
+      "description": "discovers API endpoints via headless browser crawling and generates OpenAPI specs",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "mode",
+          "description": "Operating mode: scan (default) or crawl",
+          "default": "scan",
+          "required": false,
+          "type": "string",
+          "options": [
+            "scan",
+            "crawl"
+          ]
+        },
+        {
+          "name": "timeout",
+          "description": "Total crawl duration in seconds",
+          "default": "600",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "max_pages",
+          "description": "Maximum pages to crawl",
+          "default": "100",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "depth",
+          "description": "Maximum crawl depth",
+          "default": "3",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "scope",
+          "description": "Crawl scope: same-origin or same-domain",
+          "default": "same-origin",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "headers",
+          "description": "Comma-separated auth headers (e.g. Authorization: Bearer tok)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "confidence",
+          "description": "Minimum classification confidence 0-1",
+          "default": "0.5",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "probe",
+          "description": "Enable endpoint probing",
+          "default": "true",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "mysql-login",
+      "title": "MySQL Login",
+      "target": [
+        "port"
+      ],
+      "description": "Checks MySQL servers for weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "JANUS_TOOLS",
+          "description": "Path to Janus tools directory",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "cidr",
+      "title": "CIDR",
+      "target": [
+        "preseed"
+      ],
+      "description": "queries CIDR blocks from various regional internet registries",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "julius",
+      "title": "Julius",
+      "target": [
+        "port"
+      ],
+      "description": "detects LLM services (Ollama, OpenAI, etc.) on HTTP endpoints",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "base-paths",
+          "description": "Comma-separated path prefixes for probing nonstandard LLM endpoint paths (e.g., /api,/proxy)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "whois",
+      "title": "WHOIS (Domain)",
+      "target": [
+        "asset"
+      ],
+      "description": "performs WHOIS lookups for domains and extracts registration information",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "bad-dns",
+      "title": "Bad DNS",
+      "target": [
+        "asset"
+      ],
+      "description": "A tool to check for subdomain takeover vulnerabilities using baddns.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "windows-ad-group3r",
+      "title": "Windows AD Group3r",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs security analysis of Active Directory Group Policy Objects (GPOs) to identify misconfigurations and vulnerabilities. Group3r examines GPO settings, ACLs, script paths, registry modifications, and privilege assignments to discover potential attack vectors, insecure configurations, and opportunities for privilege escalation within the client's AD Group Policy infrastructure.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Username (without domain, e.g., 'brandon.stark')",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for the specified username",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "TargetDomain",
+          "description": "Target domain to assess (e.g., 'north.sevenkingdoms.local')",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "DomainControllerIP",
+          "description": "IP address or hostname of a specific domain controller to connect to",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "diana-agent",
+      "title": "",
+      "target": [
+        "asset",
+        "integration"
+      ],
+      "description": "Diana \u2014 makes read-only API calls to cloud and integration environments (AWS, GitHub, GitLab) via native CLIs",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "freeze",
+      "title": "Tenant Burp Teardown",
+      "target": [
+        "noinput"
+      ],
+      "description": "Pause every Burp site under a frozen tenant's folder and drop folder-level schedules.",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "recorder-agent",
+      "title": "Login Recipe Recorder",
+      "target": [
+        "webapplication"
+      ],
+      "description": "Drives a browser-based login against a target with supplied credentials and emits a deterministic webauth recipe (CredentialBlob) that downstream capabilities can replay without an LLM in the loop.",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "research-exploiter",
+      "title": "CritFinder Exploit Validator",
+      "target": [
+        "asset"
+      ],
+      "description": "Validates approved vulnerability hypotheses through practical exploitation and evidence collection within the CritFinder adversarial research pipeline",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "windows-network-nmap",
+      "title": "Windows Network Nmap",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs comprehensive network reconnaissance and port scanning from Windows environments using Nmap. Identifies open ports, running services, service versions, and potential vulnerabilities across target hosts within the client's network infrastructure. Includes service detection and vulnerability scanning capabilities to map the network attack surface.",
+      "category": "recon,network",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "ports",
+          "description": "Port selection method",
+          "default": "Top100",
+          "required": true,
+          "type": "choices"
+        },
+        {
+          "name": "custom_ports",
+          "description": "Custom port specification when ports is set to 'Custom'. Examples: '80,443', '1-1000', '22,80-90,443'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "scan_flags",
+          "description": "Additional nmap flags for scanning options. The default value includes service detection, script scanning with default and vuln groups, and skipping Ping for checking if the target host responds.",
+          "default": "-sV -Pn",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "output_format",
+          "description": "Output format for Nmap results. Choose from xml (structured XML), text (normal text output), or grep (greppable format).",
+          "default": "xml",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "linux-ad-adidnsdump",
+      "title": "Linux AD ADIDNSDump",
+      "target": [
+        "addomain"
+      ],
+      "description": "Enumerates DNS records in Active Directory-integrated DNS zones using ADIDNSDump tool in a containerized Linux environment. This tool queries domain controllers for DNS records stored in Active Directory and provides a comprehensive list that can be used for security assessments and network mapping.",
+      "category": "recon,ad,dns",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller IP address or hostname",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "freeze_webapp",
+      "title": "Web Application Burp Freeze",
+      "target": [
+        "webapplication"
+      ],
+      "description": "Pause (or delete) a Burp Enterprise site to mirror a WebApplication's frozen/deleted state. Clears the site's schedule and adds the hostname to folder-wide out_of_scope_url_prefixes to stop cross-site scan spillover.",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "template-refinement",
+      "title": "Nuclei Template Refinement",
+      "target": [
+        "noinput"
+      ],
+      "description": "Refine Nuclei security templates using AI assistance with multi-agent pipeline",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "template_yaml",
+          "description": "Template YAML content to refine",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "user_message",
+          "description": "Refinement instructions from user",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "target_host",
+          "description": "Target host for template testing",
+          "default": "example.com",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "verbose",
+          "description": "Enable verbose logging",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        }
+      ],
+      "async": false,
+      "largeArtifact": true
+    },
+    {
+      "name": "anon-ftp",
+      "title": "Anonymous FTP",
+      "target": [
+        "port"
+      ],
+      "description": "Checks FTP servers for anonymous access and weak credentials.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "HOME",
+          "description": "Home environment variable for Ruby",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "dependency-confusion-scanner",
+      "title": "Dependency Confusion",
+      "target": [
+        "repository"
+      ],
+      "description": "Scans GitHub repositories for dependency confusion vulnerabilities",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "outfile",
+          "description": "The file to write the scan results to",
+          "default": "confused_results.txt",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "CONFUSED_PATH",
+          "description": "Path to the confused binary",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "GH_TOKEN",
+          "description": "GitHub token to use for enumeration",
+          "default": "from_env",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "java-jdwp-enum",
+      "title": "Java JDWP Enum Scanner (NSE)",
+      "target": [
+        "port"
+      ],
+      "description": "Integration of a Java Debug Wire Protocol (JDWP) detection capability using Nmap's jdwp-version NSE script to identify exposed Java debugging services, enabling organizations to discover potentially vulnerable Java applications that could allow remote code execution.",
+      "version": "",
+      "executor": "janus",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-network-dnsx",
+      "title": "Linux Network dnsx DNS Resolver",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs DNS resolution using dnsx, a multi-purpose DNS toolkit from ProjectDiscovery. Supports reverse DNS (PTR) for IP-to-hostname mapping and forward lookups (A, AAAA, CNAME, MX, NS, TXT) for domain reconnaissance. Uses the host's DNS resolvers by default for internal network compatibility.",
+      "category": "recon,network,dns",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Mode",
+          "description": "Execution mode",
+          "default": "dnsx",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "QueryType",
+          "description": "DNS record type to query",
+          "default": "PTR",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "Resolvers",
+          "description": "(Optional) Comma-separated list of custom DNS resolvers. If empty, uses system resolvers from /etc/resolv.conf.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Rate",
+          "description": "DNS queries per second rate limit",
+          "default": "150",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional dnsx arguments",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "linux-ad-umber-collect",
+      "title": "Linux Umber AD Collect",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs comprehensive Active Directory enumeration and data collection using Umber. Implements a SharpHound-style collection engine that enumerates all AD objects (users, computers, groups, GPOs, OUs, etc.) and collects their properties and relationships. Supports LDAP-only collection or extended collection including network sessions, local group membership, and user rights assignments via RPC.",
+      "category": "recon,ad",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Domain",
+          "description": "Domain where user credentials are valid. If empty, defaults to TargetDomain.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Username",
+          "description": "Username for authentication.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for authentication.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Server",
+          "description": "Domain controller address. If empty, auto-discovered via DNS.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Threads",
+          "description": "Number of concurrent collection threads",
+          "default": "25",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "CollectAll",
+          "description": "Enable all computer collection methods (sessions, local groups, user rights via RPC). If false, only LDAP collection is performed.",
+          "default": "false",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "linux-network-segmentation-test",
+      "title": "Linux Network Segmentation Test",
+      "target": [
+        "asset"
+      ],
+      "description": "Tests network segmentation by scanning specified IP addresses or CIDR ranges to identify accessible services. Used to validate network isolation and firewall rules by checking if services are reachable from the scanning host. Supports quick scanning (top 100 ports, reports only if services are accessible) and comprehensive scanning (top 1000 ports). All scans use -Pn to skip host discovery and focus on port scanning.",
+      "category": "recon,network",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "scan_mode",
+          "description": "Scan mode: 'quick' (top 100 ports, only reports if accessible services found), 'comprehensive' (top 1000 ports, reports all results), or 'custom' (use custom_ports parameter)",
+          "default": "quick",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "custom_ports",
+          "description": "Custom ports to scan (only used when scan_mode is 'custom'). Examples: '80,443', '1-1000', '22,80-90,443', or '-' for all ports",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "scan_flags",
+          "description": "Additional nmap flags for scanning options",
+          "default": "-Pn",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "windows-ad-sharphound",
+      "title": "Windows AD Sharphound",
+      "target": [
+        "addomain"
+      ],
+      "description": "Performs Active Directory data collection using Sharphound, the official data collector for BloodHound. Supports running with the current computer/user context (no credentials required on domain-joined machines) or with explicit credentials. Enumerates domain users, groups, computers, sessions, local admin rights, group memberships, ACLs, and trust relationships to identify potential attack paths and privilege escalation opportunities within Active Directory environments.",
+      "category": "recon,ad",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username for authentication. If empty, uses the current computer/user context.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password. Required only if Username is specified.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "CollectionMethod",
+          "description": "Data collection method to use",
+          "default": "All",
+          "required": false,
+          "type": "choices"
+        }
+      ],
+      "async": true,
+      "largeArtifact": true
+    },
+    {
+      "name": "collect-analytics",
+      "title": "Analytics Lookup",
+      "target": [
+        "port"
+      ],
+      "description": "collects analytics tracking codes from web pages",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "hadrian",
+      "title": "Hadrian API Security Testing",
+      "target": [
+        "webapplication"
+      ],
+      "description": "OWASP API security testing against web applications",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "timeout",
+          "description": "Scan timeout in minutes",
+          "default": "30",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "rate_limit",
+          "description": "Requests per second rate limit",
+          "default": "5.0",
+          "required": false,
+          "type": "float"
+        },
+        {
+          "name": "categories",
+          "description": "Comma-separated test categories to run (e.g. 'bola,bfla' or 'all')",
+          "default": "all",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "templates",
+          "description": "Comma-separated template names to run (empty for all)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "openapi_file",
+          "description": "OpenAPI spec file (overrides auto-discovered spec)",
+          "required": false,
+          "type": "file"
+        },
+        {
+          "name": "roles_file",
+          "description": "Roles YAML file (overrides default anonymous role)",
+          "required": false,
+          "type": "file"
+        },
+        {
+          "name": "template_file",
+          "description": "Template file (overrides embedded templates)",
+          "required": false,
+          "type": "file"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "ssh",
+      "title": "SSH",
+      "target": [
+        "port"
+      ],
+      "description": "checks SSH servers for known vulnerabilities",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "aurelian-azure-configuration-scan",
+      "title": "Azure Configuration Scan",
+      "target": [
+        "azureresource"
+      ],
+      "description": "Detects Azure configuration issues including weak authentication, disabled RBAC, privilege escalation paths, and overly permissive access rules via Azure Resource Graph.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "subscription-ids",
+          "description": "Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "template-dir",
+          "description": "Optional directory with additional YAML query templates",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "enricher-timeout",
+          "description": "Per-resource enricher timeout in seconds",
+          "default": "120",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "red-team",
+      "title": "Red Team Terraform Operations",
+      "target": [
+        "noinput"
+      ],
+      "description": "Run Red Team infrastructure terraform plan and apply operations",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "aurelian-aws-find-secrets",
+      "title": "AWS Find Secrets",
+      "target": [
+        "awsresource"
+      ],
+      "description": "Enumerates AWS resources via Cloud Control, extracts content likely to contain hardcoded secrets (EC2 user data, Lambda code, CloudFormation templates, CloudWatch logs, ECS task definitions, SSM documents, Step Functions executions), and scans with Titus.",
+      "version": "",
+      "executor": "aurelian",
+      "surface": "cloud",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "output-dir",
+          "description": "Base output directory",
+          "default": "aurelian-output",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile",
+          "description": "AWS profile to use",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "profile-dir",
+          "description": "Set to override the default AWS profile directory",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opsec_level",
+          "description": "Operational security level for AWS operations",
+          "default": "none",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Maximum concurrent API requests",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "regions",
+          "description": "AWS regions to scan",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-type",
+          "description": "AWS Cloud Control resource type",
+          "default": "[all]",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "resource-arn",
+          "description": "AWS target resource ARN",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "db-path",
+          "description": "Path for Titus SQLite database",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "disabled-titus-rules",
+          "description": "Rule IDs to exclude from scanning",
+          "required": false,
+          "type": "[]string"
+        },
+        {
+          "name": "validate",
+          "description": "Validate detected secrets against their source APIs",
+          "default": "false",
+          "required": false,
+          "type": "bool"
+        },
+        {
+          "name": "ignore-file",
+          "description": "Path to gitignore-style file for skipping paths; when empty uses a default list",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ruleset",
+          "description": "Titus ruleset to apply; empty string disables ruleset filtering",
+          "default": "default",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "max-events",
+          "description": "Max log events per log group",
+          "default": "10000",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "max-streams",
+          "description": "Max streams to sample per log group",
+          "default": "10",
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "async": false,
+      "bulk": true
+    },
+    {
+      "name": "seneca-agent",
+      "title": "CVE Research Orchestrator",
+      "target": [
+        "risk"
+      ],
+      "description": "Specialized agent that orchestrates CVE research capabilities to validate and enrich CVE-based triage findings with exploit intelligence, template generation, and severity assessment",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "hunt",
+      "title": "Hunter",
+      "target": [
+        "hunt"
+      ],
+      "description": "Continuous attack-surface hunt. Selects the next most interesting target, expands the surface when needed, delegates the actual exploit to a scoped subagent, and files the resulting findings.",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "azuread-discovery",
+      "title": "Azure AD Discovery",
+      "target": [
+        "asset"
+      ],
+      "description": "discovers Azure AD domains and tenants associated with a domain",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "resolver",
+      "title": "Resolver",
+      "target": [
+        "asset"
+      ],
+      "description": "resolves IP addresses for a domain",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "windows-database-powerupsql-domain-discovery",
+      "title": "Windows Database PowerUpSQL Domain Discovery",
+      "target": [
+        "addomain"
+      ],
+      "description": "Automatically discovers SQL Server instances within Active Directory environments using PowerUpSQL. Queries domain controllers and LDAP to identify registered SQL Server services, instances, and database assets across the client's AD infrastructure, providing comprehensive database inventory for security assessment.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username for authentication (optional)",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Domain user password (optional)",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "DomainController",
+          "description": "Specific domain controller to query (optional)",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "pius-discovery",
+      "title": "pius-discovery",
+      "target": [
+        "preseed",
+        "asset"
+      ],
+      "description": "discovers domains and CIDRs for an organization using Pius multi-plugin pipeline",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "mode",
+          "description": "Plugin mode filter: passive, active, or all",
+          "default": "passive",
+          "required": false,
+          "type": "string",
+          "options": [
+            "passive",
+            "active",
+            "all"
+          ]
+        },
+        {
+          "name": "plugins",
+          "description": "Comma-separated plugin whitelist (empty = all applicable)",
+          "required": false,
+          "type": "string",
+          "options": [
+            "crt-sh",
+            "apollo",
+            "github-org",
+            "gleif",
+            "passive-dns",
+            "reverse-whois",
+            "whois",
+            "urlscan",
+            "wayback",
+            "wikidata",
+            "google-dorks",
+            "reverse-ip",
+            "otx-alienvault",
+            "dns-brute",
+            "dns-zone-transfer",
+            "doh-enum",
+            "dns-permutation",
+            "favicon-hash",
+            "asn-bgp",
+            "reverse-rir",
+            "edgar",
+            "arin",
+            "ripe",
+            "lacnic",
+            "apnic",
+            "afrinic",
+            "shodan",
+            "dnsdb",
+            "crunchbase",
+            "opencorporates",
+            "proxycurl",
+            "diffbot",
+            "securitytrails",
+            "virustotal",
+            "binaryedge",
+            "censys",
+            "viewdns"
+          ]
+        },
+        {
+          "name": "disable",
+          "description": "Comma-separated plugin blacklist",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "concurrency",
+          "description": "Max concurrent plugins",
+          "default": "5",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "shodan_api_key",
+          "description": "Shodan API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "dnsdb_api_key",
+          "description": "DNSDB API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "crunchbase_api_key",
+          "description": "Crunchbase API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "opencorporates_api_key",
+          "description": "OpenCorporates API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "proxycurl_api_key",
+          "description": "Proxycurl API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "diffbot_api_key",
+          "description": "Diffbot API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "securitytrails_api_key",
+          "description": "SecurityTrails API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "virustotal_api_key",
+          "description": "VirusTotal API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "binaryedge_api_key",
+          "description": "BinaryEdge API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "apollo_api_key",
+          "description": "Apollo.io API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "censys_api_key",
+          "description": "Censys API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "censys_api_token",
+          "description": "Censys Platform API token (Personal Access Token)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "censys_org_id",
+          "description": "Censys organization ID",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "viewdns_api_key",
+          "description": "ViewDNS API key",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "doh_servers",
+          "description": "Comma-separated DoH resolver URLs (default: Cloudflare, Google, AdGuard)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "doh_gateways",
+          "description": "Comma-separated pre-deployed gateway URLs for DoH enumeration",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "doh_deploy_gateways",
+          "description": "Deploy AWS API Gateways as DoH proxies (true/false)",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "dns_brute_concurrency",
+          "description": "Max concurrent DNS queries for dns-brute (default: 50)",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "google_dorks_max_subsidiaries",
+          "description": "Max subsidiaries to resolve via Google dorks (default: 30)",
+          "required": false,
+          "type": "int"
+        },
+        {
+          "name": "github_token",
+          "description": "GitHub personal access token for improved rate limits",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": false
+    },
+    {
+      "name": "risk-scoring",
+      "title": "Risk Scoring",
+      "target": [
+        "noinput"
+      ],
+      "description": "Bulk-compute asset risk scores using single graph queries per user",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "windows-ad-scriptsentry",
+      "title": "Windows AD ScriptSentry",
+      "target": [
+        "addomain"
+      ],
+      "description": "Analyzes Active Directory logon scripts for security vulnerabilities and misconfigurations. ScriptSentry identifies dangerous logon scripts with excessive permissions, hardcoded credentials, insecure storage locations, and potential privilege escalation vectors within the client's AD environment, helping prevent script-based attacks and credential exposure.",
+      "category": "recon",
+      "runs_on": "windows",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Username",
+          "description": "Domain username (without domain, e.g., 'brandon.stark')",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "Password",
+          "description": "Password for the specified username",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "confluence-secrets",
+      "title": "Confluence Secrets",
+      "target": [
+        "asset"
+      ],
+      "description": "scans Confluence page versions for exposed secrets",
+      "version": "",
+      "executor": "chariot",
+      "surface": "application",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "linux-network-recon",
+      "title": "Linux Network Recon",
+      "target": [
+        "asset"
+      ],
+      "description": "Performs comprehensive network reconnaissance by chaining port scanning (naabu), service fingerprinting (nerva), and DNS resolution (dnsx). Discovers open ports, identifies running services, and enriches assets with reverse DNS hostnames in a single pipeline.",
+      "category": "recon,network",
+      "runs_on": "linux",
+      "version": "1.0.0",
+      "executor": "aegis",
+      "surface": "internal",
+      "integration": false,
+      "parameters": [
+        {
+          "name": "Mode",
+          "description": "Execution mode",
+          "default": "network-recon",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Ports",
+          "description": "Port selection mode",
+          "default": "Top100",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "CustomPorts",
+          "description": "Custom port specification when Ports is set to 'Custom'. Examples: '80,443', '1-1000', '22,80-90,443'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "Rate",
+          "description": "Packets per second rate limit",
+          "default": "1000",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "ServiceDetect",
+          "description": "Run service fingerprinting on discovered ports using nerva",
+          "default": "true",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "DnsResolve",
+          "description": "Run reverse DNS (PTR) lookups on discovered IPs using dnsx to enrich assets with hostnames",
+          "default": "true",
+          "required": false,
+          "type": "choices"
+        },
+        {
+          "name": "ExtraArgs",
+          "description": "(Optional) Additional arguments for the active tool",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "async": true
+    },
+    {
+      "name": "executive-summary",
+      "title": "Executive Summary Generator",
+      "target": [
+        "noinput"
+      ],
+      "description": "Generates a tenant-level executive summary PDF with risk posture, asset inventory, and key findings",
+      "version": "",
+      "executor": "agent",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "email-security",
+      "title": "Email Security",
+      "target": [
+        "asset"
+      ],
+      "description": "checks for missing SPF and DMARC records on apex domains",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    },
+    {
+      "name": "fingerprint",
+      "title": "Nerva",
+      "target": [
+        "port"
+      ],
+      "description": "Fingerprints an exposed port to enumerate services and CPEs using Nerva",
+      "version": "",
+      "executor": "chariot",
+      "surface": "external",
+      "integration": false,
+      "async": false
+    }
+  ]
+}

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -2,10 +2,13 @@
 
 import json
 import os
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_MAX_REGISTRY_SIZE = 1024 * 1024  # 1 MB
 
 _PRAETORIAN_DIR = os.path.join(os.path.expanduser("~"), ".praetorian")
 CACHE_PATH = os.path.join(_PRAETORIAN_DIR, "registry.json")
@@ -64,10 +67,13 @@ class ModuleRegistry:
             import urllib.request
             req = urllib.request.Request(REGISTRY_URL, headers={"User-Agent": "guard-cli"})
             with urllib.request.urlopen(req, timeout=10) as resp:
-                data = json.loads(resp.read().decode())
-            os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
-            with open(CACHE_PATH, "w") as f:
-                json.dump(data, f, indent=2)
+                raw = resp.read(_MAX_REGISTRY_SIZE + 1)
+                if len(raw) > _MAX_REGISTRY_SIZE:
+                    return False
+                data = json.loads(raw.decode())
+            if not isinstance(data.get("modules"), dict):
+                return False
+            self._atomic_write(CACHE_PATH, data)
             self._data = data
             return True
         except Exception:
@@ -112,6 +118,21 @@ class ModuleRegistry:
         results.sort(key=lambda r: r["name"])
         return results
 
+    @staticmethod
+    def _atomic_write(path: str, data: Dict):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
     # -- Version tracking --
 
     def _load_versions(self) -> Dict:
@@ -124,9 +145,7 @@ class ModuleRegistry:
         return {}
 
     def _save_versions(self, versions: Dict):
-        os.makedirs(os.path.dirname(VERSIONS_PATH), exist_ok=True)
-        with open(VERSIONS_PATH, "w") as f:
-            json.dump(versions, f, indent=2)
+        self._atomic_write(VERSIONS_PATH, versions)
 
     def record_version(self, name: str, version: str, path: str):
         versions = self._load_versions()

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -200,7 +200,7 @@ class ModuleRegistry:
                 "capability": name,
                 "agent": name,
                 "target_type": mod.get("target_type", "asset"),
-                "description": mod["description"],
+                "description": mod.get("description", ""),
             }
             for name, mod in modules.items()
         }

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -1,0 +1,180 @@
+"""Module registry: fetch, cache, parse, and query the tool manifest."""
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_PRAETORIAN_DIR = os.path.join(os.path.expanduser("~"), ".praetorian")
+CACHE_PATH = os.path.join(_PRAETORIAN_DIR, "registry.json")
+VERSIONS_PATH = os.path.join(_PRAETORIAN_DIR, "versions.json")
+BUNDLED_REGISTRY_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "modules", "registry.json"
+)
+
+CACHE_TTL_SECONDS = 86400  # 24 hours
+
+REGISTRY_URL = (
+    "https://raw.githubusercontent.com/praetorian-inc/praetorian-cli"
+    "/main/modules/registry.json"
+)
+
+
+class ModuleRegistry:
+    def __init__(self):
+        self._data: Optional[Dict] = None
+
+    def _load(self) -> Dict:
+        if self._data is not None:
+            return self._data
+
+        # Try cache first
+        if os.path.isfile(CACHE_PATH):
+            try:
+                with open(CACHE_PATH) as f:
+                    self._data = json.load(f)
+                return self._data
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # Fallback to bundled
+        if os.path.isfile(BUNDLED_REGISTRY_PATH):
+            try:
+                with open(BUNDLED_REGISTRY_PATH) as f:
+                    self._data = json.load(f)
+                return self._data
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        self._data = {"version": 1, "modules": {}}
+        return self._data
+
+    def _is_cache_stale(self) -> bool:
+        if not os.path.isfile(CACHE_PATH):
+            return True
+        mtime = os.path.getmtime(CACHE_PATH)
+        return (time.time() - mtime) > CACHE_TTL_SECONDS
+
+    def refresh(self, force: bool = False) -> bool:
+        if not force and not self._is_cache_stale():
+            return False
+        try:
+            import urllib.request
+            req = urllib.request.Request(REGISTRY_URL, headers={"User-Agent": "guard-cli"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode())
+            os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+            with open(CACHE_PATH, "w") as f:
+                json.dump(data, f, indent=2)
+            self._data = data
+            return True
+        except Exception:
+            return False
+
+    def get_modules(self) -> Dict[str, Dict]:
+        return self._load().get("modules", {})
+
+    def get_module(self, name: str) -> Optional[Dict]:
+        modules = self.get_modules()
+        mod = modules.get(name.lower())
+        if mod is not None:
+            return mod
+        for key, val in modules.items():
+            if key.lower() == name.lower():
+                return val
+        return None
+
+    def search_modules(
+        self,
+        query: str = "",
+        category: str = "",
+    ) -> List[Dict[str, Any]]:
+        modules = self.get_modules()
+        results = []
+        q = query.lower()
+
+        for name, mod in modules.items():
+            if category and mod.get("category", "") != category:
+                continue
+            if q:
+                searchable = " ".join([
+                    name,
+                    mod.get("description", ""),
+                    mod.get("category", ""),
+                    " ".join(mod.get("tags", [])),
+                ]).lower()
+                if q not in searchable:
+                    continue
+            results.append({"name": name, **mod})
+
+        results.sort(key=lambda r: r["name"])
+        return results
+
+    # -- Version tracking --
+
+    def _load_versions(self) -> Dict:
+        if os.path.isfile(VERSIONS_PATH):
+            try:
+                with open(VERSIONS_PATH) as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+        return {}
+
+    def _save_versions(self, versions: Dict):
+        os.makedirs(os.path.dirname(VERSIONS_PATH), exist_ok=True)
+        with open(VERSIONS_PATH, "w") as f:
+            json.dump(versions, f, indent=2)
+
+    def record_version(self, name: str, version: str, path: str):
+        versions = self._load_versions()
+        versions[name] = {
+            "version": version,
+            "path": path,
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._save_versions(versions)
+
+    def get_version(self, name: str) -> Optional[Dict]:
+        return self._load_versions().get(name)
+
+    def get_all_versions(self) -> Dict:
+        return self._load_versions()
+
+    def remove_version(self, name: str):
+        versions = self._load_versions()
+        versions.pop(name, None)
+        self._save_versions(versions)
+
+    # -- Backward-compat dict interfaces --
+
+    def get_installable_tools(self) -> Dict[str, Dict]:
+        modules = self.get_modules()
+        return {
+            name: {"repo": mod["repo"], "description": mod["description"]}
+            for name, mod in modules.items()
+        }
+
+    def get_tool_aliases(self) -> Dict[str, Dict]:
+        modules = self.get_modules()
+        return {
+            name: {
+                "capability": name,
+                "agent": name,
+                "target_type": mod.get("target_type", "asset"),
+                "description": mod["description"],
+            }
+            for name, mod in modules.items()
+        }
+
+
+_registry = None
+
+
+def get_registry() -> ModuleRegistry:
+    global _registry
+    if _registry is None:
+        _registry = ModuleRegistry()
+    return _registry

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -3,10 +3,13 @@
 import json
 import os
 import tempfile
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_versions_lock = threading.Lock()
 
 _MAX_REGISTRY_SIZE = 1024 * 1024  # 1 MB
 
@@ -165,13 +168,14 @@ class ModuleRegistry:
         self._atomic_write(VERSIONS_PATH, versions)
 
     def record_version(self, name: str, version: str, path: str):
-        versions = self._load_versions()
-        versions[name] = {
-            "version": version,
-            "path": path,
-            "installed_at": datetime.now(timezone.utc).isoformat(),
-        }
-        self._save_versions(versions)
+        with _versions_lock:
+            versions = self._load_versions()
+            versions[name] = {
+                "version": version,
+                "path": path,
+                "installed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self._save_versions(versions)
 
     def get_version(self, name: str) -> Optional[Dict]:
         return self._load_versions().get(name)
@@ -180,9 +184,10 @@ class ModuleRegistry:
         return self._load_versions()
 
     def remove_version(self, name: str):
-        versions = self._load_versions()
-        versions.pop(name, None)
-        self._save_versions(versions)
+        with _versions_lock:
+            versions = self._load_versions()
+            versions.pop(name, None)
+            self._save_versions(versions)
 
     # -- Backward-compat dict interfaces --
 

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -92,6 +92,23 @@ class ModuleRegistry:
                 return val
         return None
 
+    def get_capability_name(self, name: str) -> str:
+        """The guard capability a module maps to (defaults to its own name)."""
+        mod = self.get_module(name) or {}
+        return mod.get('capability', name.lower())
+
+    def is_local_only(self, name: str) -> bool:
+        mod = self.get_module(name) or {}
+        return bool(mod.get('local_only', False))
+
+    def get_binary_pattern(self, name: str):
+        mod = self.get_module(name) or {}
+        return mod.get('binary_pattern')
+
+    def get_plugin_name(self, name: str):
+        mod = self.get_module(name) or {}
+        return mod.get('plugin')
+
     def search_modules(
         self,
         query: str = "",
@@ -172,7 +189,7 @@ class ModuleRegistry:
     def get_installable_tools(self) -> Dict[str, Dict]:
         modules = self.get_modules()
         return {
-            name: {"repo": mod["repo"], "description": mod["description"]}
+            name: {"repo": mod.get("repo", ""), "description": mod.get("description", "")}
             for name, mod in modules.items()
         }
 

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -120,9 +120,10 @@ class ModuleRegistry:
         modules = self.get_modules()
         results = []
         q = query.lower()
+        cat = category.lower()
 
         for name, mod in modules.items():
-            if category and mod.get("category", "") != category:
+            if cat and mod.get("category", "").lower() != cat:
                 continue
             if q:
                 searchable = " ".join([
@@ -170,7 +171,7 @@ class ModuleRegistry:
     def record_version(self, name: str, version: str, path: str):
         with _versions_lock:
             versions = self._load_versions()
-            versions[name] = {
+            versions[name.lower()] = {
                 "version": version,
                 "path": path,
                 "installed_at": datetime.now(timezone.utc).isoformat(),
@@ -178,7 +179,7 @@ class ModuleRegistry:
             self._save_versions(versions)
 
     def get_version(self, name: str) -> Optional[Dict]:
-        return self._load_versions().get(name)
+        return self._load_versions().get(name.lower())
 
     def get_all_versions(self) -> Dict:
         return self._load_versions()
@@ -186,7 +187,7 @@ class ModuleRegistry:
     def remove_version(self, name: str):
         with _versions_lock:
             versions = self._load_versions()
-            versions.pop(name, None)
+            versions.pop(name.lower(), None)
             self._save_versions(versions)
 
     # -- Backward-compat dict interfaces --

--- a/praetorian_cli/registry.py
+++ b/praetorian_cli/registry.py
@@ -182,7 +182,8 @@ class ModuleRegistry:
         return self._load_versions().get(name.lower())
 
     def get_all_versions(self) -> Dict:
-        return self._load_versions()
+        raw = self._load_versions()
+        return {k.lower(): v for k, v in raw.items()}
 
     def remove_version(self, name: str):
         with _versions_lock:

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -1,5 +1,6 @@
 """Local capability runner — install and run Praetorian tools locally."""
 
+import hashlib
 import json
 import os
 import platform
@@ -127,6 +128,25 @@ def is_installed(tool_name: str) -> bool:
     return get_binary_path(tool_name) is not None
 
 
+def verify_sha256(path: str, expected: str) -> bool:
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            h.update(chunk)
+    return h.hexdigest() == (expected or '').lower().strip()
+
+
+def uninstall_tool(tool_name: str) -> bool:
+    """Remove an installed binary from INSTALL_DIR and its version record."""
+    from praetorian_cli.registry import get_registry
+    path = os.path.join(INSTALL_DIR, tool_name)
+    existed = os.path.isfile(path)
+    if existed:
+        os.remove(path)
+    get_registry().remove_version(tool_name)
+    return existed
+
+
 def install_tool(tool_name: str, force=False) -> str:
     """Download and install a tool from GitHub releases. Returns binary path."""
     if tool_name not in INSTALLABLE_TOOLS:
@@ -141,13 +161,20 @@ def install_tool(tool_name: str, force=False) -> str:
     repo = INSTALLABLE_TOOLS[tool_name]['repo']
     os_name, arch = _detect_platform()
 
+    from praetorian_cli.registry import get_registry
+    _pattern = get_registry().get_binary_pattern(tool_name)
+    if _pattern:
+        asset_pattern = _pattern.replace('{os}', os_name).replace('{arch}', arch)
+    else:
+        asset_pattern = f'{tool_name}-{os_name}-{arch}*'
+
     os.makedirs(INSTALL_DIR, exist_ok=True)
 
     # Get latest release asset URL using gh CLI
     try:
         result = subprocess.run(
             ['gh', 'release', 'download', '--repo', repo,
-             '--pattern', f'{tool_name}-{os_name}-{arch}*',
+             '--pattern', asset_pattern,
              '--dir', tempfile.gettempdir(), '--clobber'],
             capture_output=True, text=True, timeout=120,
         )

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -12,26 +12,46 @@ from typing import Optional
 # Where local binaries are installed
 INSTALL_DIR = os.path.join(os.path.expanduser('~'), '.praetorian', 'bin')
 
-# Map of tool name → GitHub repo + CLI interface
-INSTALLABLE_TOOLS = {
-    'brutus':      {'repo': 'praetorian-inc/brutus',      'description': 'Credential attacks (20+ protocols)'},
-    'julius':      {'repo': 'praetorian-inc/julius',      'description': 'LLM service fingerprinting'},
-    'augustus':     {'repo': 'praetorian-inc/augustus',     'description': 'LLM security testing (190+ probes)'},
-    'titus':       {'repo': 'praetorian-inc/titus',       'description': 'Secrets scanner (487 rules)'},
-    'trajan':      {'repo': 'praetorian-inc/trajan',      'description': 'CI/CD vulnerability scanner'},
-    'cato':        {'repo': 'praetorian-inc/cato',        'description': 'Injection scanner (SQLi, SSRF, SSTI, XXE)'},
-    'nerva':       {'repo': 'praetorian-inc/nerva',       'description': 'Service fingerprinting (120+ protocols)'},
-    'vespasian':   {'repo': 'praetorian-inc/vespasian',   'description': 'API discovery from traffic'},
-    'nuclei':      {'repo': 'praetorian-inc/nuclei',      'description': 'Vulnerability scanner templates'},
-    'gato':        {'repo': 'praetorian-inc/gato',        'description': 'GitHub Actions pipeline scanner'},
-    'constantine': {'repo': 'praetorian-inc/constantine', 'description': 'Repository security analysis'},
-    'aurelian':    {'repo': 'praetorian-inc/aurelian',    'description': 'Cloud security reconnaissance'},
-    'pius':        {'repo': 'praetorian-inc/pius',        'description': 'Organizational asset discovery'},
-    'florian':     {'repo': 'praetorian-inc/florian',     'description': 'Authentication flow testing'},
-    'caligula':    {'repo': 'praetorian-inc/caligula',    'description': 'Supply chain security scanner'},
-    'hadrian':     {'repo': 'praetorian-inc/hadrian',     'description': 'API security testing'},
-    'nero':        {'repo': 'praetorian-inc/nero',        'description': 'Default credential scanner'},
-}
+def _get_installable_tools():
+    from praetorian_cli.registry import get_registry
+    return get_registry().get_installable_tools()
+
+
+class _LazyTools:
+    def __init__(self):
+        self._loaded = None
+
+    def _ensure(self):
+        if self._loaded is None:
+            self._loaded = _get_installable_tools()
+        return self._loaded
+
+    def __contains__(self, key):
+        return key in self._ensure()
+
+    def __getitem__(self, key):
+        return self._ensure()[key]
+
+    def __iter__(self):
+        return iter(self._ensure())
+
+    def __len__(self):
+        return len(self._ensure())
+
+    def items(self):
+        return self._ensure().items()
+
+    def keys(self):
+        return self._ensure().keys()
+
+    def values(self):
+        return self._ensure().values()
+
+    def get(self, key, default=None):
+        return self._ensure().get(key, default)
+
+
+INSTALLABLE_TOOLS = _LazyTools()
 
 
 # Well-known service ports for Brutus protocol auto-detection.
@@ -178,6 +198,18 @@ def install_tool(tool_name: str, force=False) -> str:
 
     # Make executable
     os.chmod(binary_path, 0o755)
+
+    # Record version
+    try:
+        from praetorian_cli.registry import get_registry
+        ver_result = subprocess.run(
+            ['gh', 'release', 'view', '--repo', repo, '--json', 'tagName', '-q', '.tagName'],
+            capture_output=True, text=True, timeout=15,
+        )
+        version_tag = ver_result.stdout.strip() if ver_result.returncode == 0 else 'unknown'
+        get_registry().record_version(tool_name, version_tag, binary_path)
+    except Exception:
+        pass
 
     # Cleanup
     try:

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -144,12 +144,21 @@ def uninstall_tool(tool_name: str) -> bool:
         raise ValueError(f'Unknown tool: {tool_name}')
 
     path = os.path.join(INSTALL_DIR, os.path.basename(tool_name))
-    if not os.path.realpath(path).startswith(os.path.realpath(INSTALL_DIR) + os.sep):
+    real_path = os.path.realpath(path)
+    real_install = os.path.realpath(INSTALL_DIR)
+    try:
+        common = os.path.commonpath([real_path, real_install])
+    except ValueError:
+        raise ValueError(f'Invalid tool name: {tool_name}')
+    if common != real_install or real_path == real_install:
         raise ValueError(f'Invalid tool name: {tool_name}')
 
     existed = os.path.isfile(path)
     if existed:
-        os.remove(path)
+        try:
+            os.remove(path)
+        except OSError as e:
+            raise OSError(f'Failed to remove {path}: {e}') from e
     get_registry().remove_version(tool_name)
     return existed
 
@@ -233,7 +242,7 @@ def install_tool(tool_name: str, force=False) -> str:
     # Make executable
     os.chmod(binary_path, 0o755)
 
-    # Record version
+    # Record version — only persist a real tag, never a placeholder like "unknown"
     try:
         from praetorian_cli.registry import get_registry
         ver_result = subprocess.run(
@@ -241,10 +250,15 @@ def install_tool(tool_name: str, force=False) -> str:
             capture_output=True, text=True, timeout=15,
         )
         version_tag = ver_result.stdout.strip() if ver_result.returncode == 0 else ''
-        if ver_result.returncode == 0 and version_tag:
+        if version_tag:
             get_registry().record_version(tool_name, version_tag, binary_path)
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        pass
+    except FileNotFoundError:
+        pass  # gh CLI not available — version tracking is optional
+    except subprocess.TimeoutExpired:
+        pass  # version query timed out — skip recording
+    except Exception as e:
+        import sys
+        print(f'Warning: failed to record version for {tool_name}: {e}', file=sys.stderr)
 
     # Cleanup
     try:

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -139,7 +139,14 @@ def verify_sha256(path: str, expected: str) -> bool:
 def uninstall_tool(tool_name: str) -> bool:
     """Remove an installed binary from INSTALL_DIR and its version record."""
     from praetorian_cli.registry import get_registry
-    path = os.path.join(INSTALL_DIR, tool_name)
+
+    if tool_name not in INSTALLABLE_TOOLS:
+        raise ValueError(f'Unknown tool: {tool_name}')
+
+    path = os.path.join(INSTALL_DIR, os.path.basename(tool_name))
+    if not os.path.realpath(path).startswith(os.path.realpath(INSTALL_DIR) + os.sep):
+        raise ValueError(f'Invalid tool name: {tool_name}')
+
     existed = os.path.isfile(path)
     if existed:
         os.remove(path)

--- a/praetorian_cli/runners/local.py
+++ b/praetorian_cli/runners/local.py
@@ -233,9 +233,10 @@ def install_tool(tool_name: str, force=False) -> str:
             ['gh', 'release', 'view', '--repo', repo, '--json', 'tagName', '-q', '.tagName'],
             capture_output=True, text=True, timeout=15,
         )
-        version_tag = ver_result.stdout.strip() if ver_result.returncode == 0 else 'unknown'
-        get_registry().record_version(tool_name, version_tag, binary_path)
-    except Exception:
+        version_tag = ver_result.stdout.strip() if ver_result.returncode == 0 else ''
+        if ver_result.returncode == 0 and version_tag:
+            get_registry().record_version(tool_name, version_tag, binary_path)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         pass
 
     # Cleanup

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -322,11 +322,25 @@ class MCPServer:
                 return [TextContent(type="text", text=json.dumps(out, indent=2))]
 
             elif name == "install_module":
-                from praetorian_cli.runners.local import install_tool, is_installed
+                from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
                 if not arguments.get("name"):
                     return [TextContent(type="text", text="Missing required parameter: name")]
                 mod_name = arguments["name"].lower()
                 force = arguments.get("force", False)
+
+                if mod_name == "all":
+                    results = []
+                    for tool in sorted(INSTALLABLE_TOOLS):
+                        try:
+                            if not force and is_installed(tool):
+                                results.append({"name": tool, "status": "already_installed"})
+                            else:
+                                path = install_tool(tool, force=force)
+                                results.append({"name": tool, "status": "installed", "path": path})
+                        except Exception as e:
+                            results.append({"name": tool, "status": "error", "error": str(e)})
+                    return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
                 if not force and is_installed(mod_name):
                     return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "already_installed"}))]
                 path = install_tool(mod_name, force=force)

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -275,6 +275,8 @@ class MCPServer:
             elif name == "module_info":
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import is_installed, get_binary_path
+                if not arguments.get("name"):
+                    return [TextContent(type="text", text="Missing required parameter: name")]
                 reg = get_registry()
                 mod_name = arguments["name"].lower()
                 mod = reg.get_module(mod_name)
@@ -289,6 +291,8 @@ class MCPServer:
 
             elif name == "install_module":
                 from praetorian_cli.runners.local import install_tool, is_installed
+                if not arguments.get("name"):
+                    return [TextContent(type="text", text="Missing required parameter: name")]
                 mod_name = arguments["name"].lower()
                 force = arguments.get("force", False)
                 if not force and is_installed(mod_name):
@@ -298,6 +302,8 @@ class MCPServer:
 
             elif name == "run_module":
                 from praetorian_cli.runners.local import LocalRunner, get_tool_plugin, is_installed
+                if not arguments.get("name") or not arguments.get("target"):
+                    return [TextContent(type="text", text="Missing required parameter: name and target are required")]
                 mod_name = arguments["name"].lower()
                 target = arguments["target"]
                 options = arguments.get("options", {})

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -259,34 +259,66 @@ class MCPServer:
     async def _handle_module_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
         try:
             if name == "list_modules":
+                from praetorian_cli.catalog import CapabilityCatalog
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import list_installed
                 reg = get_registry()
                 query = arguments.get("query", "")
                 category = arguments.get("category", "")
-                results = reg.search_modules(query, category=category)
+                cat = CapabilityCatalog(self.chariot)
+                caps = cat.search(query, category=category) if (query or category) else cat.all()
                 installed = list_installed()
-                for r in results:
-                    r["installed"] = r["name"] in installed
-                    ver = reg.get_version(r["name"])
-                    r["version"] = ver["version"] if ver else None
+                results = []
+                for cap in caps:
+                    ver = reg.get_version(cap.name)
+                    results.append({
+                        "name": cap.name,
+                        "title": cap.title,
+                        "description": cap.description,
+                        "category": cap.category,
+                        "surface": cap.surface,
+                        "installed": cap.name in installed,
+                        "version": ver["version"] if ver else cap.version or None,
+                    })
                 return [TextContent(type="text", text=json.dumps(results, indent=2))]
 
             elif name == "module_info":
+                from praetorian_cli.catalog import CapabilityCatalog
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import is_installed, get_binary_path
                 if not arguments.get("name"):
                     return [TextContent(type="text", text="Missing required parameter: name")]
-                reg = get_registry()
                 mod_name = arguments["name"].lower()
-                mod = reg.get_module(mod_name)
-                if not mod:
+                cat = CapabilityCatalog(self.chariot)
+                cap = cat.get(mod_name)
+                if not cap:
                     return [TextContent(type="text", text=f"Unknown module: {mod_name}")]
+                reg = get_registry()
                 ver = reg.get_version(mod_name)
-                out = {"name": mod_name, **mod}
-                out["installed"] = is_installed(mod_name)
-                out["version"] = ver["version"] if ver else None
-                out["binary_path"] = get_binary_path(mod_name)
+                out = {
+                    "name": cap.name,
+                    "title": cap.title,
+                    "description": cap.description,
+                    "category": cap.category,
+                    "surface": cap.surface,
+                    "target": cap.target,
+                    "executor": cap.executor,
+                    "parameters": [
+                        {
+                            "name": p.name,
+                            "description": p.description,
+                            "type": p.type,
+                            "default": p.default,
+                            "required": p.required,
+                            "options": p.options,
+                        }
+                        for p in cap.parameters
+                    ],
+                    "installed": is_installed(mod_name),
+                    "version": ver["version"] if ver else cap.version or None,
+                    "binary_path": get_binary_path(mod_name),
+                    "local_only": reg.is_local_only(mod_name),
+                }
                 return [TextContent(type="text", text=json.dumps(out, indent=2))]
 
             elif name == "install_module":

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -14,7 +14,9 @@ class MCPServer:
         self.allowable_tools = allowable_tools
         self.server = Server("praetorian-cli")
         self.discovered_tools = {}
+        self._module_tools = {}
         self._discover_tools()
+        self._define_module_tools()
         self._register_tools()
 
     def _is_tool_allowed(self, tool_name: str) -> bool:
@@ -150,6 +152,61 @@ class MCPServer:
         
         return "string"
 
+    def _define_module_tools(self):
+        """Populate self._module_tools with explicit module management MCP tools."""
+        self._module_tools["list_modules"] = Tool(
+            name="list_modules",
+            description="List all available Guard security modules with install status. "
+                        "Returns name, category, description, install status, and version for each module.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query (matches name, description, tags)"},
+                    "category": {"type": "string", "description": "Filter by category (scanner, credential, recon, cloud, cicd, ai, supply-chain, api)"},
+                },
+            },
+        )
+
+        self._module_tools["module_info"] = Tool(
+            name="module_info",
+            description="Get full details for a Guard security module including options, version, and install path.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name (e.g., brutus, nuclei, titus)"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["install_module"] = Tool(
+            name="install_module",
+            description="Install a Guard security module binary from GitHub releases to ~/.praetorian/bin/.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name to install, or 'all'"},
+                    "force": {"type": "boolean", "description": "Reinstall even if already present"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["run_module"] = Tool(
+            name="run_module",
+            description="Execute an installed Guard security module against a target. "
+                        "The module must be installed first (use install_module).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name"},
+                    "target": {"type": "string", "description": "Target (IP, domain, URL, or Guard key)"},
+                    "options": {"type": "object", "description": "Tool-specific options as key-value pairs"},
+                },
+                "required": ["name", "target"],
+            },
+        )
+
     def _register_tools(self):
         @self.server.list_tools()
         async def list_tools() -> List[Tool]:
@@ -159,24 +216,24 @@ class MCPServer:
 
                 properties = {}
                 required = []
-                
+
                 for param_name, param_info in parameters.items():
                     if param_name == 'self':
                         continue
-                        
+
                     properties[param_name] = {
                         "type": param_info.get("type", "string"),
                         "description": param_info.get("description", f"Parameter {param_name}")
                     }
-                    
+
                     if param_info.get("required", False):
                         required.append(param_name)
-                
+
                 tool_schema = {
                     "type": "object",
                     "properties": properties
                 }
-                
+
                 if required:
                     tool_schema["required"] = required
 
@@ -191,12 +248,85 @@ class MCPServer:
                     description=description,
                     inputSchema=tool_schema
                 )
-                
+
                 tools.append(tool)
-            
+
+            # Add module management tools
+            tools.extend(self._module_tools.values())
+
             return tools
 
+    async def _handle_module_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        try:
+            if name == "list_modules":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import list_installed
+                reg = get_registry()
+                query = arguments.get("query", "")
+                category = arguments.get("category", "")
+                results = reg.search_modules(query, category=category)
+                installed = list_installed()
+                for r in results:
+                    r["installed"] = r["name"] in installed
+                    ver = reg.get_version(r["name"])
+                    r["version"] = ver["version"] if ver else None
+                return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
+            elif name == "module_info":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import is_installed, get_binary_path
+                reg = get_registry()
+                mod_name = arguments["name"].lower()
+                mod = reg.get_module(mod_name)
+                if not mod:
+                    return [TextContent(type="text", text=f"Unknown module: {mod_name}")]
+                ver = reg.get_version(mod_name)
+                out = {"name": mod_name, **mod}
+                out["installed"] = is_installed(mod_name)
+                out["version"] = ver["version"] if ver else None
+                out["binary_path"] = get_binary_path(mod_name)
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            elif name == "install_module":
+                from praetorian_cli.runners.local import install_tool, is_installed
+                mod_name = arguments["name"].lower()
+                force = arguments.get("force", False)
+                if not force and is_installed(mod_name):
+                    return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "already_installed"}))]
+                path = install_tool(mod_name, force=force)
+                return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "installed", "path": path}))]
+
+            elif name == "run_module":
+                from praetorian_cli.runners.local import LocalRunner, get_tool_plugin, is_installed
+                mod_name = arguments["name"].lower()
+                target = arguments["target"]
+                options = arguments.get("options", {})
+                if not is_installed(mod_name):
+                    return [TextContent(type="text", text=f"Module {mod_name} is not installed. Use install_module first.")]
+                plugin = get_tool_plugin(mod_name)
+                extra_config = json.dumps(options) if options else ""
+                args = plugin.build_args(target, extra_config)
+                runner = LocalRunner(mod_name)
+                result = runner.run(args, timeout=300)
+                out = {
+                    "name": mod_name,
+                    "target": target,
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            return [TextContent(type="text", text=f"Unknown module tool: {name}")]
+
+        except Exception as e:
+            return [TextContent(type="text", text=f"Error in {name}: {str(e)}")]
+
     async def _call_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        # Handle module management tools
+        if name in self._module_tools:
+            return await self._handle_module_tool(name, arguments)
+
         if name not in self.discovered_tools:
             return [TextContent(type="text", text=f"Tool {name} not found")]
         

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -42,7 +42,9 @@ class MCPServer:
         self.allowable_tools = allowable_tools
         self.server = Server("praetorian-cli")
         self.discovered_tools = {}
+        self._module_tools = {}
         self._discover_tools()
+        self._define_module_tools()
         self._register_tools()
 
     def _is_tool_allowed(self, tool_name: str) -> bool:
@@ -187,6 +189,61 @@ class MCPServer:
         
         return "string"
 
+    def _define_module_tools(self):
+        """Populate self._module_tools with explicit module management MCP tools."""
+        self._module_tools["list_modules"] = Tool(
+            name="list_modules",
+            description="List all available Guard security modules with install status. "
+                        "Returns name, category, description, install status, and version for each module.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query (matches name, description, tags)"},
+                    "category": {"type": "string", "description": "Filter by category (scanner, credential, recon, cloud, cicd, ai, supply-chain, api)"},
+                },
+            },
+        )
+
+        self._module_tools["module_info"] = Tool(
+            name="module_info",
+            description="Get full details for a Guard security module including options, version, and install path.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name (e.g., brutus, nuclei, titus)"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["install_module"] = Tool(
+            name="install_module",
+            description="Install a Guard security module binary from GitHub releases to ~/.praetorian/bin/.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name to install, or 'all'"},
+                    "force": {"type": "boolean", "description": "Reinstall even if already present"},
+                },
+                "required": ["name"],
+            },
+        )
+
+        self._module_tools["run_module"] = Tool(
+            name="run_module",
+            description="Execute an installed Guard security module against a target. "
+                        "The module must be installed first (use install_module).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Module name"},
+                    "target": {"type": "string", "description": "Target (IP, domain, URL, or Guard key)"},
+                    "options": {"type": "object", "description": "Tool-specific options as key-value pairs"},
+                },
+                "required": ["name", "target"],
+            },
+        )
+
     def _register_tools(self):
         @self.server.list_tools()
         async def list_tools() -> List[Tool]:
@@ -196,24 +253,24 @@ class MCPServer:
 
                 properties = {}
                 required = []
-                
+
                 for param_name, param_info in parameters.items():
                     if param_name == 'self':
                         continue
-                        
+
                     properties[param_name] = {
                         "type": param_info.get("type", "string"),
                         "description": param_info.get("description", f"Parameter {param_name}")
                     }
-                    
+
                     if param_info.get("required", False):
                         required.append(param_name)
-                
+
                 tool_schema = {
                     "type": "object",
                     "properties": properties
                 }
-                
+
                 if required:
                     tool_schema["required"] = required
 
@@ -228,12 +285,85 @@ class MCPServer:
                     description=description,
                     inputSchema=tool_schema
                 )
-                
+
                 tools.append(tool)
-            
+
+            # Add module management tools
+            tools.extend(self._module_tools.values())
+
             return tools
 
+    async def _handle_module_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        try:
+            if name == "list_modules":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import list_installed
+                reg = get_registry()
+                query = arguments.get("query", "")
+                category = arguments.get("category", "")
+                results = reg.search_modules(query, category=category)
+                installed = list_installed()
+                for r in results:
+                    r["installed"] = r["name"] in installed
+                    ver = reg.get_version(r["name"])
+                    r["version"] = ver["version"] if ver else None
+                return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
+            elif name == "module_info":
+                from praetorian_cli.registry import get_registry
+                from praetorian_cli.runners.local import is_installed, get_binary_path
+                reg = get_registry()
+                mod_name = arguments["name"].lower()
+                mod = reg.get_module(mod_name)
+                if not mod:
+                    return [TextContent(type="text", text=f"Unknown module: {mod_name}")]
+                ver = reg.get_version(mod_name)
+                out = {"name": mod_name, **mod}
+                out["installed"] = is_installed(mod_name)
+                out["version"] = ver["version"] if ver else None
+                out["binary_path"] = get_binary_path(mod_name)
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            elif name == "install_module":
+                from praetorian_cli.runners.local import install_tool, is_installed
+                mod_name = arguments["name"].lower()
+                force = arguments.get("force", False)
+                if not force and is_installed(mod_name):
+                    return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "already_installed"}))]
+                path = install_tool(mod_name, force=force)
+                return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "installed", "path": path}))]
+
+            elif name == "run_module":
+                from praetorian_cli.runners.local import LocalRunner, get_tool_plugin, is_installed
+                mod_name = arguments["name"].lower()
+                target = arguments["target"]
+                options = arguments.get("options", {})
+                if not is_installed(mod_name):
+                    return [TextContent(type="text", text=f"Module {mod_name} is not installed. Use install_module first.")]
+                plugin = get_tool_plugin(mod_name)
+                extra_config = json.dumps(options) if options else ""
+                args = plugin.build_args(target, extra_config)
+                runner = LocalRunner(mod_name)
+                result = runner.run(args, timeout=300)
+                out = {
+                    "name": mod_name,
+                    "target": target,
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }
+                return [TextContent(type="text", text=json.dumps(out, indent=2))]
+
+            return [TextContent(type="text", text=f"Unknown module tool: {name}")]
+
+        except Exception as e:
+            return [TextContent(type="text", text=f"Error in {name}: {str(e)}")]
+
     async def _call_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
+        # Handle module management tools
+        if name in self._module_tools:
+            return await self._handle_module_tool(name, arguments)
+
         if name not in self.discovered_tools:
             return [TextContent(type="text", text=f"Tool {name} not found")]
         

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -359,11 +359,25 @@ class MCPServer:
                 return [TextContent(type="text", text=json.dumps(out, indent=2))]
 
             elif name == "install_module":
-                from praetorian_cli.runners.local import install_tool, is_installed
+                from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
                 if not arguments.get("name"):
                     return [TextContent(type="text", text="Missing required parameter: name")]
                 mod_name = arguments["name"].lower()
                 force = arguments.get("force", False)
+
+                if mod_name == "all":
+                    results = []
+                    for tool in sorted(INSTALLABLE_TOOLS):
+                        try:
+                            if not force and is_installed(tool):
+                                results.append({"name": tool, "status": "already_installed"})
+                            else:
+                                path = install_tool(tool, force=force)
+                                results.append({"name": tool, "status": "installed", "path": path})
+                        except Exception as e:
+                            results.append({"name": tool, "status": "error", "error": str(e)})
+                    return [TextContent(type="text", text=json.dumps(results, indent=2))]
+
                 if not force and is_installed(mod_name):
                     return [TextContent(type="text", text=json.dumps({"name": mod_name, "status": "already_installed"}))]
                 path = install_tool(mod_name, force=force)

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -296,34 +296,66 @@ class MCPServer:
     async def _handle_module_tool(self, name: str, arguments: Dict[str, Any]) -> List[TextContent]:
         try:
             if name == "list_modules":
+                from praetorian_cli.catalog import CapabilityCatalog
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import list_installed
                 reg = get_registry()
                 query = arguments.get("query", "")
                 category = arguments.get("category", "")
-                results = reg.search_modules(query, category=category)
+                cat = CapabilityCatalog(self.chariot)
+                caps = cat.search(query, category=category) if (query or category) else cat.all()
                 installed = list_installed()
-                for r in results:
-                    r["installed"] = r["name"] in installed
-                    ver = reg.get_version(r["name"])
-                    r["version"] = ver["version"] if ver else None
+                results = []
+                for cap in caps:
+                    ver = reg.get_version(cap.name)
+                    results.append({
+                        "name": cap.name,
+                        "title": cap.title,
+                        "description": cap.description,
+                        "category": cap.category,
+                        "surface": cap.surface,
+                        "installed": cap.name in installed,
+                        "version": ver["version"] if ver else cap.version or None,
+                    })
                 return [TextContent(type="text", text=json.dumps(results, indent=2))]
 
             elif name == "module_info":
+                from praetorian_cli.catalog import CapabilityCatalog
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import is_installed, get_binary_path
                 if not arguments.get("name"):
                     return [TextContent(type="text", text="Missing required parameter: name")]
-                reg = get_registry()
                 mod_name = arguments["name"].lower()
-                mod = reg.get_module(mod_name)
-                if not mod:
+                cat = CapabilityCatalog(self.chariot)
+                cap = cat.get(mod_name)
+                if not cap:
                     return [TextContent(type="text", text=f"Unknown module: {mod_name}")]
+                reg = get_registry()
                 ver = reg.get_version(mod_name)
-                out = {"name": mod_name, **mod}
-                out["installed"] = is_installed(mod_name)
-                out["version"] = ver["version"] if ver else None
-                out["binary_path"] = get_binary_path(mod_name)
+                out = {
+                    "name": cap.name,
+                    "title": cap.title,
+                    "description": cap.description,
+                    "category": cap.category,
+                    "surface": cap.surface,
+                    "target": cap.target,
+                    "executor": cap.executor,
+                    "parameters": [
+                        {
+                            "name": p.name,
+                            "description": p.description,
+                            "type": p.type,
+                            "default": p.default,
+                            "required": p.required,
+                            "options": p.options,
+                        }
+                        for p in cap.parameters
+                    ],
+                    "installed": is_installed(mod_name),
+                    "version": ver["version"] if ver else cap.version or None,
+                    "binary_path": get_binary_path(mod_name),
+                    "local_only": reg.is_local_only(mod_name),
+                }
                 return [TextContent(type="text", text=json.dumps(out, indent=2))]
 
             elif name == "install_module":

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -312,6 +312,8 @@ class MCPServer:
             elif name == "module_info":
                 from praetorian_cli.registry import get_registry
                 from praetorian_cli.runners.local import is_installed, get_binary_path
+                if not arguments.get("name"):
+                    return [TextContent(type="text", text="Missing required parameter: name")]
                 reg = get_registry()
                 mod_name = arguments["name"].lower()
                 mod = reg.get_module(mod_name)
@@ -326,6 +328,8 @@ class MCPServer:
 
             elif name == "install_module":
                 from praetorian_cli.runners.local import install_tool, is_installed
+                if not arguments.get("name"):
+                    return [TextContent(type="text", text="Missing required parameter: name")]
                 mod_name = arguments["name"].lower()
                 force = arguments.get("force", False)
                 if not force and is_installed(mod_name):
@@ -335,6 +339,8 @@ class MCPServer:
 
             elif name == "run_module":
                 from praetorian_cli.runners.local import LocalRunner, get_tool_plugin, is_installed
+                if not arguments.get("name") or not arguments.get("target"):
+                    return [TextContent(type="text", text="Missing required parameter: name and target are required")]
                 mod_name = arguments["name"].lower()
                 target = arguments["target"]
                 options = arguments.get("options", {})

--- a/praetorian_cli/sdk/test/conftest.py
+++ b/praetorian_cli/sdk/test/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_singleton():
+    import praetorian_cli.registry as reg_mod
+    reg_mod._registry = None
+    yield
+    reg_mod._registry = None

--- a/praetorian_cli/sdk/test/test_catalog.py
+++ b/praetorian_cli/sdk/test/test_catalog.py
@@ -98,3 +98,31 @@ def test_catalog_falls_back_to_bundled(tmp_path):
     cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
     assert [c.name for c in cat.all()] == ['titus']
     assert cat.source == 'bundled'
+
+
+def test_catalog_falls_back_to_cache_when_api_fails_stale(tmp_path):
+    """API failure with a STALE cache must fall back to the cache (exercises the actual fallback branch)."""
+    import os, time as _time
+    cache = tmp_path / 'cap-cache.json'
+    cache.write_text(json.dumps({'capabilities': [{'Name': 'nuclei'}]}))
+    # Make the cache stale so refresh() actually attempts the API call
+    old_mtime = _time.time() - 100000
+    os.utime(str(cache), (old_mtime, old_mtime))
+    snap = tmp_path / 'snap.json'; snap.write_text('{"capabilities": []}')
+    sdk = _FakeSDK([], fail=True)
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    caps = cat.all()
+    assert [c.name for c in caps] == ['nuclei']
+    assert cat.source.startswith('cached')
+
+
+def test_bundled_snapshot_is_populated():
+    """The bundled capabilities_snapshot.json must have >= 17 entries including core tools."""
+    from praetorian_cli.catalog import DEFAULT_BUNDLED_PATH
+    data = json.load(open(DEFAULT_BUNDLED_PATH))
+    caps = data['capabilities'] if isinstance(data, dict) else data
+    assert len(caps) >= 17, f"Expected >= 17 capabilities in bundled snapshot, got {len(caps)}"
+    names = {c.get('name', c.get('Name')) for c in caps}
+    assert {'brutus', 'nuclei', 'caligula'} <= names, (
+        f"Core tools missing from bundled snapshot. Present: {sorted(names)[:20]}"
+    )

--- a/praetorian_cli/sdk/test/test_catalog.py
+++ b/praetorian_cli/sdk/test/test_catalog.py
@@ -1,0 +1,30 @@
+from praetorian_cli.catalog import Capability
+
+
+def test_capability_normalizes_agora_shape():
+    raw = {
+        'Name': 'brutus', 'Title': 'Brutus', 'Target': ['port'],
+        'Description': 'Credential testing', 'Category': ['credential'],
+        'Surface': 'external', 'RunsOn': 'any', 'Version': '0.2.0',
+        'Executor': 'chariot', 'Integration': False,
+        'Parameters': [{'Name': 'protocol', 'Description': 'svc', 'Type': 'string',
+                        'Default': '', 'Required': False, 'Options': ['ssh', 'rdp']}],
+    }
+    cap = Capability.from_api(raw)
+    assert cap.name == 'brutus'
+    assert cap.title == 'Brutus'
+    assert cap.target == ['port']
+    assert cap.category == ['credential']
+    assert cap.surface == 'external'
+    assert cap.version == '0.2.0'
+    assert cap.parameters[0].name == 'protocol'
+    assert cap.parameters[0].options == ['ssh', 'rdp']
+    assert cap.parameters[0].required is False
+
+
+def test_capability_handles_missing_and_scalar_fields():
+    cap = Capability.from_api({'Name': 'x', 'Category': 'recon', 'Target': 'port'})
+    assert cap.title == 'x'           # falls back to name
+    assert cap.category == ['recon']  # scalar coerced to list
+    assert cap.target == ['port']     # scalar coerced to list
+    assert cap.parameters == []

--- a/praetorian_cli/sdk/test/test_catalog.py
+++ b/praetorian_cli/sdk/test/test_catalog.py
@@ -1,4 +1,4 @@
-from praetorian_cli.catalog import Capability
+from praetorian_cli.catalog import Capability, rank_search
 
 
 def test_capability_normalizes_agora_shape():
@@ -28,3 +28,29 @@ def test_capability_handles_missing_and_scalar_fields():
     assert cap.category == ['recon']  # scalar coerced to list
     assert cap.target == ['port']     # scalar coerced to list
     assert cap.parameters == []
+
+
+def _caps():
+    return [
+        Capability.from_api({'Name': 'nuclei', 'Category': 'scanner', 'Surface': 'external',
+                             'Target': ['port'], 'Description': 'vuln scanner', 'Title': 'Nuclei'}),
+        Capability.from_api({'Name': 'nuclei_dast', 'Category': 'scanner', 'Surface': 'external',
+                             'Target': ['webapp'], 'Description': 'dast', 'Title': 'Nuclei DAST'}),
+        Capability.from_api({'Name': 'brutus', 'Category': 'credential', 'Surface': 'internal',
+                             'Target': ['port'], 'Description': 'creds', 'Title': 'Brutus'}),
+    ]
+
+def test_rank_search_exact_before_prefix_before_fuzzy():
+    out = rank_search(_caps(), 'nuclei')
+    assert out[0].name == 'nuclei'          # exact wins
+    assert out[1].name == 'nuclei_dast'     # prefix next
+
+def test_rank_search_typo_tolerant():
+    out = rank_search(_caps(), 'nuclie')    # transposed
+    assert out and out[0].name in ('nuclei', 'nuclei_dast')
+
+def test_rank_search_filters():
+    out = rank_search(_caps(), '', category='credential')
+    assert [c.name for c in out] == ['brutus']
+    out = rank_search(_caps(), '', surface='external', target='port')
+    assert [c.name for c in out] == ['nuclei']

--- a/praetorian_cli/sdk/test/test_catalog.py
+++ b/praetorian_cli/sdk/test/test_catalog.py
@@ -54,3 +54,47 @@ def test_rank_search_filters():
     assert [c.name for c in out] == ['brutus']
     out = rank_search(_caps(), '', surface='external', target='port')
     assert [c.name for c in out] == ['nuclei']
+
+
+import json
+from praetorian_cli.catalog import CapabilityCatalog
+
+class _FakeSDK:
+    def __init__(self, caps, fail=False):
+        self._caps = caps; self._fail = fail
+        outer = self
+        class _C:
+            def list(inner, name='', target='', executor=''):
+                if outer._fail:
+                    raise RuntimeError('network down')
+                return (outer._caps, None)
+        self.capabilities = _C()
+
+def test_catalog_live_then_cache(tmp_path):
+    cache = tmp_path / 'cap-cache.json'
+    snap = tmp_path / 'snap.json'; snap.write_text('{"capabilities": []}')
+    sdk = _FakeSDK([{'Name': 'brutus', 'Category': 'credential'}])
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    caps = cat.all()
+    assert [c.name for c in caps] == ['brutus']
+    assert cat.source == 'live'
+    assert cache.exists()
+
+def test_catalog_falls_back_to_cache_when_api_fails(tmp_path):
+    cache = tmp_path / 'cap-cache.json'
+    cache.write_text(json.dumps({'capabilities': [{'Name': 'nuclei'}]}))
+    snap = tmp_path / 'snap.json'; snap.write_text('{"capabilities": []}')
+    sdk = _FakeSDK([], fail=True)
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    caps = cat.all()
+    assert [c.name for c in caps] == ['nuclei']
+    assert cat.source.startswith('cached')
+
+def test_catalog_falls_back_to_bundled(tmp_path):
+    cache = tmp_path / 'missing.json'
+    snap = tmp_path / 'snap.json'
+    snap.write_text(json.dumps({'capabilities': [{'Name': 'titus'}]}))
+    sdk = _FakeSDK([], fail=True)
+    cat = CapabilityCatalog(sdk, cache_path=str(cache), bundled_path=str(snap))
+    assert [c.name for c in cat.all()] == ['titus']
+    assert cat.source == 'bundled'

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -228,3 +228,36 @@ class TestPluginsForwardPassthrough:
         assert NucleiPlugin().build_args('example.com') == ['-u', 'example.com', '-jsonl']
         assert TitusPlugin().build_args('x') == ['scan', 'x']
         assert JuliusPlugin().build_args('x') == ['-t', 'x']
+
+
+import os
+from praetorian_cli.runners import local
+
+
+def test_uninstall_removes_binary_and_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    binp = tmp_path / 'titus'
+    binp.write_text('#!/bin/sh\n'); os.chmod(binp, 0o755)
+    removed = {}
+    class _Reg:
+        def remove_version(self, n): removed['n'] = n
+    monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
+    assert local.uninstall_tool('titus') is True
+    assert not binp.exists()
+    assert removed['n'] == 'titus'
+
+
+def test_uninstall_missing_returns_false(tmp_path, monkeypatch):
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    class _Reg:
+        def remove_version(self, n): pass
+    monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
+    assert local.uninstall_tool('ghost') is False
+
+
+def test_verify_sha256_matches(tmp_path):
+    import hashlib
+    f = tmp_path / 'b'; f.write_bytes(b'hello')
+    digest = hashlib.sha256(b'hello').hexdigest()
+    assert local.verify_sha256(str(f), digest) is True
+    assert local.verify_sha256(str(f), 'deadbeef') is False

--- a/praetorian_cli/sdk/test/test_local_runner.py
+++ b/praetorian_cli/sdk/test/test_local_runner.py
@@ -236,10 +236,12 @@ from praetorian_cli.runners import local
 
 def test_uninstall_removes_binary_and_version(tmp_path, monkeypatch):
     monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    monkeypatch.setattr(local.INSTALLABLE_TOOLS, '_loaded', None)
     binp = tmp_path / 'titus'
     binp.write_text('#!/bin/sh\n'); os.chmod(binp, 0o755)
     removed = {}
     class _Reg:
+        def get_installable_tools(self): return {'titus': {'repo': '', 'description': ''}}
         def remove_version(self, n): removed['n'] = n
     monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
     assert local.uninstall_tool('titus') is True
@@ -248,11 +250,53 @@ def test_uninstall_removes_binary_and_version(tmp_path, monkeypatch):
 
 
 def test_uninstall_missing_returns_false(tmp_path, monkeypatch):
+    # A registered tool that was never installed is a safe no-op.
     monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    monkeypatch.setattr(local.INSTALLABLE_TOOLS, '_loaded', None)
+    class _Reg:
+        def get_installable_tools(self): return {'nuclei': {'repo': '', 'description': ''}}
+        def remove_version(self, n): pass
+    monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
+    assert local.uninstall_tool('nuclei') is False
+
+
+def test_uninstall_unknown_tool_raises(tmp_path, monkeypatch):
+    # Unregistered tool names are rejected outright (ENG security review finding).
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    monkeypatch.setattr(local.INSTALLABLE_TOOLS, '_loaded', None)
+    with pytest.raises(ValueError):
+        local.uninstall_tool('ghost')
+
+
+def test_uninstall_rejects_unregistered_traversal_name(tmp_path, monkeypatch):
+    # A traversal-y name is not a registered tool, so it's rejected outright.
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    monkeypatch.setattr(local.INSTALLABLE_TOOLS, '_loaded', None)
+    outside_target = tmp_path.parent / 'passwd'
+    outside_target.write_text('canary')
+    with pytest.raises(ValueError):
+        local.uninstall_tool('../../../../etc/passwd')
+    assert outside_target.exists()
+
+
+@pytest.mark.parametrize('malicious_name', [
+    '../../../../etc/passwd',
+    '/etc/passwd',
+    '../evil',
+])
+def test_uninstall_never_escapes_install_dir(tmp_path, malicious_name, monkeypatch):
+    # Defense in depth: even if a traversal-y name were ever considered
+    # "known" (e.g. via a future registry bug), removal must stay confined
+    # to INSTALL_DIR and never touch a path outside it.
+    monkeypatch.setattr(local, 'INSTALL_DIR', str(tmp_path))
+    monkeypatch.setattr(local, 'INSTALLABLE_TOOLS', {malicious_name: {}})
     class _Reg:
         def remove_version(self, n): pass
     monkeypatch.setattr('praetorian_cli.registry.get_registry', lambda: _Reg())
-    assert local.uninstall_tool('ghost') is False
+    outside_target = tmp_path.parent / 'passwd'
+    outside_target.write_text('canary')
+    local.uninstall_tool(malicious_name)
+    assert outside_target.read_text() == 'canary'
 
 
 def test_verify_sha256_matches(tmp_path):

--- a/praetorian_cli/sdk/test/test_mcp_modules.py
+++ b/praetorian_cli/sdk/test/test_mcp_modules.py
@@ -1,0 +1,112 @@
+"""Tests for MCP list_modules / module_info using CapabilityCatalog."""
+
+import asyncio
+import json
+from unittest.mock import patch, MagicMock
+
+from praetorian_cli.catalog import Capability
+from praetorian_cli.sdk.mcp_server import MCPServer
+
+SAMPLE = [
+    Capability.from_api({'Name': 'brutus', 'Category': ['credential'],
+                         'Description': 'Credential tester', 'Version': '1.0.0'}),
+    Capability.from_api({'Name': 'nuclei', 'Category': ['scanner'],
+                         'Description': 'Vuln scanner', 'Version': '2.0.0'}),
+]
+
+
+class _FakeSDK:
+    """Minimal SDK stub — MCPServer only reads .chariot attrs for _discover_tools;
+    we don't need real entity objects since we're testing module tools only."""
+    pass
+
+
+def _make_server():
+    return MCPServer(_FakeSDK())
+
+
+# ---------------------------------------------------------------------------
+# list_modules — returns all capabilities from CapabilityCatalog
+# ---------------------------------------------------------------------------
+
+def test_list_modules_returns_all_capabilities():
+    server = _make_server()
+    with patch('praetorian_cli.catalog.CapabilityCatalog.all', return_value=SAMPLE), \
+         patch('praetorian_cli.runners.local.list_installed', return_value={}), \
+         patch('praetorian_cli.registry.get_registry') as mock_reg:
+        mock_reg.return_value.get_version.return_value = None
+        result = asyncio.run(server._handle_module_tool('list_modules', {}))
+
+    assert len(result) == 1
+    data = json.loads(result[0].text)
+    names = {item['name'] for item in data}
+    assert names == {'brutus', 'nuclei'}
+
+
+def test_list_modules_query_filter():
+    """query param should narrow results to matching capabilities."""
+    server = _make_server()
+    with patch('praetorian_cli.catalog.CapabilityCatalog.all', return_value=SAMPLE), \
+         patch('praetorian_cli.runners.local.list_installed', return_value={}), \
+         patch('praetorian_cli.registry.get_registry') as mock_reg:
+        mock_reg.return_value.get_version.return_value = None
+        result = asyncio.run(server._handle_module_tool('list_modules', {'query': 'brutus'}))
+
+    data = json.loads(result[0].text)
+    assert len(data) == 1
+    assert data[0]['name'] == 'brutus'
+
+
+def test_list_modules_install_status():
+    """installed flag should be True only for installed modules."""
+    server = _make_server()
+    with patch('praetorian_cli.catalog.CapabilityCatalog.all', return_value=SAMPLE), \
+         patch('praetorian_cli.runners.local.list_installed',
+               return_value={'brutus': '/usr/local/bin/brutus'}), \
+         patch('praetorian_cli.registry.get_registry') as mock_reg:
+        mock_reg.return_value.get_version.return_value = {'version': '1.0.0'}
+        result = asyncio.run(server._handle_module_tool('list_modules', {}))
+
+    data = json.loads(result[0].text)
+    by_name = {item['name']: item for item in data}
+    assert by_name['brutus']['installed'] is True
+    assert by_name['nuclei']['installed'] is False
+
+
+# ---------------------------------------------------------------------------
+# module_info — returns detailed info for a single capability
+# ---------------------------------------------------------------------------
+
+def test_module_info_returns_capability_fields():
+    server = _make_server()
+    with patch('praetorian_cli.catalog.CapabilityCatalog.get',
+               return_value=SAMPLE[0]), \
+         patch('praetorian_cli.runners.local.is_installed', return_value=False), \
+         patch('praetorian_cli.runners.local.get_binary_path', return_value=None), \
+         patch('praetorian_cli.registry.get_registry') as mock_reg:
+        mock_reg.return_value.get_version.return_value = {'version': '1.0.0'}
+        mock_reg.return_value.is_local_only.return_value = False
+        result = asyncio.run(server._handle_module_tool('module_info', {'name': 'brutus'}))
+
+    data = json.loads(result[0].text)
+    assert data['name'] == 'brutus'
+    assert data['description'] == 'Credential tester'
+    assert 'installed' in data
+    assert 'version' in data
+    assert 'binary_path' in data
+    assert 'local_only' in data
+
+
+def test_module_info_unknown_module():
+    """Unknown module should return a helpful error message (not crash)."""
+    server = _make_server()
+    with patch('praetorian_cli.catalog.CapabilityCatalog.get', return_value=None):
+        result = asyncio.run(server._handle_module_tool('module_info', {'name': 'nonexistent'}))
+
+    assert 'Unknown module' in result[0].text
+
+
+def test_module_info_missing_name_param():
+    server = _make_server()
+    result = asyncio.run(server._handle_module_tool('module_info', {}))
+    assert 'Missing required parameter' in result[0].text

--- a/praetorian_cli/sdk/test/test_mcp_modules.py
+++ b/praetorian_cli/sdk/test/test_mcp_modules.py
@@ -110,3 +110,50 @@ def test_module_info_missing_name_param():
     server = _make_server()
     result = asyncio.run(server._handle_module_tool('module_info', {}))
     assert 'Missing required parameter' in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# install_module — name='all' installs every installable tool
+# ---------------------------------------------------------------------------
+
+def test_install_module_all_installs_each_tool():
+    """install_module with name='all' should attempt each tool and return a list."""
+    server = _make_server()
+    calls = []
+
+    def _stub_install(name, force=False):
+        calls.append(name)
+        return f'/bin/{name}'
+
+    with patch('praetorian_cli.runners.local.install_tool', side_effect=_stub_install), \
+         patch('praetorian_cli.runners.local.is_installed', return_value=False), \
+         patch('praetorian_cli.runners.local.INSTALLABLE_TOOLS', {'brutus': {}, 'nuclei': {}}):
+        result = asyncio.run(server._handle_module_tool('install_module', {'name': 'all'}))
+
+    assert sorted(calls) == ['brutus', 'nuclei']
+    data = json.loads(result[0].text)
+    assert isinstance(data, list)
+    names = {item['name'] for item in data}
+    assert names == {'brutus', 'nuclei'}
+    assert all(item['status'] == 'installed' for item in data)
+
+
+def test_install_module_all_isolates_failures():
+    """One tool failing must not abort the batch."""
+    server = _make_server()
+
+    def _stub_install(name, force=False):
+        if name == 'brutus':
+            raise RuntimeError('boom')
+        return f'/bin/{name}'
+
+    with patch('praetorian_cli.runners.local.install_tool', side_effect=_stub_install), \
+         patch('praetorian_cli.runners.local.is_installed', return_value=False), \
+         patch('praetorian_cli.runners.local.INSTALLABLE_TOOLS', {'brutus': {}, 'nuclei': {}}):
+        result = asyncio.run(server._handle_module_tool('install_module', {'name': 'all'}))
+
+    data = json.loads(result[0].text)
+    by_name = {item['name']: item for item in data}
+    assert by_name['brutus']['status'] == 'error'
+    assert 'boom' in by_name['brutus']['error']
+    assert by_name['nuclei']['status'] == 'installed'

--- a/praetorian_cli/sdk/test/test_module_cli.py
+++ b/praetorian_cli/sdk/test/test_module_cli.py
@@ -1,0 +1,117 @@
+"""Unit tests for `guard module` CLI commands."""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.module  # registers `module` subcommand on chariot
+from praetorian_cli.handlers.chariot import chariot
+
+pytestmark = pytest.mark.cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    return sdk
+
+
+SAMPLE_MODULES = {
+    "brutus": {
+        "repo": "praetorian-inc/brutus",
+        "description": "Credential attacks across 20+ protocols",
+        "category": "credential",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {
+            "protocol": {"type": "string", "description": "Target protocol", "required": False},
+        },
+        "tags": ["brute-force", "password"],
+    },
+    "nuclei": {
+        "repo": "praetorian-inc/nuclei",
+        "description": "Vulnerability scanner",
+        "category": "scanner",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {},
+        "tags": ["vulnerability"],
+    },
+}
+
+
+def _invoke(runner, fake_sdk, argv):
+    obj = {"keychain": MagicMock(), "proxy": ""}
+    with patch("praetorian_cli.sdk.chariot.Chariot", return_value=fake_sdk), \
+         patch("praetorian_cli.handlers.cli_decorators.upgrade_check", lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, catch_exceptions=False)
+
+
+class TestModuleSearch:
+    def test_search_no_args_lists_all(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+        assert "nuclei" in result.output
+
+    def test_search_with_query(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "credential"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+
+    def test_search_with_category_filter(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "--category", "scanner"])
+        assert result.exit_code == 0
+        assert "nuclei" in result.output
+
+    def test_search_json_output(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "search", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+
+class TestModuleInfo:
+    def test_info_existing_module(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            result = _invoke(runner, fake_sdk, ["module", "info", "brutus"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output
+        assert "credential" in result.output.lower() or "Credential" in result.output
+
+    def test_info_unknown_module(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            result = _invoke(runner, fake_sdk, ["module", "info", "nonexistent"])
+        assert result.exit_code != 0
+
+    def test_info_json_output(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            result = _invoke(runner, fake_sdk, ["module", "info", "brutus", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["name"] == "brutus"
+
+
+class TestModuleInstalled:
+    def test_installed_lists_tools(self, runner, fake_sdk):
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={"brutus": "/path/brutus"}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_all_versions", return_value={
+                 "brutus": {"version": "v1.2.3", "path": "/path/brutus"}
+             }):
+            result = _invoke(runner, fake_sdk, ["module", "installed"])
+        assert result.exit_code == 0
+        assert "brutus" in result.output

--- a/praetorian_cli/sdk/test/test_module_cli.py
+++ b/praetorian_cli/sdk/test/test_module_cli.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 import praetorian_cli.handlers.module  # registers `module` subcommand on chariot
+from praetorian_cli.catalog import Capability
 from praetorian_cli.handlers.chariot import chariot
 
 pytestmark = pytest.mark.cli
@@ -46,6 +47,25 @@ SAMPLE_MODULES = {
 }
 
 
+SAMPLE_CAPS = [
+    Capability.from_api({
+        "Name": "brutus", "Title": "Brutus", "Category": ["credential"],
+        "Surface": "external", "Target": ["port"],
+        "Description": "Credential attacks across 20+ protocols",
+        "Version": "v1.2.3", "Executor": "chariot",
+        "Parameters": [
+            {"Name": "protocol", "Type": "string", "Description": "Target protocol", "Required": False},
+        ],
+    }),
+    Capability.from_api({
+        "Name": "nuclei", "Title": "Nuclei", "Category": ["scanner"],
+        "Surface": "external", "Target": ["asset"],
+        "Description": "Vulnerability scanner",
+        "Version": "v2.0.0", "Executor": "chariot", "Parameters": [],
+    }),
+]
+
+
 def _invoke(runner, fake_sdk, argv):
     obj = {"keychain": MagicMock(), "proxy": ""}
     with patch("praetorian_cli.sdk.chariot.Chariot", return_value=fake_sdk), \
@@ -55,36 +75,49 @@ def _invoke(runner, fake_sdk, argv):
 
 class TestModuleSearch:
     def test_search_no_args_lists_all(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS):
             result = _invoke(runner, fake_sdk, ["module", "search"])
         assert result.exit_code == 0
         assert "brutus" in result.output
         assert "nuclei" in result.output
 
     def test_search_with_query(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS):
             result = _invoke(runner, fake_sdk, ["module", "search", "credential"])
         assert result.exit_code == 0
         assert "brutus" in result.output
 
     def test_search_with_category_filter(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS):
             result = _invoke(runner, fake_sdk, ["module", "search", "--category", "scanner"])
         assert result.exit_code == 0
         assert "nuclei" in result.output
 
     def test_search_json_output(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS):
             result = _invoke(runner, fake_sdk, ["module", "search", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert isinstance(data, list)
         assert len(data) == 2
 
+    @patch("praetorian_cli.catalog.CapabilityCatalog.all")
+    def test_module_search_json_uses_catalog(self, mock_all, runner, fake_sdk):
+        mock_all.return_value = [Capability.from_api(
+            {'Name': 'brutus', 'Title': 'Brutus', 'Category': ['credential'],
+             'Surface': 'external', 'Target': ['port'], 'Description': 'creds',
+             'Version': '0.2.0', 'Executor': 'chariot', 'Parameters': []})]
+        with patch("praetorian_cli.runners.local.list_installed", return_value={}):
+            result = _invoke(runner, fake_sdk, ["module", "search", "brutus", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["name"] == "brutus"
+        assert data[0]["version"] == "0.2.0"
+
 
 class TestModuleInfo:
     def test_info_existing_module(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS), \
              patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
             result = _invoke(runner, fake_sdk, ["module", "info", "brutus"])
         assert result.exit_code == 0
@@ -92,12 +125,12 @@ class TestModuleInfo:
         assert "credential" in result.output.lower() or "Credential" in result.output
 
     def test_info_unknown_module(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS):
             result = _invoke(runner, fake_sdk, ["module", "info", "nonexistent"])
         assert result.exit_code != 0
 
     def test_info_json_output(self, runner, fake_sdk):
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPS), \
              patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
             result = _invoke(runner, fake_sdk, ["module", "info", "brutus", "--json"])
         assert result.exit_code == 0

--- a/praetorian_cli/sdk/test/test_module_cli.py
+++ b/praetorian_cli/sdk/test/test_module_cli.py
@@ -138,6 +138,32 @@ class TestModuleInfo:
         assert data["name"] == "brutus"
 
 
+PIUS_CAPS = [
+    Capability.from_api({
+        "Name": "pius_discovery", "Title": "Pius Discovery", "Category": ["discovery"],
+        "Surface": "external", "Target": ["asset"],
+        "Description": "Asset discovery via pius",
+        "Version": "v1.0.0", "Executor": "chariot", "Parameters": [],
+    }),
+]
+
+
+class TestModuleCapabilityAlias:
+    def test_info_resolves_via_capability_alias(self, runner, fake_sdk):
+        """`module info pius` must resolve to the aliased capability `pius_discovery`."""
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=PIUS_CAPS), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            result = _invoke(runner, fake_sdk, ["module", "info", "pius", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["name"] == "pius_discovery"
+
+    def test_options_resolves_via_capability_alias(self, runner, fake_sdk):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=PIUS_CAPS):
+            result = _invoke(runner, fake_sdk, ["module", "options", "pius", "--json"])
+        assert result.exit_code == 0, result.output
+
+
 class TestModuleInstalled:
     def test_installed_lists_tools(self, runner, fake_sdk):
         with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \

--- a/praetorian_cli/sdk/test/test_registry.py
+++ b/praetorian_cli/sdk/test/test_registry.py
@@ -216,3 +216,18 @@ class TestRegistryAsInstallableTools:
         assert "target_type" in aliases["brutus"]
         assert "description" in aliases["brutus"]
         assert "capability" in aliases["brutus"]
+
+
+def test_get_tool_aliases_tolerates_slim_manifest(monkeypatch, tmp_path):
+    import praetorian_cli.registry as reg_mod
+    from praetorian_cli.registry import get_registry
+    manifest = tmp_path / 'registry.json'
+    manifest.write_text('{"version": 2, "modules": {"brutus": {"repo": "praetorian-inc/brutus"}}}')
+    monkeypatch.setattr(reg_mod, 'BUNDLED_REGISTRY_PATH', str(manifest))
+    monkeypatch.setattr(reg_mod, 'CACHE_PATH', str(tmp_path / 'none.json'))
+    reg_mod._registry = None
+    aliases = get_registry().get_tool_aliases()
+    assert 'brutus' in aliases
+    assert aliases['brutus']['description'] == ''          # defaults, no KeyError
+    assert aliases['brutus']['target_type'] == 'asset'
+    assert aliases['brutus']['capability'] == 'brutus'

--- a/praetorian_cli/sdk/test/test_registry.py
+++ b/praetorian_cli/sdk/test/test_registry.py
@@ -231,3 +231,37 @@ def test_get_tool_aliases_tolerates_slim_manifest(monkeypatch, tmp_path):
     assert aliases['brutus']['description'] == ''          # defaults, no KeyError
     assert aliases['brutus']['target_type'] == 'asset'
     assert aliases['brutus']['capability'] == 'brutus'
+
+
+# ---------------------------------------------------------------------------
+# FIX 2: Thread-safe version writes under concurrent install all
+# ---------------------------------------------------------------------------
+
+def test_record_version_concurrent_no_lost_writes(tmp_path, monkeypatch):
+    """12 concurrent threads each calling record_version must all persist; no lost writes."""
+    import concurrent.futures
+    import praetorian_cli.registry as reg_mod
+
+    monkeypatch.setattr(reg_mod, 'VERSIONS_PATH', str(tmp_path / 'versions.json'))
+    monkeypatch.setattr(reg_mod, 'CACHE_PATH', str(tmp_path / 'cache-none.json'))
+
+    # Each thread gets its own registry instance so no in-process _data caching
+    # masks the race — they all read/write the same file.
+    n = 12
+
+    def install(i):
+        reg = reg_mod.ModuleRegistry()
+        reg.record_version(f'tool{i}', 'v1', f'/path/{i}')
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
+        futures = [ex.submit(install, i) for i in range(n)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()  # re-raise any exceptions
+
+    # Read back via a fresh instance
+    final_reg = reg_mod.ModuleRegistry()
+    all_versions = final_reg.get_all_versions()
+    assert len(all_versions) == n, (
+        f"Expected {n} version entries (no lost writes), got {len(all_versions)}: "
+        f"{sorted(all_versions.keys())}"
+    )

--- a/praetorian_cli/sdk/test/test_registry.py
+++ b/praetorian_cli/sdk/test/test_registry.py
@@ -176,6 +176,29 @@ class TestVersionTracking:
         assert reg.get_version("brutus") is None
 
 
+def test_manifest_exposes_capability_alias_and_local_only(monkeypatch, tmp_path):
+    import praetorian_cli.registry as reg_mod
+    from praetorian_cli.registry import get_registry
+    manifest = tmp_path / 'registry.json'
+    manifest.write_text('''{
+      "version": 2,
+      "modules": {
+        "brutus": {"repo": "praetorian-inc/brutus", "binary_pattern": "brutus-{os}-{arch}*", "plugin": "brutus"},
+        "pius": {"repo": "praetorian-inc/pius", "capability": "pius_discovery"},
+        "titus": {"repo": "praetorian-inc/titus", "local_only": true}
+      }
+    }''')
+    monkeypatch.setattr(reg_mod, 'BUNDLED_REGISTRY_PATH', str(manifest))
+    monkeypatch.setattr(reg_mod, 'CACHE_PATH', str(tmp_path / 'cache-none.json'))
+    reg_mod._registry = None
+    reg = get_registry()
+    assert reg.get_capability_name('pius') == 'pius_discovery'
+    assert reg.get_capability_name('brutus') == 'brutus'   # defaults to name
+    assert reg.is_local_only('titus') is True
+    assert reg.is_local_only('brutus') is False
+    assert reg.get_binary_pattern('brutus') == 'brutus-{os}-{arch}*'
+
+
 class TestRegistryAsInstallableTools:
     def test_get_installable_tools_dict(self, seeded_cache):
         """get_installable_tools returns a dict compatible with the old INSTALLABLE_TOOLS."""

--- a/praetorian_cli/sdk/test/test_registry.py
+++ b/praetorian_cli/sdk/test/test_registry.py
@@ -1,0 +1,195 @@
+"""Unit tests for the module registry."""
+import json
+import os
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from praetorian_cli.registry import (
+    ModuleRegistry,
+    CACHE_PATH,
+    VERSIONS_PATH,
+    BUNDLED_REGISTRY_PATH,
+)
+
+
+SAMPLE_REGISTRY = {
+    "version": 1,
+    "modules": {
+        "brutus": {
+            "repo": "praetorian-inc/brutus",
+            "description": "Credential attacks across 20+ protocols",
+            "category": "credential",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {
+                "protocol": {"type": "string", "description": "Target protocol", "required": False},
+            },
+            "args_template": ["--target", "{target}"],
+            "tags": ["brute-force", "password"],
+        },
+        "nuclei": {
+            "repo": "praetorian-inc/nuclei",
+            "description": "Vulnerability scanner with template engine",
+            "category": "scanner",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {},
+            "args_template": ["-u", "{target}", "-jsonl"],
+            "tags": ["vulnerability", "cve"],
+        },
+        "julius": {
+            "repo": "praetorian-inc/julius",
+            "description": "LLM/AI service fingerprinting",
+            "category": "ai",
+            "author": "Praetorian",
+            "target_type": "asset",
+            "options": {},
+            "args_template": ["-t", "{target}"],
+            "tags": ["llm", "ai"],
+        },
+    },
+}
+
+
+@pytest.fixture
+def tmp_home(tmp_path, monkeypatch):
+    """Redirect registry cache and versions to a temp dir."""
+    cache = tmp_path / "registry.json"
+    versions = tmp_path / "versions.json"
+    monkeypatch.setattr("praetorian_cli.registry.CACHE_PATH", str(cache))
+    monkeypatch.setattr("praetorian_cli.registry.VERSIONS_PATH", str(versions))
+    return tmp_path
+
+
+@pytest.fixture
+def seeded_cache(tmp_home):
+    """Write SAMPLE_REGISTRY into the cache file."""
+    cache = tmp_home / "registry.json"
+    cache.write_text(json.dumps(SAMPLE_REGISTRY))
+    return tmp_home
+
+
+class TestRegistryLoading:
+    def test_loads_from_cache(self, seeded_cache):
+        reg = ModuleRegistry()
+        modules = reg.get_modules()
+        assert "brutus" in modules
+        assert "nuclei" in modules
+        assert modules["brutus"]["category"] == "credential"
+
+    def test_falls_back_to_bundled(self, tmp_home):
+        """When cache is missing, loads the bundled registry."""
+        reg = ModuleRegistry()
+        modules = reg.get_modules()
+        assert len(modules) > 0
+
+    def test_get_module_by_name(self, seeded_cache):
+        reg = ModuleRegistry()
+        mod = reg.get_module("brutus")
+        assert mod is not None
+        assert mod["repo"] == "praetorian-inc/brutus"
+
+    def test_get_module_unknown_returns_none(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg.get_module("nonexistent") is None
+
+    def test_get_module_case_insensitive(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg.get_module("BRUTUS") is not None
+        assert reg.get_module("Brutus") is not None
+
+
+class TestRegistrySearch:
+    def test_search_by_name(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("brut")
+        assert any(r["name"] == "brutus" for r in results)
+
+    def test_search_by_category(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules(category="credential")
+        names = [r["name"] for r in results]
+        assert "brutus" in names
+        assert "nuclei" not in names
+
+    def test_search_by_tag(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("llm")
+        assert any(r["name"] == "julius" for r in results)
+
+    def test_search_by_description(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("template")
+        assert any(r["name"] == "nuclei" for r in results)
+
+    def test_search_no_query_returns_all(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules()
+        assert len(results) == 3
+
+    def test_search_combined_query_and_category(self, seeded_cache):
+        reg = ModuleRegistry()
+        results = reg.search_modules("brut", category="scanner")
+        assert len(results) == 0  # brutus is credential, not scanner
+
+
+class TestRegistryCacheStaleness:
+    def test_fresh_cache_is_not_stale(self, seeded_cache):
+        reg = ModuleRegistry()
+        assert reg._is_cache_stale() is False
+
+    def test_old_cache_is_stale(self, seeded_cache):
+        cache = seeded_cache / "registry.json"
+        old_time = time.time() - 90000  # 25 hours ago
+        os.utime(str(cache), (old_time, old_time))
+        reg = ModuleRegistry()
+        assert reg._is_cache_stale() is True
+
+
+class TestVersionTracking:
+    def test_record_and_get_version(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.2.3", "/path/to/brutus")
+        info = reg.get_version("brutus")
+        assert info["version"] == "v1.2.3"
+        assert info["path"] == "/path/to/brutus"
+        assert "installed_at" in info
+
+    def test_get_version_uninstalled_returns_none(self, tmp_home):
+        reg = ModuleRegistry()
+        assert reg.get_version("nonexistent") is None
+
+    def test_get_all_versions(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.0.0", "/a")
+        reg.record_version("nuclei", "v3.0.0", "/b")
+        versions = reg.get_all_versions()
+        assert "brutus" in versions
+        assert "nuclei" in versions
+
+    def test_remove_version(self, tmp_home):
+        reg = ModuleRegistry()
+        reg.record_version("brutus", "v1.0.0", "/a")
+        reg.remove_version("brutus")
+        assert reg.get_version("brutus") is None
+
+
+class TestRegistryAsInstallableTools:
+    def test_get_installable_tools_dict(self, seeded_cache):
+        """get_installable_tools returns a dict compatible with the old INSTALLABLE_TOOLS."""
+        reg = ModuleRegistry()
+        tools = reg.get_installable_tools()
+        assert "brutus" in tools
+        assert tools["brutus"]["repo"] == "praetorian-inc/brutus"
+        assert "description" in tools["brutus"]
+
+    def test_get_tool_aliases_dict(self, seeded_cache):
+        """get_tool_aliases returns a dict compatible with the old TOOL_ALIASES."""
+        reg = ModuleRegistry()
+        aliases = reg.get_tool_aliases()
+        assert "brutus" in aliases
+        assert "target_type" in aliases["brutus"]
+        assert "description" in aliases["brutus"]
+        assert "capability" in aliases["brutus"]

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -1,0 +1,115 @@
+"""Unit tests for console module commands (search, info, update)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from praetorian_cli.ui.console.commands.tools import ToolCommands
+from praetorian_cli.sdk.test.ui_mocks import MockConsole as _BaseMockConsole
+
+pytestmark = pytest.mark.tui
+
+
+SAMPLE_MODULES = {
+    "brutus": {
+        "repo": "praetorian-inc/brutus",
+        "description": "Credential attacks across 20+ protocols",
+        "category": "credential",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {
+            "protocol": {"type": "string", "description": "Target protocol", "required": False},
+        },
+        "tags": ["brute-force", "password"],
+    },
+    "nuclei": {
+        "repo": "praetorian-inc/nuclei",
+        "description": "Vulnerability scanner",
+        "category": "scanner",
+        "author": "Praetorian",
+        "target_type": "asset",
+        "options": {},
+        "tags": ["vulnerability"],
+    },
+}
+
+
+class MockConsole(_BaseMockConsole):
+    def print(self, msg="", **kwargs):
+        from rich.console import Console as _RichConsole
+        from io import StringIO
+        from rich.table import Table
+        from rich.panel import Panel
+        from rich.text import Text
+        if isinstance(msg, (Table, Panel, Text)):
+            buf = StringIO()
+            rc = _RichConsole(file=buf, highlight=False, markup=False)
+            rc.print(msg)
+            self.lines.append(buf.getvalue())
+        else:
+            self.lines.append(str(msg))
+
+
+class _FakeContext:
+    active_tool = None
+    account = "acct"
+    _last_job_key = ""
+
+    def apply_scope_to_message(self, msg):
+        return msg
+
+
+class _Harness(ToolCommands):
+    def __init__(self, sdk=None):
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FakeContext()
+        self.colors = {
+            "primary": "cyan", "accent": "magenta", "dim": "dim",
+            "info": "blue", "success": "green", "warning": "yellow", "error": "red",
+        }
+
+    def _send_to_marcus(self, message):
+        return ""
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+
+class TestConsoleSearch:
+    def test_search_lists_all_modules(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_search([])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+        assert "nuclei" in output
+
+    def test_search_filters_by_query(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_search(["credential"])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+
+
+class TestConsoleInfo:
+    def test_info_shows_module_details(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+             patch("praetorian_cli.runners.local.is_installed", return_value=False), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_info(["brutus"])
+        output = "\n".join(h.console.lines)
+        assert "brutus" in output
+        assert "credential" in output.lower() or "Credential" in output
+
+    def test_info_unknown_module(self):
+        h = _Harness()
+        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+            h._cmd_module_info(["nonexistent"])
+        output = "\n".join(h.console.lines)
+        assert "unknown" in output.lower() or "not found" in output.lower()

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from praetorian_cli.catalog import Capability
 from praetorian_cli.ui.console.commands.tools import ToolCommands
 from praetorian_cli.sdk.test.ui_mocks import MockConsole as _BaseMockConsole
 
@@ -31,6 +32,33 @@ SAMPLE_MODULES = {
         "tags": ["vulnerability"],
     },
 }
+
+SAMPLE_CAPABILITIES = [
+    Capability.from_api({
+        "Name": "brutus",
+        "Title": "Brutus Credential Attacks",
+        "Description": "Credential attacks across 20+ protocols",
+        "Category": ["credential"],
+        "Surface": "network",
+        "Target": ["asset"],
+        "Version": "1.2.3",
+        "Executor": "local",
+        "Parameters": [
+            {"Name": "protocol", "Description": "Target protocol", "Type": "string", "Required": False},
+        ],
+    }),
+    Capability.from_api({
+        "Name": "nuclei",
+        "Title": "Nuclei Vulnerability Scanner",
+        "Description": "Vulnerability scanner",
+        "Category": ["scanner"],
+        "Surface": "network",
+        "Target": ["asset"],
+        "Version": "2.0.0",
+        "Executor": "local",
+        "Parameters": [],
+    }),
+]
 
 
 class MockConsole(_BaseMockConsole):
@@ -78,9 +106,10 @@ class _Harness(ToolCommands):
 class TestConsoleSearch:
     def test_search_lists_all_modules(self):
         h = _Harness()
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
              patch("praetorian_cli.runners.local.list_installed", return_value={}), \
-             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None), \
+             patch("praetorian_cli.registry.ModuleRegistry.is_local_only", return_value=False):
             h._cmd_module_search([])
         output = "\n".join(h.console.lines)
         assert "brutus" in output
@@ -88,9 +117,10 @@ class TestConsoleSearch:
 
     def test_search_filters_by_query(self):
         h = _Harness()
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
              patch("praetorian_cli.runners.local.list_installed", return_value={}), \
-             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None), \
+             patch("praetorian_cli.registry.ModuleRegistry.is_local_only", return_value=False):
             h._cmd_module_search(["credential"])
         output = "\n".join(h.console.lines)
         assert "brutus" in output
@@ -99,7 +129,7 @@ class TestConsoleSearch:
 class TestConsoleInfo:
     def test_info_shows_module_details(self):
         h = _Harness()
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES), \
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
              patch("praetorian_cli.runners.local.is_installed", return_value=False), \
              patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
             h._cmd_module_info(["brutus"])
@@ -109,7 +139,39 @@ class TestConsoleInfo:
 
     def test_info_unknown_module(self):
         h = _Harness()
-        with patch("praetorian_cli.registry.ModuleRegistry.get_modules", return_value=SAMPLE_MODULES):
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES):
             h._cmd_module_info(["nonexistent"])
         output = "\n".join(h.console.lines)
         assert "unknown" in output.lower() or "not found" in output.lower()
+
+
+class TestConsoleModuleNumberedLookup:
+    def test_console_module_info_accepts_result_number(self):
+        """After a search, 'info 1' resolves to the first result by number."""
+        h = _Harness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None), \
+             patch("praetorian_cli.registry.ModuleRegistry.is_local_only", return_value=False):
+            h._cmd_module_search([])  # populates self._module_list
+
+        # The first capability in SAMPLE_CAPABILITIES is "brutus"
+        assert hasattr(h, "_module_list"), "_module_list should be set after search"
+        assert len(h._module_list) >= 1
+        first_name = h._module_list[0]
+
+        h.console.lines.clear()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
+             patch("praetorian_cli.runners.local.is_installed", return_value=False), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None):
+            h._cmd_module_info(["1"])
+
+        output = "\n".join(h.console.lines)
+        # Must NOT print "Unknown module: 1"
+        assert "Unknown module: 1" not in output, (
+            f"'info 1' should resolve to '{first_name}', not treat '1' as a name. Got:\n{output}"
+        )
+        # Must render info for the first capability
+        assert first_name in output, (
+            f"Expected '{first_name}' in output after 'info 1'. Got:\n{output}"
+        )

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -353,3 +353,90 @@ class TestOptionsPopulatedFromLiveParams:
         # Must NOT contain an error about unknown/invalid
         assert "unknown" not in output.lower(), f"Valid enum value should be accepted. Got:\n{output}"
         assert "invalid" not in output.lower(), f"Valid enum value should be accepted. Got:\n{output}"
+
+
+# ---------------------------------------------------------------------------
+# FIX 1: set→execute config merge
+# After `use brutus` + `set protocol ssh`, calling `_cmd_run` must pass the
+# set value through to sdk.jobs.add as part of the config_str argument.
+# ---------------------------------------------------------------------------
+
+class _ExecuteHarness(ContextCommands, ToolCommands):
+    """Full harness that uses the REAL _cmd_run (not stubbed) for FIX 1 test."""
+
+    def __init__(self, sdk=None):
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FullFakeContext()
+        self.colors = {
+            "primary": "cyan", "accent": "magenta", "dim": "dim",
+            "info": "blue", "success": "green", "warning": "yellow", "error": "red",
+        }
+
+    def _send_to_marcus(self, message):
+        return ""
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+    def _show_engagement_status(self):
+        pass
+
+    def _cmd_switch(self, args):
+        pass
+
+
+_BRUTUS_FOR_EXECUTE = Capability.from_api({
+    "Name": "brutus",
+    "Title": "Brutus Credential Attacks",
+    "Description": "Credential attacks across 20+ protocols",
+    "Category": ["credential"],
+    "Surface": "network",
+    "Target": ["asset"],
+    "Version": "1.2.3",
+    "Executor": "local",
+    "Parameters": [
+        {
+            "Name": "protocol",
+            "Description": "Target protocol",
+            "Type": "string",
+            "Required": False,
+            "Options": ["ssh", "rdp"],
+        }
+    ],
+})
+
+
+class TestSetConfigReachesExecute:
+    def test_set_value_passed_to_jobs_add(self):
+        """set protocol ssh → execute must pass protocol=ssh in config_str to sdk.jobs.add."""
+        import json as _json
+
+        sdk = MagicMock()
+        sdk.jobs.add.return_value = [{"key": "#job#123"}]
+        h = _ExecuteHarness(sdk=sdk)
+
+        with patch("praetorian_cli.catalog.CapabilityCatalog.get", return_value=_BRUTUS_FOR_EXECUTE), \
+             patch("praetorian_cli.handlers.run.TOOL_ALIASES", {"brutus": {
+                 "capability": "brutus",
+                 "agent": None,
+                 "target_type": "asset",
+                 "description": "Credential attacks",
+                 "default_config": {},
+             }}), \
+             patch("praetorian_cli.handlers.run.resolve_target", return_value=("#asset#target1", None)):
+            h._cmd_use(["brutus"])
+            h._cmd_set(["protocol", "ssh"])
+            # target key must start with '#' so resolve_target short-circuits,
+            # but we patch it to be safe
+            h._cmd_run(["brutus", "#asset#target1"])
+
+        assert sdk.jobs.add.called, "sdk.jobs.add was never called"
+        call_args = sdk.jobs.add.call_args
+        # Third positional arg is config_str (json string or None)
+        config_str = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("config_str")
+        assert config_str is not None, "config_str should not be None when active_tool_config is set"
+        config = _json.loads(config_str)
+        assert config.get("protocol") == "ssh", (
+            f"Expected protocol=ssh in config passed to sdk.jobs.add. Got: {config}"
+        )

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -5,6 +5,7 @@ import pytest
 
 from praetorian_cli.catalog import Capability
 from praetorian_cli.ui.console.commands.tools import ToolCommands
+from praetorian_cli.ui.console.commands.context import ContextCommands
 from praetorian_cli.sdk.test.ui_mocks import MockConsole as _BaseMockConsole
 
 pytestmark = pytest.mark.tui
@@ -45,6 +46,20 @@ SAMPLE_CAPABILITIES = [
         "Executor": "local",
         "Parameters": [
             {"Name": "protocol", "Description": "Target protocol", "Type": "string", "Required": False},
+        ],
+    }),
+    Capability.from_api({
+        "Name": "brutus-with-enum",
+        "Title": "Brutus with enum param",
+        "Description": "Test capability with required param + enum options",
+        "Category": ["credential"],
+        "Surface": "network",
+        "Target": ["asset"],
+        "Version": "1.0.0",
+        "Executor": "local",
+        "Parameters": [
+            {"Name": "protocol", "Description": "svc", "Type": "string", "Required": True,
+             "Options": ["ssh", "rdp"]},
         ],
     }),
     Capability.from_api({
@@ -175,3 +190,166 @@ class TestConsoleModuleNumberedLookup:
         assert first_name in output, (
             f"Expected '{first_name}' in output after 'info 1'. Got:\n{output}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Harness that mixes in both ContextCommands and ToolCommands to test use/set/options
+# ---------------------------------------------------------------------------
+
+class _FullFakeContext:
+    """A richer fake context that includes all fields used by use/options/set."""
+    active_tool = None
+    account = "acct"
+    _last_job_key = ""
+    target = None
+    scope = None
+    mode = "query"
+    verbose = False
+    active_agent = None
+    conversation_id = ""
+    active_tool_config = {}
+
+    def apply_scope_to_message(self, msg):
+        return msg
+
+    def clear_tool(self):
+        self.active_tool = None
+        self.target = None
+        self.active_tool_config = {}
+
+    def clear_conversation(self):
+        pass
+
+
+class _ContextHarness(ContextCommands, ToolCommands):
+    """Harness that covers the Metasploit-style use/options/set commands."""
+
+    def __init__(self, sdk=None):
+        from unittest.mock import MagicMock
+        self.console = MockConsole()
+        self.sdk = sdk or MagicMock()
+        self.context = _FullFakeContext()
+        self.colors = {
+            "primary": "cyan", "accent": "magenta", "dim": "dim",
+            "info": "blue", "success": "green", "warning": "yellow", "error": "red",
+        }
+
+    # Stubs for cross-mixin calls not exercised in these tests
+    def _cmd_run(self, args):
+        pass
+
+    def _cmd_switch(self, args):
+        pass
+
+    def _send_to_marcus(self, message):
+        return ""
+
+    def _wait_for_job(self, *a, **kw):
+        pass
+
+    def _show_engagement_status(self):
+        pass
+
+
+# Use a capability that has a *required* parameter with an enum (Options list)
+_BRUTUS_WITH_ENUM = Capability.from_api({
+    "Name": "brutus",
+    "Title": "Brutus Credential Attacks",
+    "Description": "Credential attacks across 20+ protocols",
+    "Category": ["credential"],
+    "Surface": "network",
+    "Target": ["asset"],
+    "Version": "1.2.3",
+    "Executor": "local",
+    "Parameters": [
+        {
+            "Name": "protocol",
+            "Description": "svc",
+            "Type": "string",
+            "Required": True,
+            "Options": ["ssh", "rdp"],
+        }
+    ],
+})
+
+
+class TestOptionsPopulatedFromLiveParams:
+    def test_options_populated_from_live_params(self):
+        """After 'use brutus', 'options' must render the live capability params."""
+        h = _ContextHarness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.get", return_value=_BRUTUS_WITH_ENUM), \
+             patch("praetorian_cli.handlers.run.TOOL_ALIASES", {"brutus": {
+                 "capability": "brutus",
+                 "agent": None,
+                 "target_type": "asset",
+                 "description": "Credential attacks",
+                 "default_config": {},
+             }}):
+            h._cmd_use(["brutus"])
+            h.console.lines.clear()
+            h._cmd_options([])
+
+        output = "\n".join(h.console.lines)
+        assert "protocol" in output, f"Expected 'protocol' in options output. Got:\n{output}"
+        # Required indicator should appear — 'yes' for required params
+        assert "yes" in output.lower(), f"Expected required indicator in options output. Got:\n{output}"
+
+    def test_set_rejects_unknown_param(self):
+        """After 'use brutus', 'set nonsense x' must print an error containing 'unknown'."""
+        h = _ContextHarness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.get", return_value=_BRUTUS_WITH_ENUM), \
+             patch("praetorian_cli.handlers.run.TOOL_ALIASES", {"brutus": {
+                 "capability": "brutus",
+                 "agent": None,
+                 "target_type": "asset",
+                 "description": "Credential attacks",
+                 "default_config": {},
+             }}):
+            h._cmd_use(["brutus"])
+            h.console.lines.clear()
+            h._cmd_set(["nonsense", "x"])
+
+        output = "\n".join(h.console.lines)
+        assert "unknown" in output.lower(), (
+            f"Expected 'unknown' in error output for invalid param. Got:\n{output}"
+        )
+
+    def test_set_rejects_bad_enum_value(self):
+        """After 'use brutus', 'set protocol telnet' (not in enum) must print an error."""
+        h = _ContextHarness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.get", return_value=_BRUTUS_WITH_ENUM), \
+             patch("praetorian_cli.handlers.run.TOOL_ALIASES", {"brutus": {
+                 "capability": "brutus",
+                 "agent": None,
+                 "target_type": "asset",
+                 "description": "Credential attacks",
+                 "default_config": {},
+             }}):
+            h._cmd_use(["brutus"])
+            h.console.lines.clear()
+            h._cmd_set(["protocol", "telnet"])
+
+        output = "\n".join(h.console.lines)
+        assert any(word in output.lower() for word in ("allowed", "invalid", "ssh", "rdp")), (
+            f"Expected enum error mentioning allowed values. Got:\n{output}"
+        )
+
+    def test_set_accepts_valid_enum_value(self):
+        """After 'use brutus', 'set protocol ssh' must be accepted without error."""
+        h = _ContextHarness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.get", return_value=_BRUTUS_WITH_ENUM), \
+             patch("praetorian_cli.handlers.run.TOOL_ALIASES", {"brutus": {
+                 "capability": "brutus",
+                 "agent": None,
+                 "target_type": "asset",
+                 "description": "Credential attacks",
+                 "default_config": {},
+             }}):
+            h._cmd_use(["brutus"])
+            h.console.lines.clear()
+            h._cmd_set(["protocol", "ssh"])
+
+        output = "\n".join(h.console.lines)
+        # Must NOT contain an error about unknown/invalid
+        assert "unknown" not in output.lower(), f"Valid enum value should be accepted. Got:\n{output}"
+        assert "invalid" not in output.lower(), f"Valid enum value should be accepted. Got:\n{output}"

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -192,6 +192,59 @@ class TestConsoleModuleNumberedLookup:
         )
 
 
+class TestConsoleModuleDispatch:
+    def test_module_sync_prints_count_and_source(self):
+        from praetorian_cli.ui.console.console import GuardConsole
+        h = _Harness()
+        # Borrow the real dispatch + sync handlers onto our harness.
+        h._cmd_module_dispatch = GuardConsole._cmd_module_dispatch.__get__(h)
+        h._cmd_module_options = GuardConsole._cmd_module_options.__get__(h)
+        h._cmd_module_sync = GuardConsole._cmd_module_sync.__get__(h)
+        h._cmd_module_uninstall = GuardConsole._cmd_module_uninstall.__get__(h)
+        with patch("praetorian_cli.catalog.CapabilityCatalog.refresh", return_value=True), \
+             patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES):
+            h._cmd_module_dispatch(["sync"])
+        output = "\n".join(h.console.lines)
+        assert "3" in output  # SAMPLE_CAPABILITIES has 3 entries
+        assert "capabilit" in output.lower()
+
+    def test_module_uninstall_prints_result(self):
+        from praetorian_cli.ui.console.console import GuardConsole
+        h = _Harness()
+        h._cmd_module_dispatch = GuardConsole._cmd_module_dispatch.__get__(h)
+        h._cmd_module_options = GuardConsole._cmd_module_options.__get__(h)
+        h._cmd_module_sync = GuardConsole._cmd_module_sync.__get__(h)
+        h._cmd_module_uninstall = GuardConsole._cmd_module_uninstall.__get__(h)
+        with patch("praetorian_cli.runners.local.uninstall_tool", return_value=False):
+            h._cmd_module_dispatch(["uninstall", "brutus"])
+        output = "\n".join(h.console.lines)
+        assert "not installed" in output.lower() or "removed" in output.lower()
+
+    def test_module_options_renders_parameters(self):
+        from praetorian_cli.ui.console.console import GuardConsole
+        h = _Harness()
+        h._cmd_module_dispatch = GuardConsole._cmd_module_dispatch.__get__(h)
+        h._cmd_module_options = GuardConsole._cmd_module_options.__get__(h)
+        h._cmd_module_sync = GuardConsole._cmd_module_sync.__get__(h)
+        h._cmd_module_uninstall = GuardConsole._cmd_module_uninstall.__get__(h)
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES):
+            h._cmd_module_dispatch(["options", "brutus"])
+        output = "\n".join(h.console.lines)
+        assert "protocol" in output
+
+    def test_module_options_unknown_prints_error(self):
+        from praetorian_cli.ui.console.console import GuardConsole
+        h = _Harness()
+        h._cmd_module_dispatch = GuardConsole._cmd_module_dispatch.__get__(h)
+        h._cmd_module_options = GuardConsole._cmd_module_options.__get__(h)
+        h._cmd_module_sync = GuardConsole._cmd_module_sync.__get__(h)
+        h._cmd_module_uninstall = GuardConsole._cmd_module_uninstall.__get__(h)
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES):
+            h._cmd_module_dispatch(["options", "doesnotexist"])
+        output = "\n".join(h.console.lines)
+        assert "unknown" in output.lower() or "not found" in output.lower()
+
+
 # ---------------------------------------------------------------------------
 # Harness that mixes in both ContextCommands and ToolCommands to test use/set/options
 # ---------------------------------------------------------------------------

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -139,6 +139,7 @@ class TestConsoleSearch:
             h._cmd_module_search(["credential"])
         output = "\n".join(h.console.lines)
         assert "brutus" in output
+        assert "nuclei" not in output
 
 
 class TestConsoleInfo:

--- a/praetorian_cli/sdk/test/ui/test_console_modules.py
+++ b/praetorian_cli/sdk/test/ui/test_console_modules.py
@@ -139,7 +139,21 @@ class TestConsoleSearch:
             h._cmd_module_search(["credential"])
         output = "\n".join(h.console.lines)
         assert "brutus" in output
+        # nuclei is category=scanner, must NOT appear when filtering for "credential"
         assert "nuclei" not in output
+
+    def test_search_scanner_excludes_credential(self):
+        """Searching 'scanner' must include nuclei but exclude brutus."""
+        h = _Harness()
+        with patch("praetorian_cli.catalog.CapabilityCatalog.all", return_value=SAMPLE_CAPABILITIES), \
+             patch("praetorian_cli.runners.local.list_installed", return_value={}), \
+             patch("praetorian_cli.registry.ModuleRegistry.get_version", return_value=None), \
+             patch("praetorian_cli.registry.ModuleRegistry.is_local_only", return_value=False):
+            h._cmd_module_search(["scanner"])
+        output = "\n".join(h.console.lines)
+        assert "nuclei" in output
+        # brutus is category=credential, must NOT appear when filtering for "scanner"
+        assert "brutus" not in output
 
 
 class TestConsoleInfo:

--- a/praetorian_cli/ui/console/commands/context.py
+++ b/praetorian_cli/ui/console/commands/context.py
@@ -6,6 +6,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from praetorian_cli.catalog import CapabilityCatalog
+
 
 class ContextCommands:
     """Context-related console commands. Mixed into GuardConsole."""
@@ -15,6 +17,35 @@ class ContextCommands:
             self.console.print('[dim]Usage: set <account|scope|mode|target> <value>[/dim]')
             return
         key, value = args[0].lower(), ' '.join(args[1:]).strip().rstrip('.')
+
+        # When a capability is selected, validate the key against its live parameters.
+        # Skip validation for built-in context keys (account, scope, mode, target, etc.).
+        _builtin_keys = {'account', 'scope', 'mode', 'target', 'rhost', 'rhosts', 'verbose'}
+        selected_cap = getattr(self, '_selected_cap', None)
+        if selected_cap is not None and key not in _builtin_keys:
+            param_names = {p.name.lower() for p in selected_cap.parameters}
+            if key not in param_names:
+                self.console.print(
+                    f'[{self.colors["error"]}]Unknown option: {key}. '
+                    f'Known parameters: {", ".join(sorted(param_names)) or "(none)"}[/{self.colors["error"]}]'
+                )
+                return
+            # Validate against allowed enum values if the parameter has options.
+            matched_param = next((p for p in selected_cap.parameters if p.name.lower() == key), None)
+            if matched_param and matched_param.options and value not in matched_param.options:
+                allowed = ', '.join(matched_param.options)
+                self.console.print(
+                    f'[{self.colors["error"]}]Invalid value for {key}: "{value}". '
+                    f'Allowed values: {allowed}[/{self.colors["error"]}]'
+                )
+                return
+            # Valid capability param — store in active_tool_config.
+            if not hasattr(self.context, 'active_tool_config') or self.context.active_tool_config is None:
+                self.context.active_tool_config = {}
+            self.context.active_tool_config[key] = value
+            self.console.print(f'[{self.colors["success"]}]{key} => {value}[/{self.colors["success"]}]')
+            return
+
         if key == 'account':
             # Always validate against the real account list
             if not (hasattr(self, '_account_list') and self._account_list):
@@ -302,6 +333,11 @@ class ContextCommands:
             self.context.active_tool_config = dict(alias.get('default_config', {}))
             self.console.print(f'[info]Using {tool_name} -- {alias["description"]}[/info]')
             self.console.print(f'[dim]Target type: {alias["target_type"]}. Use "show targets" to see valid targets.[/dim]')
+            # Resolve live capability for options/set validation (best-effort).
+            try:
+                self._selected_cap = CapabilityCatalog(self.sdk).get(tool_name)
+            except Exception:
+                self._selected_cap = None
             return
 
         # Try resolving as a backend capability name (any of the 141 capabilities)
@@ -322,6 +358,11 @@ class ContextCommands:
                 'target_type': target_type,
                 'description': desc,
             }
+            # Resolve live capability for options/set validation (best-effort).
+            try:
+                self._selected_cap = CapabilityCatalog(self.sdk).get(tool_name)
+            except Exception:
+                self._selected_cap = None
             return
 
         available = ', '.join(sorted(k for k in TOOL_ALIASES if k != 'secrets'))
@@ -350,16 +391,33 @@ class ContextCommands:
         if not self.context.active_tool:
             self.console.print('[dim]No tool selected. Use "use <tool>" first.[/dim]')
             return
-        alias = TOOL_ALIASES[self.context.active_tool]
+        alias = TOOL_ALIASES.get(self.context.active_tool, {})
         table = Table(title=f'Options: {self.context.active_tool}', border_style=self.colors['primary'])
         table.add_column('Name', style=f'bold {self.colors["primary"]}', min_width=15)
         table.add_column('Current Value', min_width=20)
         table.add_column('Required', style=self.colors['accent'])
         table.add_column('Description')
-        table.add_row('TARGET', self.context.target or '', 'yes', f'Target {alias["target_type"]} key')
+
+        target_type = alias.get('target_type', 'asset')
+        table.add_row('TARGET', self.context.target or '', 'yes', f'Target {target_type} key')
+
         config = self.context.active_tool_config or {}
-        for k, v in config.items():
-            table.add_row(k, str(v), 'no', f'Config: {k}')
+
+        # If we have a live capability, render its parameters.
+        selected_cap = getattr(self, '_selected_cap', None)
+        if selected_cap and selected_cap.parameters:
+            for p in selected_cap.parameters:
+                current = config.get(p.name, p.default or '')
+                req = 'yes' if p.required else 'no'
+                desc = p.description or ''
+                if p.options:
+                    desc = f'{desc} [{", ".join(p.options)}]' if desc else f'[{", ".join(p.options)}]'
+                table.add_row(p.name, str(current), req, desc)
+        else:
+            # Fallback: show whatever is in active_tool_config.
+            for k, v in config.items():
+                table.add_row(k, str(v), 'no', f'Config: {k}')
+
         if alias.get('agent'):
             table.add_row('USE_AGENT', 'false', 'no', f'Route through {alias["agent"]} for AI analysis')
         self.console.print(table)
@@ -391,5 +449,6 @@ class ContextCommands:
         if self.context.active_tool:
             self.console.print(f'[dim]Deselected {self.context.active_tool}[/dim]')
             self.context.clear_tool()
+            self._selected_cap = None
         else:
             self.console.print('[dim]Nothing to go back from.[/dim]')

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -151,11 +151,6 @@ class MarcusCommands:
         account is always restored.
         """
         message = self.context.apply_skills_to_message(message)
-    def _post_to_planner(self, message: str):
-        """POST to /planner, handling the 403 retry-as-Praetorian path safely.
-        Returns the parsed JSON dict. Raises on network/HTTP error; the keychain
-        account is always restored.
-        """
         url = self.sdk.url('/planner')
         payload = {'message': message, 'mode': self.context.mode}
         if self.context.conversation_id:
@@ -176,9 +171,6 @@ class MarcusCommands:
                 saved_account = self.sdk.keychain.account
                 try:
                     self.sdk.keychain.account = None
-                    account_context = f'[Context: querying data for account {self.context.account}]'
-                    if not message.startswith(account_context):
-                        message = f'{account_context} {message}'
                     if self.context.account not in message:
                         message = f'[Context: querying data for account {self.context.account}] {message}'
                     payload['message'] = message
@@ -191,7 +183,6 @@ class MarcusCommands:
                             response = self.sdk.chariot_request('POST', url, json=payload)
                         except RequestException as e:
                             raise MarcusError(f'Network error reaching Marcus: {e}')
-                    with self.console.status('Sending via Praetorian account...', spinner='dots', spinner_style=self.colors['primary']):
                 finally:
                     self.sdk.keychain.account = saved_account
 
@@ -203,32 +194,6 @@ class MarcusCommands:
         except (ValueError, json.JSONDecodeError):
             raise MarcusError(
                 f'Unexpected non-JSON response ({response.status_code}): {response.text[:200]}')
-    def _send_to_marcus(self, message: str) -> Optional[str]:
-        """Send message to Marcus and poll for response with live tool output."""
-            result = self._post_to_planner(message)
-        except KeyboardInterrupt:
-            self.console.print('\n[warning]Cancelled — returned to console.[/warning]')
-            return None
-        except MarcusError as e:
-            self.console.print(f'[error]{e}[/error]')
-            return None
-        if not self.context.conversation_id and 'conversation' in result:
-        if isinstance(result, dict) and not self.context.conversation_id and 'conversation' in result:
-            self.context.conversation_id = result['conversation'].get('uuid')
-
-    def _snapshot_last_key(self, conversation_id: Optional[str]) -> str:
-        """Return the highest existing message key for a conversation, or '' if none/unknown."""
-        if not conversation_id:
-            return ''
-        try:
-            existing, _ = self.sdk.search.by_key_prefix(
-                f'#message#{conversation_id}#', user=True
-            )
-            if existing:
-                return max(m.get('key', '') for m in existing)
-        except Exception:
-            pass
-        return ''
 
     def _snapshot_last_key(self, conversation_id: Optional[str]) -> str:
         """Return the highest existing message key for a conversation, or '' if none/unknown."""
@@ -253,19 +218,6 @@ class MarcusCommands:
         pre_conversation_id = self.context.conversation_id
         last_key = self._snapshot_last_key(pre_conversation_id)
 
-        acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
-        self.console.print(f'[dim]Thinking...[/dim]{acct_label}')
-        tool_log = []
-        last_key = ''
-        if self.context.conversation_id:
-            try:
-                existing, _ = self.sdk.search.by_key_prefix(
-                    f'#message#{self.context.conversation_id}#', user=True
-                )
-                if existing:
-                    last_key = max(m.get('key', '') for m in existing)
-            except Exception:
-                pass
         try:
             result = self._post_to_planner(message)
         except KeyboardInterrupt:
@@ -291,8 +243,6 @@ class MarcusCommands:
         tool_log = []
         try:
             for msg in self._stream_messages(self.context.conversation_id, after_key=last_key):
-        pending_tool = None
-            for msg in self._poll_messages(self.context.conversation_id, after_key=last_key):
                 role = msg.get('role', '')
                 content = msg.get('content', '')
                 if role == 'chariot':
@@ -412,7 +362,6 @@ class MarcusCommands:
                     if yielded:
                         raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
                     raise _WSUnavailable(str(e))
-                    pass  # periodic wake to re-check / honor max_wait
                 new = sorted((m for m in messages if isinstance(m, dict) and m.get('key', '') > last_key),
                              key=lambda x: x.get('key', ''))
                 for msg in new:
@@ -445,44 +394,6 @@ class MarcusCommands:
                     raise MarcusError('WebSocket connection lost mid-stream')
                 # else fall through to polling
         yield from self._poll_messages(conversation_id, after_key=after_key)
-            self.console.print(f'\n[warning]{e}[/warning]')
-
-    def _poll_messages(self, conversation_id, after_key='', *, max_wait=180,
-                       sleep=time.sleep, error_threshold=5):
-        """Yield new conversation messages in key order until a 'chariot' reply.
-
-        Pages by after_key (client-side filter). Backs off when idle. Raises
-        MarcusError after `error_threshold` consecutive fetch failures so
-        problems surface instead of hanging.
-        """
-        start = time.time()
-        last_key = after_key
-        delay = 1.0
-        consecutive_errors = 0
-        prefix = f'#message#{conversation_id}#'
-        while time.time() - start < max_wait:
-            try:
-                messages, _ = self.sdk.search.by_key_prefix(prefix, user=True)
-                consecutive_errors = 0
-            except Exception as e:
-                consecutive_errors += 1
-                if consecutive_errors >= error_threshold:
-                    raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
-                sleep(delay)
-                continue
-            new = sorted((m for m in messages if m.get('key', '') > last_key),
-                         key=lambda x: x.get('key', ''))
-            if new:
-                delay = 1.0
-                for msg in new:
-                    last_key = msg.get('key', '')
-                    yield msg
-                    if msg.get('role', '') == 'chariot':
-                        return
-            else:
-                delay = min(delay + 1.0, 3.0)
-            sleep(delay)
-        raise MarcusError('Timed out waiting for response')
 
     def _parse_tool_name(self, content: str, msg: dict = None) -> str:
         """Extract a human-readable tool name from a tool call message."""
@@ -668,29 +579,14 @@ class MarcusCommands:
     def _marcus_do(self, args):
         """Give Marcus a direct instruction to execute."""
         if not args:
-            self.console.print('[dim]Usage: marcus do "<instruction>" [--skill <path>][/dim]')
+            self.console.print('[dim]Usage: marcus do "<instruction>"[/dim]')
             self.console.print('[dim]  Examples:[/dim]')
             self.console.print('[dim]    marcus do "add example.com as a seed and start discovery"[/dim]')
-            self.console.print('[dim]    marcus do "find SQLi" --skill ./skills/sqli.md[/dim]')
+            self.console.print('[dim]    marcus do "run nuclei on all assets with port 443"[/dim]')
+            self.console.print('[dim]    marcus do "generate an executive summary"[/dim]')
             return
 
-        # Parse --skill flags from args
-        remaining = []
-        i = 0
-        while i < len(args):
-            if args[i] == '--skill' and i + 1 < len(args):
-                try:
-                    name = self.context.load_skill(args[i + 1])
-                    self.console.print(f'[dim]Loaded skill: {name}[/dim]')
-                except (FileNotFoundError, ValueError) as e:
-                    self.console.print(f'[error]{e}[/error]')
-                    return
-                i += 2
-            else:
-                remaining.append(args[i])
-                i += 1
-
-        instruction = ' '.join(remaining)
+        instruction = ' '.join(args)
         message = self.context.apply_scope_to_message(instruction)
         response = self._send_to_marcus(message)
         if response:
@@ -789,8 +685,6 @@ class MarcusCommands:
                 self.console.print('[error]Usage: hunt start "<prompt>" [--duration 24h] [--scope #asset#...][/error]')
                 return
 
-            # Pull --duration/--scope flags out of rest before treating the
-            # remainder as the hunt mandate (prompt) text.
             prompt_parts = []
             duration = '24h'
             scope = []

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -543,3 +543,172 @@ class ToolCommands:
                 self.console.print('[dim]No capabilities found.[/dim]')
         except Exception as e:
             self.console.print(f'[error]{e}[/error]')
+
+    def _cmd_module_search(self, args):
+        """Search modules from the registry."""
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import list_installed
+
+        reg = get_registry()
+        query = args[0] if args else ''
+        category = ''
+        if '--category' in args:
+            idx = args.index('--category')
+            if idx + 1 < len(args):
+                category = args[idx + 1]
+                query = args[0] if args[0] != '--category' else ''
+
+        results = reg.search_modules(query, category=category)
+        installed = list_installed()
+
+        if not results:
+            self.console.print('[dim]No modules match the query.[/dim]')
+            return
+
+        table = Table(title=f'Modules ({len(results)})', border_style=self.colors['primary'])
+        table.add_column('#', style=self.colors['dim'], width=4)
+        table.add_column('Name', style=f'bold {self.colors["primary"]}', min_width=16)
+        table.add_column('Category', style=self.colors['accent'])
+        table.add_column('Installed', min_width=10)
+        table.add_column('Description')
+
+        self._module_list = []
+        for i, r in enumerate(results, 1):
+            name = r['name']
+            ver = reg.get_version(name)
+            if name in installed:
+                status = f'[success]{ver["version"]}[/success]' if ver else '[success]yes[/success]'
+            else:
+                status = '[dim]—[/dim]'
+            desc = r.get('description', '')
+            if len(desc) > 50:
+                desc = desc[:49] + '…'
+            table.add_row(str(i), name, r.get('category', ''), status, desc)
+            self._module_list.append(name)
+
+        self.console.print(table)
+        self.console.print(f'\n[dim]Use "info <name>" for details or "install <name>" to install.[/dim]')
+
+    def _cmd_module_info(self, args):
+        """Show full details for a module."""
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import is_installed, get_binary_path
+
+        if not args:
+            self.console.print('[dim]Usage: info <module_name>[/dim]')
+            return
+
+        name = args[0].lower()
+        reg = get_registry()
+        mod = reg.get_module(name)
+        if not mod:
+            self.console.print(f'[error]Unknown module: {name}. Use "search" to find modules.[/error]')
+            return
+
+        ver_info = reg.get_version(name)
+        installed_str = 'not installed'
+        if is_installed(name):
+            path = get_binary_path(name)
+            ver = ver_info['version'] if ver_info else 'unknown'
+            installed_str = f'{ver} ({path})'
+
+        info_text = Text()
+        info_text.append(f'Name:        ', style=self.colors['dim'])
+        info_text.append(f'{name}\n', style=f'bold {self.colors["primary"]}')
+        info_text.append(f'Category:    ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("category", "")}\n', style=self.colors['accent'])
+        info_text.append(f'Author:      ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("author", "")}\n')
+        info_text.append(f'Repository:  ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("repo", "")}\n')
+        info_text.append(f'Installed:   ', style=self.colors['dim'])
+        info_text.append(f'{installed_str}\n')
+        info_text.append(f'Target:      ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("target_type", "asset")}\n')
+        info_text.append(f'Description: ', style=self.colors['dim'])
+        info_text.append(f'{mod.get("description", "")}\n')
+
+        tags = mod.get('tags', [])
+        if tags:
+            info_text.append(f'Tags:        ', style=self.colors['dim'])
+            info_text.append(f'{", ".join(tags)}\n')
+
+        self.console.print(Panel(info_text, title=f'Module: {name}', border_style=self.colors['primary']))
+
+        options = mod.get('options', {})
+        if options:
+            opt_table = Table(title='Options', border_style=self.colors['dim'])
+            opt_table.add_column('Option', style=f'bold {self.colors["primary"]}')
+            opt_table.add_column('Type', style=self.colors['accent'])
+            opt_table.add_column('Required')
+            opt_table.add_column('Description')
+            for opt_name, opt_info in options.items():
+                opt_table.add_row(
+                    f'--{opt_name}',
+                    opt_info.get('type', 'string'),
+                    'yes' if opt_info.get('required') else 'no',
+                    opt_info.get('description', ''),
+                )
+            self.console.print(opt_table)
+
+    def _cmd_module_update(self, args):
+        """Update installed modules to latest release."""
+        import subprocess
+        from praetorian_cli.registry import get_registry
+        from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
+
+        if '--registry' in args:
+            reg = get_registry()
+            refreshed = reg.refresh(force=True)
+            self.console.print(
+                '[success]Registry refreshed.[/success]' if refreshed
+                else '[warning]Registry refresh failed (using cached).[/warning]'
+            )
+            return
+
+        reg = get_registry()
+        name = args[0].lower() if args else 'all'
+        tools = sorted(INSTALLABLE_TOOLS) if name == 'all' else [name]
+
+        updated = 0
+        for tool_name in tools:
+            if not is_installed(tool_name):
+                if name != 'all':
+                    self.console.print(f'[dim]{tool_name}: not installed[/dim]')
+                continue
+
+            mod = reg.get_module(tool_name)
+            if not mod:
+                continue
+
+            current = reg.get_version(tool_name)
+            current_ver = current['version'] if current else 'unknown'
+
+            try:
+                ver_result = subprocess.run(
+                    ['gh', 'release', 'view', '--repo', mod['repo'],
+                     '--json', 'tagName', '-q', '.tagName'],
+                    capture_output=True, text=True, timeout=15,
+                )
+                latest = ver_result.stdout.strip() if ver_result.returncode == 0 else None
+            except Exception:
+                latest = None
+
+            if not latest:
+                self.console.print(f'[warning]{tool_name}: could not check latest version[/warning]')
+                continue
+
+            if latest == current_ver:
+                if name != 'all':
+                    self.console.print(f'[dim]{tool_name}: up to date ({current_ver})[/dim]')
+                continue
+
+            try:
+                install_tool(tool_name, force=True)
+                self.console.print(f'[success]{tool_name}: {current_ver} → {latest}[/success]')
+                updated += 1
+            except Exception as e:
+                self.console.print(f'[error]{tool_name}: {e}[/error]')
+
+        if name == 'all':
+            self.console.print(f'[dim]{updated} module(s) updated.[/dim]')

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -121,6 +121,7 @@ class ToolCommands:
 
         capability = alias.get('capability')
         config = dict(alias.get('default_config', {}))
+        config.update(getattr(self.context, 'active_tool_config', {}) or {})
 
         if alias.get('agent') and (use_agent or not capability):
             agent_name = alias['agent']

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -635,13 +635,13 @@ class ToolCommands:
                 args = [mods[idx]] + list(args[1:])
 
         name = args[0].lower()
+        reg = get_registry()
         cat = CapabilityCatalog(self.sdk)
-        cap = cat.get(name)
+        cap = cat.get(name) or cat.get(reg.get_capability_name(name))
         if not cap:
             self.console.print(f'[error]Unknown module: {name}. Use "search" to find modules.[/error]')
             return
 
-        reg = get_registry()
         ver_info = reg.get_version(name)
         installed_str = 'not installed'
         if is_installed(name):

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -545,21 +545,42 @@ class ToolCommands:
             self.console.print(f'[error]{e}[/error]')
 
     def _cmd_module_search(self, args):
-        """Search modules from the registry."""
+        """Search modules from the capability catalog."""
+        from praetorian_cli.catalog import CapabilityCatalog
         from praetorian_cli.registry import get_registry
         from praetorian_cli.runners.local import list_installed
 
-        reg = get_registry()
-        query = args[0] if args else ''
+        query = ''
         category = ''
-        if '--category' in args:
-            idx = args.index('--category')
-            if idx + 1 < len(args):
-                category = args[idx + 1]
-                query = args[0] if args[0] != '--category' else ''
+        surface = ''
+        target = ''
+        tag = ''
 
-        results = reg.search_modules(query, category=category)
+        i = 0
+        while i < len(args):
+            a = args[i]
+            if a == '--category' and i + 1 < len(args):
+                category = args[i + 1]
+                i += 2
+            elif a == '--surface' and i + 1 < len(args):
+                surface = args[i + 1]
+                i += 2
+            elif a == '--target' and i + 1 < len(args):
+                target = args[i + 1]
+                i += 2
+            elif a == '--tag' and i + 1 < len(args):
+                tag = args[i + 1]
+                i += 2
+            elif not a.startswith('--'):
+                query = a
+                i += 1
+            else:
+                i += 1
+
+        cat = CapabilityCatalog(self.sdk)
+        results = cat.search(query, category=category, surface=surface, target=target, tag=tag)
         installed = list_installed()
+        reg = get_registry()
 
         if not results:
             self.console.print('[dim]No modules match the query.[/dim]')
@@ -569,87 +590,112 @@ class ToolCommands:
         table.add_column('#', style=self.colors['dim'], width=4)
         table.add_column('Name', style=f'bold {self.colors["primary"]}', min_width=16)
         table.add_column('Category', style=self.colors['accent'])
+        table.add_column('Surface', style=self.colors['dim'], min_width=8)
         table.add_column('Installed', min_width=10)
         table.add_column('Description')
 
         self._module_list = []
-        for i, r in enumerate(results, 1):
-            name = r['name']
+        for n, cap in enumerate(results, 1):
+            name = cap.name
             ver = reg.get_version(name)
+            local_only = reg.is_local_only(name)
             if name in installed:
-                status = f'[success]{ver["version"]}[/success]' if ver else '[success]yes[/success]'
+                ver_str = ver['version'] if ver else 'yes'
+                status = f'[success]{ver_str}[/success]'
             else:
                 status = '[dim]—[/dim]'
-            desc = r.get('description', '')
+            if local_only:
+                status += ' [dim][local-only][/dim]'
+            category_str = ', '.join(cap.category) if cap.category else ''
+            desc = cap.description or ''
             if len(desc) > 50:
                 desc = desc[:49] + '…'
-            table.add_row(str(i), name, r.get('category', ''), status, desc)
+            table.add_row(str(n), name, category_str, cap.surface or '', status, desc)
             self._module_list.append(name)
 
         self.console.print(table)
         self.console.print(f'\n[dim]Use "info <name>" for details or "install <name>" to install.[/dim]')
 
     def _cmd_module_info(self, args):
-        """Show full details for a module."""
+        """Show full details for a module (by name or prior-search result number)."""
+        from praetorian_cli.catalog import CapabilityCatalog
         from praetorian_cli.registry import get_registry
         from praetorian_cli.runners.local import is_installed, get_binary_path
 
         if not args:
-            self.console.print('[dim]Usage: info <module_name>[/dim]')
+            self.console.print('[dim]Usage: info <module_name|#>[/dim]')
             return
 
+        # Resolve numeric argument to a stored search result name.
+        if args[0].isdigit():
+            idx = int(args[0]) - 1
+            mods = getattr(self, '_module_list', [])
+            if 0 <= idx < len(mods):
+                args = [mods[idx]] + list(args[1:])
+
         name = args[0].lower()
-        reg = get_registry()
-        mod = reg.get_module(name)
-        if not mod:
+        cat = CapabilityCatalog(self.sdk)
+        cap = cat.get(name)
+        if not cap:
             self.console.print(f'[error]Unknown module: {name}. Use "search" to find modules.[/error]')
             return
 
+        reg = get_registry()
         ver_info = reg.get_version(name)
         installed_str = 'not installed'
         if is_installed(name):
-            path = get_binary_path(name)
+            try:
+                path = get_binary_path(name)
+            except Exception:
+                path = ''
             ver = ver_info['version'] if ver_info else 'unknown'
-            installed_str = f'{ver} ({path})'
+            installed_str = f'{ver} ({path})' if path else ver
+
+        category_str = ', '.join(cap.category) if cap.category else ''
+        target_str = ', '.join(cap.target) if cap.target else ''
 
         info_text = Text()
         info_text.append(f'Name:        ', style=self.colors['dim'])
-        info_text.append(f'{name}\n', style=f'bold {self.colors["primary"]}')
+        info_text.append(f'{cap.name}\n', style=f'bold {self.colors["primary"]}')
+        info_text.append(f'Title:       ', style=self.colors['dim'])
+        info_text.append(f'{cap.title}\n')
         info_text.append(f'Category:    ', style=self.colors['dim'])
-        info_text.append(f'{mod.get("category", "")}\n', style=self.colors['accent'])
-        info_text.append(f'Author:      ', style=self.colors['dim'])
-        info_text.append(f'{mod.get("author", "")}\n')
-        info_text.append(f'Repository:  ', style=self.colors['dim'])
-        info_text.append(f'{mod.get("repo", "")}\n')
+        info_text.append(f'{category_str}\n', style=self.colors['accent'])
+        info_text.append(f'Surface:     ', style=self.colors['dim'])
+        info_text.append(f'{cap.surface}\n')
+        info_text.append(f'Target:      ', style=self.colors['dim'])
+        info_text.append(f'{target_str}\n')
+        info_text.append(f'Version:     ', style=self.colors['dim'])
+        info_text.append(f'{cap.version}\n')
+        info_text.append(f'Executor:    ', style=self.colors['dim'])
+        info_text.append(f'{cap.executor}\n')
         info_text.append(f'Installed:   ', style=self.colors['dim'])
         info_text.append(f'{installed_str}\n')
-        info_text.append(f'Target:      ', style=self.colors['dim'])
-        info_text.append(f'{mod.get("target_type", "asset")}\n')
         info_text.append(f'Description: ', style=self.colors['dim'])
-        info_text.append(f'{mod.get("description", "")}\n')
+        info_text.append(f'{cap.description}\n')
 
-        tags = mod.get('tags', [])
-        if tags:
-            info_text.append(f'Tags:        ', style=self.colors['dim'])
-            info_text.append(f'{", ".join(tags)}\n')
+        if reg.is_local_only(name):
+            info_text.append(f'[local-only] This capability runs exclusively as a local binary.\n',
+                             style=self.colors['dim'])
 
-        self.console.print(Panel(info_text, title=f'Module: {name}', border_style=self.colors['primary']))
+        self.console.print(Panel(info_text, title=f'Module: {cap.name}', border_style=self.colors['primary']))
 
-        options = mod.get('options', {})
-        if options:
-            opt_table = Table(title='Options', border_style=self.colors['dim'])
-            opt_table.add_column('Option', style=f'bold {self.colors["primary"]}')
-            opt_table.add_column('Type', style=self.colors['accent'])
-            opt_table.add_column('Required')
-            opt_table.add_column('Description')
-            for opt_name, opt_info in options.items():
-                opt_table.add_row(
-                    f'--{opt_name}',
-                    opt_info.get('type', 'string'),
-                    'yes' if opt_info.get('required') else 'no',
-                    opt_info.get('description', ''),
+        if cap.parameters:
+            param_table = Table(title='Parameters', border_style=self.colors['dim'])
+            param_table.add_column('Parameter', style=f'bold {self.colors["primary"]}')
+            param_table.add_column('Type', style=self.colors['accent'])
+            param_table.add_column('Required')
+            param_table.add_column('Default')
+            param_table.add_column('Description')
+            for p in cap.parameters:
+                param_table.add_row(
+                    f'--{p.name}',
+                    p.type,
+                    'yes' if p.required else 'no',
+                    p.default or '',
+                    p.description,
                 )
-            self.console.print(opt_table)
+            self.console.print(param_table)
 
     def _cmd_module_update(self, args):
         """Update installed modules to latest release."""

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -22,7 +22,7 @@ class ToolCommands:
         capabilities = args[1:] if len(args) > 1 else []
         try:
             result = self.sdk.jobs.add(asset_key, capabilities=capabilities)
-            self.console.print(f'[success]Job queued[/success]')
+            self.console.print('[success]Job queued[/success]')
             self.console.print_json(json.dumps(result, indent=2))
         except Exception as e:
             self.console.print(f'[error]{e}[/error]')
@@ -161,7 +161,7 @@ class ToolCommands:
                 table2.add_row(name, info['target_type'], info['description'])
             self.console.print(table2)
 
-        self.console.print(f'\n[dim]Usage: use <name> or <name> <target_key>[/dim]')
+        self.console.print('\n[dim]Usage: use <name> or <name> <target_key>[/dim]')
 
     def _print_tool_help(self, tool_name):
         """Run `<tool> --help` locally and stream its output to the console."""
@@ -290,7 +290,7 @@ class ToolCommands:
         self.context._last_job_key = job_key
         self.console.print(f'[success]Job queued: {capability} -> {target_key}[/success]')
         self.console.print(f'[dim]Job key: {job_key}[/dim]')
-        self.console.print(f'[dim]Use "status" to check progress, or "run --wait" to wait for results.[/dim]')
+        self.console.print('[dim]Use "status" to check progress, or "run --wait" to wait for results.[/dim]')
         return result
 
     def _wait_for_job(self, target_key, capability):
@@ -311,7 +311,7 @@ class ToolCommands:
                             self._render_job_results(latest, capability)
                             return
                         elif st.startswith('JF'):
-                            self.console.print(f'\n[error]Job failed.[/error]')
+                            self.console.print('\n[error]Job failed.[/error]')
                             self._render_job_results(latest, capability)
                             return
                         else:
@@ -360,7 +360,7 @@ class ToolCommands:
             status_text = Text()
             status_text.append(f'{cap}', style=f'bold {self.colors["primary"]}')
             status_text.append(f' -> {dns}\n', style='white')
-            status_text.append(f'Status: ', style=self.colors['dim'])
+            status_text.append('Status: ', style=self.colors['dim'])
             status_text.append(f'{status_label}\n', style=f'bold {color}')
             status_text.append(f'Created:  {created}\n', style=self.colors['dim'])
             status_text.append(f'Started:  {started}\n', style=self.colors['dim'])
@@ -500,9 +500,9 @@ class ToolCommands:
         table.add_column('Path', style=self.colors['dim'])
         for name in sorted(INSTALLABLE_TOOLS):
             if name in inst:
-                table.add_row(name, f'[success]installed[/success]', inst[name])
+                table.add_row(name, '[success]installed[/success]', inst[name])
             else:
-                table.add_row(name, f'[dim]---[/dim]', '')
+                table.add_row(name, '[dim]---[/dim]', '')
         self.console.print(table)
 
     def _cmd_capabilities(self, args):
@@ -539,7 +539,7 @@ class ToolCommands:
                         table.add_row(str(i), name, str(target), executor, desc)
                         self._capability_list.append(name)
                 self.console.print(table)
-                self.console.print(f'\n[dim]Use "use <#>" or "use <name>" to select a capability.[/dim]')
+                self.console.print('\n[dim]Use "use <#>" or "use <name>" to select a capability.[/dim]')
             else:
                 self.console.print('[dim]No capabilities found.[/dim]')
         except Exception as e:
@@ -615,7 +615,7 @@ class ToolCommands:
             self._module_list.append(name)
 
         self.console.print(table)
-        self.console.print(f'\n[dim]Use "info <name>" for details or "install <name>" to install.[/dim]')
+        self.console.print('\n[dim]Use "info <name>" for details or "install <name>" to install.[/dim]')
 
     def _cmd_module_info(self, args):
         """Show full details for a module (by name or prior-search result number)."""
@@ -656,27 +656,27 @@ class ToolCommands:
         target_str = ', '.join(cap.target) if cap.target else ''
 
         info_text = Text()
-        info_text.append(f'Name:        ', style=self.colors['dim'])
+        info_text.append('Name:        ', style=self.colors['dim'])
         info_text.append(f'{cap.name}\n', style=f'bold {self.colors["primary"]}')
-        info_text.append(f'Title:       ', style=self.colors['dim'])
+        info_text.append('Title:       ', style=self.colors['dim'])
         info_text.append(f'{cap.title}\n')
-        info_text.append(f'Category:    ', style=self.colors['dim'])
+        info_text.append('Category:    ', style=self.colors['dim'])
         info_text.append(f'{category_str}\n', style=self.colors['accent'])
-        info_text.append(f'Surface:     ', style=self.colors['dim'])
+        info_text.append('Surface:     ', style=self.colors['dim'])
         info_text.append(f'{cap.surface}\n')
-        info_text.append(f'Target:      ', style=self.colors['dim'])
+        info_text.append('Target:      ', style=self.colors['dim'])
         info_text.append(f'{target_str}\n')
-        info_text.append(f'Version:     ', style=self.colors['dim'])
+        info_text.append('Version:     ', style=self.colors['dim'])
         info_text.append(f'{cap.version}\n')
-        info_text.append(f'Executor:    ', style=self.colors['dim'])
+        info_text.append('Executor:    ', style=self.colors['dim'])
         info_text.append(f'{cap.executor}\n')
-        info_text.append(f'Installed:   ', style=self.colors['dim'])
+        info_text.append('Installed:   ', style=self.colors['dim'])
         info_text.append(f'{installed_str}\n')
-        info_text.append(f'Description: ', style=self.colors['dim'])
+        info_text.append('Description: ', style=self.colors['dim'])
         info_text.append(f'{cap.description}\n')
 
         if reg.is_local_only(name):
-            info_text.append(f'[local-only] This capability runs exclusively as a local binary.\n',
+            info_text.append('[local-only] This capability runs exclusively as a local binary.\n',
                              style=self.colors['dim'])
 
         self.console.print(Panel(info_text, title=f'Module: {cap.name}', border_style=self.colors['primary']))
@@ -700,6 +700,7 @@ class ToolCommands:
 
     def _cmd_module_update(self, args):
         """Update installed modules to latest release."""
+        import shutil
         import subprocess
         from praetorian_cli.registry import get_registry
         from praetorian_cli.runners.local import install_tool, is_installed, INSTALLABLE_TOOLS
@@ -711,6 +712,11 @@ class ToolCommands:
                 '[success]Registry refreshed.[/success]' if refreshed
                 else '[warning]Registry refresh failed (using cached).[/warning]'
             )
+            return
+
+        gh_path = shutil.which('gh')
+        if not gh_path:
+            self.console.print('[warning]gh CLI not found. Install GitHub CLI: https://cli.github.com/[/warning]')
             return
 
         reg = get_registry()
@@ -733,7 +739,7 @@ class ToolCommands:
 
             try:
                 ver_result = subprocess.run(
-                    ['gh', 'release', 'view', '--repo', mod['repo'],
+                    [gh_path, 'release', 'view', '--repo', mod['repo'],
                      '--json', 'tagName', '-q', '.tagName'],
                     capture_output=True, text=True, timeout=15,
                 )

--- a/praetorian_cli/ui/console/commands/tools.py
+++ b/praetorian_cli/ui/console/commands/tools.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import time
 
 from rich.markdown import Markdown
@@ -9,6 +10,8 @@ from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
+
+_REPO_RE = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
 
 
 class ToolCommands:
@@ -579,7 +582,13 @@ class ToolCommands:
                 i += 1
 
         cat = CapabilityCatalog(self.sdk)
-        results = cat.search(query, category=category, surface=surface, target=target, tag=tag)
+        results = cat.search(
+            query,
+            category=category.lower() if category else category,
+            surface=surface.lower() if surface else surface,
+            target=target.lower() if target else target,
+            tag=tag.lower() if tag else tag,
+        )
         installed = list_installed()
         reg = get_registry()
 
@@ -734,12 +743,17 @@ class ToolCommands:
             if not mod:
                 continue
 
+            repo = mod.get('repo', '')
+            if not _REPO_RE.match(repo):
+                self.console.print(f'[warning]{tool_name}: invalid repo format in registry[/warning]')
+                continue
+
             current = reg.get_version(tool_name)
             current_ver = current['version'] if current else 'unknown'
 
             try:
                 ver_result = subprocess.run(
-                    [gh_path, 'release', 'view', '--repo', mod['repo'],
+                    [gh_path, 'release', 'view', '--repo', repo,
                      '--json', 'tagName', '-q', '.tagName'],
                     capture_output=True, text=True, timeout=15,
                 )

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -6,7 +6,7 @@ import shlex
 from typing import Optional
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.completion import WordCompleter, NestedCompleter
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
 
@@ -77,8 +77,43 @@ class GuardConsole(
 
         self.session = PromptSession(
             history=FileHistory(history_path),
-            completer=WordCompleter(CONSOLE_COMMANDS, ignore_case=True),
+            completer=self._build_completer(),
         )
+
+    def _build_completer(self):
+        """Build a NestedCompleter with live module names; fall back to WordCompleter."""
+        try:
+            from praetorian_cli.catalog import CapabilityCatalog
+            caps = CapabilityCatalog(self.sdk).all()
+            module_names = {c.name: None for c in caps} if caps else {}
+
+            # module subcommands
+            module_sub = {
+                'search': None,
+                'info': module_names or None,
+                'options': None,
+                'install': module_names or None,
+                'uninstall': module_names or None,
+                'update': module_names or None,
+                'sync': None,
+                'list': None,
+                'installed': None,
+            }
+
+            # Build top-level nested dict from CONSOLE_COMMANDS (top-level → None)
+            # plus richer sub-completions for a few commands.
+            top: dict = {cmd: None for cmd in CONSOLE_COMMANDS}
+            top['module'] = module_sub
+            top['use'] = module_names or None
+            top['info'] = module_names or None
+            top['install'] = module_names or None
+            top['uninstall'] = module_names or None
+
+            return NestedCompleter.from_nested_dict(top)
+        except Exception:
+            # Any failure (SDK not authenticated yet, network error, etc.) —
+            # degrade gracefully to flat WordCompleter.
+            return WordCompleter(CONSOLE_COMMANDS, ignore_case=True)
 
     def run(self):
         """Main console loop."""

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -39,6 +39,7 @@ CONSOLE_COMMANDS = [
     'search', 'find', 'assets', 'risks', 'jobs', 'info',
     'next', 'n', 'prev', 'p', 'page',
     'scan', 'tag',
+    'update', 'module',
     'run', 'status', 'download', 'install', 'installed',
     'asset-analyzer', 'brutus', 'julius', 'augustus', 'aurelius',
     'trajan', 'cato', 'priscus', 'seneca', 'titus',
@@ -219,6 +220,8 @@ class GuardConsole(
             'download': self._cmd_download,
             'install': self._cmd_install,
             'installed': self._cmd_installed,
+            'update': self._cmd_module_update,
+            'module': self._cmd_module_dispatch,
             'capabilities': self._cmd_capabilities,
             'evidence': self._cmd_evidence,
             'report': self._cmd_report,
@@ -356,6 +359,10 @@ class GuardConsole(
         help_table.add_row('capabilities [name]', 'List all backend capabilities')
         help_table.add_row('install <tool|all>', 'Install binary from GitHub')
         help_table.add_row('installed', 'List locally installed binaries')
+        help_table.add_row('update [module|all]', 'Update installed modules to latest')
+        help_table.add_row('module search [query]', 'Search module registry (name, category, tag)')
+        help_table.add_row('module info <name>', 'Show module details (options, version, author)')
+        help_table.add_row('module update [name|all]', 'Update installed modules to latest')
 
         help_table.add_row('', '')
         help_table.add_row('[section]Evidence & Reports[/section]', '')
@@ -443,6 +450,28 @@ class GuardConsole(
 
     def _cmd_quit(self, args):
         raise EOFError()
+
+    def _cmd_module_dispatch(self, args):
+        """Route 'module <subcommand>' to the right handler."""
+        if not args:
+            self._cmd_module_search([])
+            return
+        sub = args[0].lower()
+        rest = args[1:]
+        routes = {
+            'search': self._cmd_module_search,
+            'info': self._cmd_module_info,
+            'update': self._cmd_module_update,
+            'install': self._cmd_install,
+            'installed': self._cmd_installed,
+            'options': self._cmd_options,
+            'list': self._cmd_module_search,
+        }
+        handler = routes.get(sub)
+        if handler:
+            handler(rest)
+        else:
+            self.console.print(f'[dim]Unknown: module {sub}. Try: search, info, install, installed, update, options[/dim]')
 
 
 def run_console(sdk: Chariot, account: Optional[str] = None):

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -499,14 +499,74 @@ class GuardConsole(
             'update': self._cmd_module_update,
             'install': self._cmd_install,
             'installed': self._cmd_installed,
-            'options': self._cmd_options,
+            'uninstall': self._cmd_module_uninstall,
+            'sync': self._cmd_module_sync,
+            'options': self._cmd_module_options,
             'list': self._cmd_module_search,
         }
         handler = routes.get(sub)
         if handler:
             handler(rest)
         else:
-            self.console.print(f'[dim]Unknown: module {sub}. Try: search, info, install, installed, update, options[/dim]')
+            self.console.print(
+                f'[dim]Unknown: module {sub}. '
+                f'Try: search, info, install, uninstall, installed, update, sync, options[/dim]'
+            )
+
+    def _cmd_module_uninstall(self, args):
+        """Remove an installed module binary."""
+        from praetorian_cli.runners.local import uninstall_tool
+        if not args:
+            self.console.print('[dim]Usage: module uninstall <name>[/dim]')
+            return
+        name = args[0].lower()
+        removed = uninstall_tool(name)
+        if removed:
+            self.console.print(f'[success]{name}: removed[/success]')
+        else:
+            self.console.print(f'[dim]{name}: not installed[/dim]')
+
+    def _cmd_module_sync(self, args):
+        """Force-refresh the capability catalog from the backend."""
+        from praetorian_cli.catalog import CapabilityCatalog
+        cat = CapabilityCatalog(self.sdk)
+        ok = cat.refresh(force=True)
+        n = len(cat.all())
+        verb = 'refreshed' if ok else 'unchanged'
+        self.console.print(f'[success]Catalog {verb}: {n} capabilities ({cat.source}).[/success]')
+
+    def _cmd_module_options(self, args):
+        """Show the configurable parameters for a module (no active tool required)."""
+        from praetorian_cli.catalog import CapabilityCatalog
+        from praetorian_cli.registry import get_registry
+        if not args:
+            self.console.print('[dim]Usage: module options <name>[/dim]')
+            return
+        name = args[0].lower()
+        reg = get_registry()
+        cat = CapabilityCatalog(self.sdk)
+        cap = cat.get(name) or cat.get(reg.get_capability_name(name))
+        if not cap:
+            self.console.print(f'[error]Unknown module: {name}. Use "module search" to find modules.[/error]')
+            return
+        if not cap.parameters:
+            self.console.print(f'[dim]{cap.name}: no configurable options.[/dim]')
+            return
+        param_table = Table(title=f'{cap.name} options', border_style=self.colors['dim'])
+        param_table.add_column('Parameter', style=f'bold {self.colors["primary"]}')
+        param_table.add_column('Type', style=self.colors['accent'])
+        param_table.add_column('Required')
+        param_table.add_column('Default')
+        param_table.add_column('Description')
+        for p in cap.parameters:
+            desc = p.description or ''
+            if p.options:
+                desc = f"{desc} [{', '.join(p.options)}]".strip()
+            param_table.add_row(
+                f'--{p.name}', p.type, 'yes' if p.required else 'no',
+                p.default or '', desc,
+            )
+        self.console.print(param_table)
 
 
 def run_console(sdk: Chariot, account: Optional[str] = None):

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -81,10 +81,9 @@ class GuardConsole(
 
         self.session = PromptSession(
             history=FileHistory(history_path),
-            completer=WordCompleter(CONSOLE_COMMANDS, ignore_case=True),
+            completer=self._build_completer(),
             complete_style=CompleteStyle.MULTI_COLUMN,
             reserve_space_for_menu=3,
-            completer=self._build_completer(),
         )
 
     def _build_completer(self):

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -42,6 +42,7 @@ CONSOLE_COMMANDS = [
     'search', 'find', 'assets', 'risks', 'jobs', 'info',
     'next', 'n', 'prev', 'p', 'page',
     'scan', 'tag',
+    'update', 'module',
     'run', 'status', 'download', 'install', 'installed',
     'asset-analyzer', 'brutus', 'julius', 'augustus', 'aurelius',
     'trajan', 'cato', 'priscus', 'seneca', 'titus',
@@ -225,6 +226,8 @@ class GuardConsole(
             'download': self._cmd_download,
             'install': self._cmd_install,
             'installed': self._cmd_installed,
+            'update': self._cmd_module_update,
+            'module': self._cmd_module_dispatch,
             'capabilities': self._cmd_capabilities,
             'evidence': self._cmd_evidence,
             'report': self._cmd_report,
@@ -431,6 +434,10 @@ class GuardConsole(
         help_table.add_row('capabilities [name]', 'List all backend capabilities')
         help_table.add_row('install <tool|all>', 'Install binary from GitHub')
         help_table.add_row('installed', 'List locally installed binaries')
+        help_table.add_row('update [module|all]', 'Update installed modules to latest')
+        help_table.add_row('module search [query]', 'Search module registry (name, category, tag)')
+        help_table.add_row('module info <name>', 'Show module details (options, version, author)')
+        help_table.add_row('module update [name|all]', 'Update installed modules to latest')
 
         help_table.add_row('', '')
         help_table.add_row('[section]Evidence & Reports[/section]', '')
@@ -544,6 +551,28 @@ class GuardConsole(
 
     def _cmd_quit(self, args):
         raise EOFError()
+
+    def _cmd_module_dispatch(self, args):
+        """Route 'module <subcommand>' to the right handler."""
+        if not args:
+            self._cmd_module_search([])
+            return
+        sub = args[0].lower()
+        rest = args[1:]
+        routes = {
+            'search': self._cmd_module_search,
+            'info': self._cmd_module_info,
+            'update': self._cmd_module_update,
+            'install': self._cmd_install,
+            'installed': self._cmd_installed,
+            'options': self._cmd_options,
+            'list': self._cmd_module_search,
+        }
+        handler = routes.get(sub)
+        if handler:
+            handler(rest)
+        else:
+            self.console.print(f'[dim]Unknown: module {sub}. Try: search, info, install, installed, update, options[/dim]')
 
 
 def run_console(sdk: Chariot, account: Optional[str] = None):

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -469,10 +469,11 @@ class GuardConsole(
         help_table.add_row('capabilities [name]', 'List all backend capabilities')
         help_table.add_row('install <tool|all>', 'Install binary from GitHub')
         help_table.add_row('installed', 'List locally installed binaries')
-        help_table.add_row('update [module|all]', 'Update installed modules to latest')
+        help_table.add_row('update [<name>|all]', 'Update installed module(s) to latest')
         help_table.add_row('module search [query]', 'Search module registry (name, category, tag)')
         help_table.add_row('module info <name>', 'Show module details (options, version, author)')
-        help_table.add_row('module update [name|all]', 'Update installed modules to latest')
+        help_table.add_row('module options <name>', 'Show configurable parameters for a module')
+        help_table.add_row('module update [<name>|all]', 'Update installed module(s) to latest')
 
         help_table.add_row('', '')
         help_table.add_row('[section]Evidence & Reports[/section]', '')
@@ -621,7 +622,11 @@ class GuardConsole(
             self.console.print('[dim]Usage: module uninstall <name>[/dim]')
             return
         name = args[0].lower()
-        removed = uninstall_tool(name)
+        try:
+            removed = uninstall_tool(name)
+        except (OSError, ValueError) as e:
+            self.console.print(f'[error]Failed to remove {name}: {e}[/error]')
+            return
         if removed:
             self.console.print(f'[success]{name}: removed[/success]')
         else:

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -601,14 +601,74 @@ class GuardConsole(
             'update': self._cmd_module_update,
             'install': self._cmd_install,
             'installed': self._cmd_installed,
-            'options': self._cmd_options,
+            'uninstall': self._cmd_module_uninstall,
+            'sync': self._cmd_module_sync,
+            'options': self._cmd_module_options,
             'list': self._cmd_module_search,
         }
         handler = routes.get(sub)
         if handler:
             handler(rest)
         else:
-            self.console.print(f'[dim]Unknown: module {sub}. Try: search, info, install, installed, update, options[/dim]')
+            self.console.print(
+                f'[dim]Unknown: module {sub}. '
+                f'Try: search, info, install, uninstall, installed, update, sync, options[/dim]'
+            )
+
+    def _cmd_module_uninstall(self, args):
+        """Remove an installed module binary."""
+        from praetorian_cli.runners.local import uninstall_tool
+        if not args:
+            self.console.print('[dim]Usage: module uninstall <name>[/dim]')
+            return
+        name = args[0].lower()
+        removed = uninstall_tool(name)
+        if removed:
+            self.console.print(f'[success]{name}: removed[/success]')
+        else:
+            self.console.print(f'[dim]{name}: not installed[/dim]')
+
+    def _cmd_module_sync(self, args):
+        """Force-refresh the capability catalog from the backend."""
+        from praetorian_cli.catalog import CapabilityCatalog
+        cat = CapabilityCatalog(self.sdk)
+        ok = cat.refresh(force=True)
+        n = len(cat.all())
+        verb = 'refreshed' if ok else 'unchanged'
+        self.console.print(f'[success]Catalog {verb}: {n} capabilities ({cat.source}).[/success]')
+
+    def _cmd_module_options(self, args):
+        """Show the configurable parameters for a module (no active tool required)."""
+        from praetorian_cli.catalog import CapabilityCatalog
+        from praetorian_cli.registry import get_registry
+        if not args:
+            self.console.print('[dim]Usage: module options <name>[/dim]')
+            return
+        name = args[0].lower()
+        reg = get_registry()
+        cat = CapabilityCatalog(self.sdk)
+        cap = cat.get(name) or cat.get(reg.get_capability_name(name))
+        if not cap:
+            self.console.print(f'[error]Unknown module: {name}. Use "module search" to find modules.[/error]')
+            return
+        if not cap.parameters:
+            self.console.print(f'[dim]{cap.name}: no configurable options.[/dim]')
+            return
+        param_table = Table(title=f'{cap.name} options', border_style=self.colors['dim'])
+        param_table.add_column('Parameter', style=f'bold {self.colors["primary"]}')
+        param_table.add_column('Type', style=self.colors['accent'])
+        param_table.add_column('Required')
+        param_table.add_column('Default')
+        param_table.add_column('Description')
+        for p in cap.parameters:
+            desc = p.description or ''
+            if p.options:
+                desc = f"{desc} [{', '.join(p.options)}]".strip()
+            param_table.add_row(
+                f'--{p.name}', p.type, 'yes' if p.required else 'no',
+                p.default or '', desc,
+            )
+        self.console.print(param_table)
 
 
 def run_console(sdk: Chariot, account: Optional[str] = None):

--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -8,7 +8,7 @@ from typing import Optional
 import click
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.completion import WordCompleter, NestedCompleter
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import CompleteStyle
@@ -84,7 +84,43 @@ class GuardConsole(
             completer=WordCompleter(CONSOLE_COMMANDS, ignore_case=True),
             complete_style=CompleteStyle.MULTI_COLUMN,
             reserve_space_for_menu=3,
+            completer=self._build_completer(),
         )
+
+    def _build_completer(self):
+        """Build a NestedCompleter with live module names; fall back to WordCompleter."""
+        try:
+            from praetorian_cli.catalog import CapabilityCatalog
+            caps = CapabilityCatalog(self.sdk).all()
+            module_names = {c.name: None for c in caps} if caps else {}
+
+            # module subcommands
+            module_sub = {
+                'search': None,
+                'info': module_names or None,
+                'options': None,
+                'install': module_names or None,
+                'uninstall': module_names or None,
+                'update': module_names or None,
+                'sync': None,
+                'list': None,
+                'installed': None,
+            }
+
+            # Build top-level nested dict from CONSOLE_COMMANDS (top-level → None)
+            # plus richer sub-completions for a few commands.
+            top: dict = {cmd: None for cmd in CONSOLE_COMMANDS}
+            top['module'] = module_sub
+            top['use'] = module_names or None
+            top['info'] = module_names or None
+            top['install'] = module_names or None
+            top['uninstall'] = module_names or None
+
+            return NestedCompleter.from_nested_dict(top)
+        except Exception:
+            # Any failure (SDK not authenticated yet, network error, etc.) —
+            # degrade gracefully to flat WordCompleter.
+            return WordCompleter(CONSOLE_COMMANDS, ignore_case=True)
 
     def run(self):
         """Main console loop."""


### PR DESCRIPTION
> **PR Stack (12/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> 3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)
> 4. #268 Knossos, Aegis management (st7-st9)
> 5. #269 Red Team CLI (st5)
> 6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> 8. #272 share, leaderboard, misc, multipart (st18-st21)
> 9. #244 skills, risk-status, conversation UX
> 10. #243 Hannibal hunt CLI + TUI
> 11. #228 Marcus terminal hardening
> **12. #226 module management system** (this PR)


## Summary

- Adds a dynamic module registry (`modules/registry.json`) as the single source of truth for all 17 security tools — adding a new tool no longer requires a CLI release
- New `guard module` CLI commands: `search`, `info`, `options`, `install`, `uninstall`, `update`, `installed`, `list` — all with `--json` support
- Console commands: `module search`, `module info`, `module update` with Rich table/panel rendering
- MCP tools for Claude integration: `list_modules`, `module_info`, `install_module`, `run_module`
- Version tracking via `~/.praetorian/versions.json` (records GitHub release tags on install)
- Fully backward compatible: `guard run install`, `guard run list`, `guard run installed` unchanged

## Test plan

- [x] 313 unit tests pass (19 registry, 8 CLI, 4 console, plus all existing)
- [x] E2E: `guard module install julius` — installs from GitHub, records version v0.2.0
- [x] E2E: `guard module info julius` — shows version, path, options
- [x] E2E: `guard module update julius` — confirms up to date
- [x] E2E: `guard module uninstall julius` — removes binary and version record
- [x] E2E: `guard module search credential` — filters correctly in both CLI and console
- [x] E2E: `module search`, `module info brutus` in interactive console — Rich tables render correctly
- [x] Backward compat: `guard run list`, `guard run installed` produce identical output
- [x] JSON output clean (`--json` flag, upgrade notice goes to stderr)

Linear: 10T-277

🤖 Generated with [Claude Code](https://claude.com/claude-code)