### PR TITLE
feat(access): add github subcommand for temporary App installation tokens

### DIFF
--- a/praetorian_cli/handlers/access.py
+++ b/praetorian_cli/handlers/access.py
@@ -207,3 +207,109 @@ def aws(sdk, account, prefix):
     click.echo(f'Wrote {len(all_profiles)} AWS profile(s) to ~/.aws/config:')
     for profile_name, _ in all_profiles:
         click.echo(f'  {profile_name}')
+
+
+# Tokens minted by Guard's GitHub App installation flow start with `ghs_`.
+# Static PATs (`ghp_` classic, `github_pat_` fine-grained) are refused so the
+# CLI only ever surfaces 1-hour temporary tokens.
+GITHUB_APP_TOKEN_PREFIX = 'ghs_'
+
+
+@access.command()
+@cli_handler
+@click.option('--account', default=None,
+              help='Guard account email (also inherited from guard --account).')
+@click.option('--format', 'output_format', default='token',
+              type=click.Choice(['token', 'env']), show_default=True,
+              help='Output shape. token: bare token on stdout. '
+                   'env: export GITHUB_TOKEN / GH_TOKEN lines for `eval`.')
+def github(sdk, account, output_format):
+    """Retrieve a temporary GitHub App installation token.
+
+    Looks up github integrations for the active account, asks the broker to
+    mint a 1-hour App installation token, and prints it. Only temporary App
+    installation tokens are returned — static PATs are refused via the `ghs_`
+    prefix check.
+
+    \b
+    Example usages:
+        - guard access github
+        - guard access github --format env
+        - eval "$(guard access github --format env)" && gh auth status
+    """
+    if account is None:
+        account = sdk.keychain.account
+    if account is None:
+        raise click.ClickException(
+            '--account is required. Provide it here or as guard --account.'
+        )
+    sdk.keychain.assume_role(account)
+
+    integrations, _ = sdk.integrations.list(name_filter='github')
+    if not integrations:
+        click.echo(f'No GitHub integrations found for account {account}', err=True)
+        return
+
+    printed = 0
+    for integration in integrations:
+        resource_key = integration.get('key', '')
+        target = integration.get('value') or resource_key
+        token = _fetch_github_app_token(sdk, resource_key, target)
+        if token is None:
+            continue
+        if not token.startswith(GITHUB_APP_TOKEN_PREFIX):
+            click.echo(
+                f'Refusing token from {target}: prefix is not '
+                f'{GITHUB_APP_TOKEN_PREFIX!r}; this looks like a static PAT '
+                'rather than a 1-hour App installation token.',
+                err=True,
+            )
+            continue
+        _print_github_token(token, output_format)
+        printed += 1
+
+    if not printed:
+        raise click.ClickException(
+            'No temporary GitHub App installation tokens were retrieved.'
+        )
+
+
+def _fetch_github_app_token(sdk, resource_key, target):
+    """Resolve a github credential via the broker's from-parent path.
+
+    The github credential is not surfaced in the per-account credentials list,
+    so the only request shape that reaches the github handler is
+    resolution=from-parent with the integration's resource_key. Returns the
+    token string on success, None after printing a stderr message on failure.
+    """
+    try:
+        result = sdk.credentials.get(
+            '', 'env-integration', 'github', ['token'],
+            resolution='from-parent', resource_key=resource_key,
+        )
+    except Exception as e:
+        msg = str(e)
+        if '[403]' in msg or 'unauthorized' in msg.lower():
+            click.echo(
+                f'Skipping {target}: Guard denied the request. End-user '
+                'retrieval of GitHub App installation tokens may not be '
+                'enabled on this deployment yet.',
+                err=True,
+            )
+        else:
+            click.echo(f'Skipping {target}: {msg.splitlines()[0]}', err=True)
+        return None
+
+    token = (result or {}).get('credentialValue', {}).get('github')
+    if not token:
+        click.echo(f'Skipping {target}: broker returned no token', err=True)
+        return None
+    return token
+
+
+def _print_github_token(token, output_format):
+    if output_format == 'env':
+        click.echo(f'export GITHUB_TOKEN={token}')
+        click.echo(f'export GH_TOKEN={token}')
+    else:
+        click.echo(token)

