### PR TITLE
fix(console): remove extra empty space below the prompt (LAB-3945)

### DIFF
--- a/praetorian_cli/ui/console/console.py
+++ b/praetorian_cli/ui/console/console.py
@@ -9,6 +9,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
+from prompt_toolkit.shortcuts import CompleteStyle
 
 from rich.console import Console
 from rich.table import Table
@@ -77,6 +78,8 @@ class GuardConsole(
         self.session = PromptSession(
             history=FileHistory(history_path),
             completer=WordCompleter(CONSOLE_COMMANDS, ignore_case=True),
+            complete_style=CompleteStyle.MULTI_COLUMN,
+            reserve_space_for_menu=3,
         )
 
     def run(self):


### PR DESCRIPTION
## Summary

The Guard interactive console (`guard console`) rendered a large block of empty vertical space below the `guard >` prompt. This was prompt_toolkit's `PromptSession` default `reserve_space_for_menu=8`, which permanently reserves ~8 rows below the cursor so the completion dropdown has room to render.

This change switches to a multi-column completion menu and shrinks the reserved space:

```python
self.session = PromptSession(
    history=FileHistory(history_path),
    completer=WordCompleter(CONSOLE_COMMANDS, ignore_case=True),
    complete_style=CompleteStyle.MULTI_COLUMN,
    reserve_space_for_menu=3,
)
```

`MULTI_COLUMN` lays completions out in a compact grid, so even with only 3 reserved rows the user sees many of the ~50 console commands at once — while the idle gap below the prompt drops from 8 rows to 3.

## Testing

Compared `COLUMN`/`reserve=2`, `READLINE_LIKE`/`reserve=0`, and `MULTI_COLUMN`/`reserve=3` live in the console via an editable install. Settled on `MULTI_COLUMN` + `reserve=3` as the best balance of a small idle gap and a usable, information-dense completion menu.

## Acceptance criteria

- [x] No large empty block below the `guard >` prompt.
- [x] Command autocompletion still works.

Closes LAB-3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)