### PR TITLE
chore: rev up to 2.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 2.4.5
+- [Bug fix] Improved the `guard console` completion menu to use a compact multi-column grid with a smaller idle gap below the prompt
+
 # 2.4.4
 - [Bug fix] Updated to new API requirements for credential retrieval, see `guard get credential`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = praetorian-cli
-version = 2.4.4
+version = 2.4.5
 author = Praetorian
 author_email = support@praetorian.com
 description = For interacting with the Guard API


### PR DESCRIPTION
## Summary
- Bump version `2.4.4` → `2.4.5` in `setup.cfg`
- Add CHANGELOG entry for the `guard console` multi-column completion fix (LAB-3945, #231)

The only user-facing change merged since the 2.4.4 release was the console completions fix; the remaining merges since then were CI/workflow-only and are intentionally omitted from the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)