### PR TITLE
chore(graphify): add code-graph CI workflow

### DIFF
--- a/.github/workflows/graphify-graph.yml
+++ b/.github/workflows/graphify-graph.yml
@@ -1,0 +1,39 @@
+name: graphify-graph
+# Builds this repo's code knowledge graph via the shared public-workflows reusable
+# and publishes graph.json as an artifact, so engineers and agents query the latest
+# graph without each rebuilding it locally. graphify has no server — the graph is a
+# file (graphify-out/graph.json) that `graphify query` reads.
+#
+# Pull the latest graph:
+#   gh run download -R praetorian-inc/praetorian-cli -n praetorian-cli-graph -D graphify-out
+#
+# Code-only & keyless: respects the committed .graphifyignore (no LLM API key needed).
+# Bump the reusable pin in lockstep with the GRAPHIFY_VERSION pin in the
+# praetorian-claude monorepo Makefile.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'requirements*.txt'
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  pull_request:
+    paths:
+      - '.graphifyignore'
+      - '.github/workflows/graphify-graph.yml'
+  schedule:
+    - cron: '0 7 * * 1'   # Mondays 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  graph:
+    uses: praetorian-inc/public-workflows/.github/workflows/graphify-graph.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
+    permissions:
+      contents: read

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,39 @@
+# graphify: keyless code-only baseline.
+# Docs/papers/images require an LLM backend for semantic extraction; excluding
+# them keeps the graph buildable with no API key and matches what the keyless
+# per-commit hook (`graphify update`, AST-only) maintains. To include docs later,
+# remove the relevant lines and rebuild with a backend (e.g. GEMINI_API_KEY).
+
+# Transient / generated noise (.json is treated as code by graphify)
+.claude/
+*-lock.json
+package-lock.json
+*.lock
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.webp
+*.ico
+*.bmp
+*.tiff
+
+# Docs / papers (graphify DOC_EXTENSIONS + PAPER_EXTENSIONS)
+*.md
+*.mdx
+*.qmd
+*.txt
+*.rst
+*.html
+*.yaml
+*.yml
+*.pdf
+# extra office/text formats (not graphify-native, excluded for cleanliness)
+*.doc
+*.docx
+*.ppt
+*.pptx
+*.csv


### PR DESCRIPTION
## What

Adds the `graphify-graph` CI workflow (a thin caller of the shared `praetorian-inc/public-workflows` reusable, SHA-pinned to v2.9.3) so this repo's [graphify](https://github.com/safishamsi/graphify) code knowledge graph is **rebuilt automatically on every push to the default branch** (plus a weekly cron), and published as a downloadable artifact.

## Why

Engineers and Claude agents fetch the latest graph automatically (via the monorepo SessionStart hook). Building it in CI — server-side, on the merge event — means:

- **Zero local setup**: no one needs the `graphifyy` CLI installed to benefit.
- **Graphs never go stale**: contributors who never installed graphify still get their merged PRs reflected, because the rebuild happens in CI, not on a developer's machine.

## Details

- Code-only & **keyless** extraction (`--no-cluster`), respecting the committed `.graphifyignore` — no LLM API key required.
- Reusable pinned by SHA (`@0c60237`, v2.9.3), matching the existing titus/julius/pius/guard-core callers.
- `permissions: contents: read` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)