--- a/praetorian_cli/handlers/access.py
+++ b/praetorian_cli/handlers/access.py
@@ -274,18 +274,25 @@ def github(sdk, account, output_format):
         error('No temporary GitHub App installation tokens were retrieved.')
 
 
-def _fetch_github_app_token(sdk, resource_key, target):
-    """Resolve a github credential via the broker's from-parent path.
+def _fetch_github_app_token(sdk, integration_key, target):
+    """Resolve a github credential via the broker.
 
-    The github credential is not surfaced in the per-account credentials list,
-    so the only request shape that reaches the github handler is
-    resolution=from-parent with the integration's resource_key. Returns the
-    token string on success, None after printing a stderr message on failure.
+    Github integrations don't use the standard "Asset + Credential record"
+    pattern that from-parent walks: the OAuth installation flow stores the
+    binding (installation_id, value) directly on the Account record, and the
+    broker reads it from SSM keyed by the integration's own key
+    (backend/pkg/services/account/integration_utils.go writes
+    aws.Secrets.Set(account.Key, account.Secret); the github handler reads
+    aws.Secrets.Get(request.CredentialID)). So for github, CredentialID *is*
+    the integration key, and the right resolution is by-target.
+
+    Returns the token string on success, None after printing a stderr message
+    on failure.
     """
     try:
         result = sdk.credentials.get(
-            '', 'env-integration', 'github', ['token'],
-            resolution='from-parent', resource_key=resource_key,
+            integration_key, 'env-integration', 'github', ['token'],
+            resolution='by-target',
         )
     except Exception as e:
         msg = str(e)

--- a/praetorian_cli/handlers/access.py
+++ b/praetorian_cli/handlers/access.py
@@ -4,6 +4,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error
 
 
 def extract_prefix(email):
@@ -240,9 +241,10 @@ def github(sdk, account, output_format):
     if account is None:
         account = sdk.keychain.account
     if account is None:
-        raise click.ClickException(
-            '--account is required. Provide it here or as guard --account.'
-        )
+        # error() raises SystemExit(1), bypassing the broad `except Exception`
+        # in cli_decorators.handle_error that would otherwise swallow a
+        # ClickException and let the process exit 0.
+        error('--account is required. Provide it here or as guard --account.')
     sdk.keychain.assume_role(account)
 
     integrations, _ = sdk.integrations.list(name_filter='github')
@@ -269,9 +271,7 @@ def github(sdk, account, output_format):
         printed += 1
 
     if not printed:
-        raise click.ClickException(
-            'No temporary GitHub App installation tokens were retrieved.'
-        )
+        error('No temporary GitHub App installation tokens were retrieved.')
 
 
 def _fetch_github_app_token(sdk, resource_key, target):

--- a/praetorian_cli/sdk/test/test_access_github.py
+++ b/praetorian_cli/sdk/test/test_access_github.py
@@ -1,0 +1,156 @@
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.access import access, github, GITHUB_APP_TOKEN_PREFIX
+
+
+class FakeKeychain:
+    def __init__(self, account='someone@example.com'):
+        self.account = account
+        self.assumed = []
+
+    def assume_role(self, account):
+        self.assumed.append(account)
+
+
+class FakeIntegrations:
+    def __init__(self, items):
+        self._items = items
+
+    def list(self, name_filter='', offset=None, pages=100000):
+        if name_filter:
+            return [i for i in self._items if i.get('member') == name_filter], None
+        return list(self._items), None
+
+
+class FakeCredentials:
+    def __init__(self, *, response=None, raise_exc=None):
+        self._response = response
+        self._raise = raise_exc
+        self.calls = []
+
+    def get(self, credential_id, category, type, format, **kwargs):
+        self.calls.append({'credential_id': credential_id, 'category': category,
+                           'type': type, 'format': format, **kwargs})
+        if self._raise:
+            raise self._raise
+        return self._response
+
+
+class FakeSdk:
+    def __init__(self, integrations, credentials):
+        self.keychain = FakeKeychain()
+        self.integrations = integrations
+        self.credentials = credentials
+
+
+def _github_integration(url='https://github.com/acme-inc'):
+    return {
+        'key': f'#account#someone@example.com#github#{url}',
+        'member': 'github',
+        'name': 'someone@example.com',
+        'value': url,
+    }
+
+
+def _invoke(sdk, *args):
+    return CliRunner().invoke(access, ['github', *args], obj=sdk)
+
+
+class TestAccessCLIWiring:
+
+    def test_github_subcommand_registered(self):
+        assert 'github' in access.commands
+
+    def test_github_help_lists_flags(self):
+        result = CliRunner().invoke(access, ['github', '--help'])
+        assert result.exit_code == 0
+        assert '--account' in result.output
+        assert '--format' in result.output
+        # The output choices wrap onto two lines under Click's formatter, so
+        # match on the un-broken substring instead of the full bracketed form.
+        assert 'token' in result.output
+        assert 'env' in result.output
+
+
+class TestGithubRetrieval:
+
+    def test_no_integrations(self):
+        sdk = FakeSdk(FakeIntegrations([]), FakeCredentials())
+        result = _invoke(sdk)
+        assert result.exit_code == 0
+        assert 'No GitHub integrations' in result.output
+        # When there's nothing to print, stdout stays empty.
+        assert GITHUB_APP_TOKEN_PREFIX not in result.output
+
+    def test_app_token_printed_default_format(self):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(response={'credentialValue': {'github': 'ghs_abc123'}}),
+        )
+        result = _invoke(sdk)
+        assert result.exit_code == 0, result.output
+        assert 'ghs_abc123' in result.output
+        # Default format is bare token, not env-export lines.
+        assert 'export' not in result.output
+
+    def test_app_token_env_format(self):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(response={'credentialValue': {'github': 'ghs_abc123'}}),
+        )
+        result = _invoke(sdk, '--format', 'env')
+        assert result.exit_code == 0, result.output
+        assert 'export GITHUB_TOKEN=ghs_abc123' in result.output
+        assert 'export GH_TOKEN=ghs_abc123' in result.output
+
+    @pytest.mark.parametrize('token', ['ghp_classicPATvalue', 'github_pat_finegrained'])
+    def test_pat_prefix_refused(self, token):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(response={'credentialValue': {'github': token}}),
+        )
+        result = _invoke(sdk)
+        # Refused because no temporary token was retrieved -> non-zero exit.
+        assert result.exit_code != 0
+        assert 'Refusing token' in result.output
+        assert token not in result.output  # nothing leaked to stdout
+
+    def test_forbidden_403_emits_friendly_message(self):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(raise_exc=Exception('[403] Request failed\nError: unauthorized')),
+        )
+        result = _invoke(sdk)
+        assert result.exit_code != 0
+        assert 'Guard denied the request' in result.output
+        assert 'github.com/acme-inc' in result.output
+
+    def test_empty_token_skipped(self):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(response={'credentialValue': {}}),
+        )
+        result = _invoke(sdk)
+        assert result.exit_code != 0
+        assert 'broker returned no token' in result.output
+
+    def test_broker_request_shape(self):
+        """Lock in the only request shape the github broker handler routes."""
+        fake_creds = FakeCredentials(response={'credentialValue': {'github': 'ghs_ok'}})
+        sdk = FakeSdk(FakeIntegrations([_github_integration()]), fake_creds)
+        _invoke(sdk)
+        assert fake_creds.calls, 'broker should have been called'
+        call = fake_creds.calls[0]
+        assert call['resolution'] == 'from-parent'
+        assert call['resource_key'] == _github_integration()['key']
+        assert call['type'] == 'github'
+        assert call['format'] == ['token']
+
+    def test_keychain_assume_role_called(self):
+        sdk = FakeSdk(
+            FakeIntegrations([_github_integration()]),
+            FakeCredentials(response={'credentialValue': {'github': 'ghs_ok'}}),
+        )
+        _invoke(sdk, '--account', 'override@example.com')
+        assert sdk.keychain.assumed == ['override@example.com']

--- a/praetorian_cli/sdk/test/test_access_github.py
+++ b/praetorian_cli/sdk/test/test_access_github.py
@@ -136,14 +136,22 @@ class TestGithubRetrieval:
         assert 'broker returned no token' in result.output
 
     def test_broker_request_shape(self):
-        """Lock in the only request shape the github broker handler routes."""
+        """Lock in the request shape the github broker handler actually accepts.
+
+        Github integrations store their secret directly on the Account record
+        keyed by the integration's own key (see
+        backend/pkg/services/account/integration_utils.go), not as a separate
+        Credential entity with a HAS_CREDENTIAL edge. So the broker resolves
+        github via by-target with the integration key as CredentialID, not via
+        from-parent (which would walk the graph for a non-existent Credential).
+        """
         fake_creds = FakeCredentials(response={'credentialValue': {'github': 'ghs_ok'}})
         sdk = FakeSdk(FakeIntegrations([_github_integration()]), fake_creds)
         _invoke(sdk)
         assert fake_creds.calls, 'broker should have been called'
         call = fake_creds.calls[0]
-        assert call['resolution'] == 'from-parent'
-        assert call['resource_key'] == _github_integration()['key']
+        assert call['resolution'] == 'by-target'
+        assert call['credential_id'] == _github_integration()['key']
         assert call['type'] == 'github'
         assert call['format'] == ['token']
 


### PR DESCRIPTION
## Summary

Adds `guard access github` under the existing `access` group to retrieve a temporary GitHub App installation token via the credential broker. Refuses static PATs (anything not prefixed `ghs_`) so only 1-hour App installation tokens ever leave the CLI. Output goes to stdout in one of two formats:

- `--format token` (default): bare token on stdout
- `--format env`: `export GITHUB_TOKEN=…` / `export GH_TOKEN=…` lines for `eval "$(guard access github --format env)"`

Discovery uses `sdk.integrations.list(name_filter='github')`; the broker call uses `resolution='from-parent'` with the integration's resource key, which is the only request shape the github handler routes (the credential isn't surfaced in `list credentials`). 403 from the broker is caught explicitly and surfaced with a friendly hint rather than a stack trace.

Sister PR — depends on the guard backend authz change that allows end-user retrieval of App installation tokens (`Static` PATs continue to be blocked server-side by the lifecycle check): https://github.com/praetorian-inc/guard/pull/5764.

## Notable behaviors

- **Exit code is non-zero on retrieval failure.** Uses `error('…')` (which raises `SystemExit(1)`) rather than `click.ClickException`, because the broad `except Exception` in `handle_error` would otherwise swallow `ClickException` and let the process exit 0. Validated against the installed binary.
- **PAT refusal is defense-in-depth.** Guard's `authorizePostInvoke` lifecycle check also blocks static credentials server-side, but the CLI checks the `ghs_` prefix too in case the response ever sneaks past.
- **No file writes.** Materializing into a `hosts.yml` (and the scoped `.guard/credentials/` layout that goes with it) is intentionally out of scope here — that's a follow-up.

## Test plan

- [x] `pytest praetorian_cli/sdk/test/test_access_github.py` — 11 cases, all passing
- [x] `pytest praetorian_cli/sdk/test/test_access_aws.py` — existing aws tests untouched, 17 cases passing
- [x] Direct broker probe against playground (`dev-github-test-001`, `by-target` resolution) — returns `credentialLifecycle = temporary` + `ghs_`-prefixed token
- [x] Real installed CLI exit code = 1 on the missing-account error path
- [ ] End-to-end exercise via integration discovery once the sister guard PR is merged and deployed (the playground's jerry-rigged integration record isn't graph-linked to the credential, so `from-parent` resolution isn't reachable on that stack; production OAuth-callback flow creates the edge automatically)