### PR TITLE
feat: add Hannibal hunt management CLI and interactive TUI

### DIFF
--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -51,17 +51,17 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except click.ClickException:
+            raise
         except click.Abort:
             raise
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
-        except click.ClickException:
         except click.exceptions.Exit:
+            raise
         except CancelledError:
+            raise
         except Exception as exc:
             if _debug_enabled(ctx):
+                raise
             raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper

--- a/praetorian_cli/handlers/critfinder.py
+++ b/praetorian_cli/handlers/critfinder.py
@@ -114,31 +114,27 @@ def _stream_research(sdk, message, agent='research-coordinator'):
         error(f'CritFinder error: {e}')
 
 
-@chariot.command('critfinder')
+@chariot.command('critfinder', deprecated=True)
 @cli_handler
 @click.argument('target', required=False, default=None)
 @click.option('--depth', default=1, type=int, help='Pipeline cycles (1=single pass, 2-3=iterative)')
 @click.option('--novel', is_flag=True, default=False, help='Hunt for 0days and new variants')
 @click.option('--mode', 'research_mode', type=click.Choice(['offensive', 'knowledge']), default='offensive', help='Research mode')
 def critfinder(sdk, target, depth, novel, research_mode):
-    """Hunt for critical vulnerabilities in the current engagement.
-
-    Runs the CritFinder adversarial research pipeline: SCANNER generates
-    vulnerability hypotheses, GATEKEEPER filters weak findings, EXPLOITER
-    validates and produces proof-of-concept exploits.
+    """[DEPRECATED] Use 'guard hunt start' for persistent hunting.
 
     \b
-    Auto-selects the most promising attack surface if no target specified.
-    Streams progress in real-time.
+    This command is deprecated. Use:
+        guard hunt start "Find vulnerabilities"           # persistent Hannibal hunt
+        guard hunt interactive                            # interactive TUI
+        guard hunt start "Find SQLi" --scope "#asset#x"   # scoped hunt
 
     \b
-    Examples:
-        guard critfinder                          # full engagement scan
-        guard critfinder k8s.client.com           # scoped to target
-        guard critfinder --depth 3                # iterative deep hunt
-        guard critfinder --novel                  # 0day hunting mode
-        guard critfinder --mode knowledge CVE-2024-1234
+    The critfinder pipeline still works but will be removed in a future release.
     """
+    click.echo(click.style('⚠ critfinder is deprecated. Use "guard hunt start" for persistent hunting.', fg='yellow'), err=True)
+    click.echo(click.style('  See "guard hunt --help" for the new hunt management commands.', fg='yellow'), err=True)
+    click.echo(err=True)
     message = _build_research_message(target, depth, novel, research_mode)
 
     click.echo(click.style('CritFinder', bold=True) + ' — Adversarial Vulnerability Research Pipeline')

--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -1,0 +1,477 @@
+"""Hannibal hunt management — create, monitor, and control persistent hunting agents."""
+import json
+import time
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import error, print_json
+
+
+STATUS_COLORS = {
+    'active': 'green',
+    'paused': 'yellow',
+    'completed': 'cyan',
+    'stopped': 'red',
+    'expired': 'magenta',
+    'errored': 'red',
+}
+
+
+def _format_hunt_line(h):
+    """Format a single hunt for list display."""
+    uuid = h.get('uuid', h.get('key', '?'))
+    status = h.get('status', '?')
+    color = STATUS_COLORS.get(status, 'white')
+    prompt = (h.get('prompt', '') or '')[:60]
+    if len(h.get('prompt', '') or '') > 60:
+        prompt += '...'
+    iterations = h.get('iterationCount', 0)
+    findings = h.get('findingsCount', 0)
+    return (
+        f"{uuid}  "
+        f"{click.style(status, fg=color, bold=True):>20s}  "
+        f"iterations={iterations}  findings={findings}  "
+        f"{prompt}"
+    )
+
+
+def _parse_duration(duration_str):
+    """Parse a human-friendly duration like '24h', '12h', '72h' into hours."""
+    duration_str = duration_str.strip().lower()
+    if duration_str.endswith('h'):
+        try:
+            return int(duration_str[:-1])
+        except ValueError:
+            pass
+    if duration_str.endswith('d'):
+        try:
+            return int(duration_str[:-1]) * 24
+        except ValueError:
+            pass
+    try:
+        return int(duration_str)
+    except ValueError:
+        error(f'Invalid duration: {duration_str}. Use e.g. "24h", "48h", "72h", or "3d".')
+
+
+@chariot.group('hunt')
+def hunt():
+    """Manage Hannibal persistent hunting agents.
+
+    \b
+    Hannibal is Guard's autonomous offensive security agent. A hunt is a
+    persistent, tenant-scoped agent instance that iterates: selecting targets,
+    planning dispatches, running exploit agents, and reporting findings.
+
+    \b
+    Examples:
+        guard hunt start "Find SQL injection in web apps" --duration 24h
+        guard hunt list
+        guard hunt show <uuid>
+        guard hunt pause <uuid>
+        guard hunt resume <uuid>
+        guard hunt stop <uuid>
+    """
+    pass
+
+
+@hunt.command('start')
+@cli_handler
+@click.argument('prompt')
+@click.option('--duration', default='24h', help='Hunt duration (e.g. 12h, 24h, 48h, 72h, 3d). Max 72h.', show_default=True)
+@click.option('--scope', multiple=True, help='Scope to specific assets (e.g. "#asset#example.com"). Repeatable.')
+@click.option('--finish-criteria', default=None, help='Optional criteria for the agent to self-complete.')
+@click.option('--agent', default=None, help='Agent name (default: hannibal).')
+@click.option('--allowed-tools', multiple=True, help='Restrict to specific tools. Repeatable.')
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON response.')
+def start(sdk, prompt, duration, scope, finish_criteria, agent, allowed_tools, json_out):
+    """Launch a new Hannibal hunt.
+
+    \b
+    PROMPT is the hunt mandate — what Hannibal should look for.
+
+    \b
+    Examples:
+        guard hunt start "Find critical web vulnerabilities"
+        guard hunt start "Test OAuth flows on api.example.com" --scope "#asset#api.example.com"
+        guard hunt start "Hunt for RCE in Java services" --duration 48h
+        guard hunt start "Find SQLi" --finish-criteria "At least 3 confirmed SQL injection findings"
+    """
+    from datetime import datetime, timezone, timedelta
+
+    hours = _parse_duration(duration)
+    if hours > 72:
+        error('Maximum hunt duration is 72 hours.')
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    body = {
+        'prompt': prompt,
+        'expiresAt': expires_at,
+    }
+    if scope:
+        body['scope'] = list(scope)
+    if finish_criteria:
+        body['finishCriteria'] = finish_criteria
+    if agent:
+        body['agent'] = agent
+    if allowed_tools:
+        body['allowedTools'] = list(allowed_tools)
+
+    result = sdk.post('hunt', body)
+
+    if json_out:
+        print_json(result)
+        return
+
+    uuid = result.get('uuid', '?')
+    status = result.get('status', '?')
+    click.echo(click.style('Hannibal is at the gates!', fg='red', bold=True))
+    click.echo()
+    click.echo(f'  Hunt:     {uuid}')
+    click.echo(f'  Status:   {click.style(status, fg="green", bold=True)}')
+    click.echo(f'  Expires:  {expires_at}')
+    click.echo(f'  Mandate:  {prompt}')
+    if scope:
+        click.echo(f'  Scope:    {", ".join(scope)}')
+    click.echo()
+    click.echo(f'Track progress: guard hunt show {uuid}')
+    click.echo(f'Watch live:     guard hunt watch {uuid}')
+
+
+@hunt.command('list')
+@cli_handler
+@click.option('--status', 'filter_status', default=None,
+              type=click.Choice(['active', 'paused', 'completed', 'stopped', 'expired', 'errored']),
+              help='Filter by hunt status.')
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON.')
+def list_hunts(sdk, filter_status, json_out):
+    """List all hunts for the current account.
+
+    \b
+    Examples:
+        guard hunt list
+        guard hunt list --status active
+        guard hunt list --json-output
+    """
+    resp = sdk.my({'key': '#hunt'})
+    hunts = resp.get('hunts', resp.get('data', []))
+
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
+
+    if filter_status:
+        hunts = [h for h in hunts if h.get('status') == filter_status]
+
+    if json_out:
+        print_json({'hunts': hunts, 'count': len(hunts)})
+        return
+
+    if not hunts:
+        click.echo('No hunts found.' + (f' (filter: {filter_status})' if filter_status else ''))
+        return
+
+    click.echo(click.style(f'{len(hunts)} hunt(s)', bold=True))
+    click.echo(click.style('─' * 80, dim=True))
+    for h in hunts:
+        click.echo(_format_hunt_line(h))
+
+
+@hunt.command('show')
+@cli_handler
+@click.argument('uuid')
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON.')
+def show(sdk, uuid, json_out):
+    """Show details of a specific hunt.
+
+    \b
+    UUID is the hunt identifier.
+
+    \b
+    Examples:
+        guard hunt show 550e8400-e29b-41d4-a716-446655440000
+    """
+    resp = sdk.my({'key': f'#hunt#{uuid}'})
+    hunts = resp.get('hunts', resp.get('data', []))
+
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
+
+    if not hunts:
+        error(f'Hunt {uuid} not found.')
+
+    h = hunts[0]
+
+    if json_out:
+        print_json(h)
+        return
+
+    status = h.get('status', '?')
+    color = STATUS_COLORS.get(status, 'white')
+
+    click.echo(click.style('Hunt Details', bold=True))
+    click.echo(click.style('─' * 60, dim=True))
+    click.echo(f'  UUID:           {h.get("uuid", "?")}')
+    click.echo(f'  Status:         {click.style(status, fg=color, bold=True)}')
+    click.echo(f'  Created:        {h.get("created", "?")}')
+    click.echo(f'  Created By:     {h.get("createdBy", "?")}')
+    click.echo(f'  Expires:        {h.get("expiresAt", "?")}')
+    click.echo(f'  Agent:          {h.get("agent", "hannibal")}')
+    click.echo(f'  Iterations:     {h.get("iterationCount", 0)}')
+    click.echo(f'  Findings:       {h.get("findingsCount", 0)}')
+    click.echo(f'  Last Started:   {h.get("lastStartedAt", "—")}')
+    click.echo(f'  Last Completed: {h.get("lastCompletedAt", "—")}')
+
+    prompt = h.get('prompt', '')
+    if prompt:
+        click.echo(f'  Mandate:')
+        for line in prompt.split('\n'):
+            click.echo(f'    {line}')
+
+    scope = h.get('scope', [])
+    if scope:
+        click.echo(f'  Scope:')
+        for s in scope:
+            click.echo(f'    {s}')
+
+    finish = h.get('finishCriteria', '')
+    if finish:
+        click.echo(f'  Finish Criteria: {finish}')
+
+    last_error = h.get('lastError', '')
+    if last_error:
+        click.echo(f'  Last Error:     {click.style(last_error, fg="red")}')
+
+
+@hunt.command('pause')
+@cli_handler
+@click.argument('uuid')
+def pause(sdk, uuid):
+    """Pause an active hunt. The hunt can be resumed later.
+
+    \b
+    Examples:
+        guard hunt pause 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.put(f'hunt/{uuid}', {'status': 'paused'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="yellow", bold=True)}')
+
+
+@hunt.command('resume')
+@cli_handler
+@click.argument('uuid')
+def resume(sdk, uuid):
+    """Resume a paused hunt.
+
+    \b
+    Examples:
+        guard hunt resume 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.put(f'hunt/{uuid}', {'status': 'active'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="green", bold=True)}')
+
+
+@hunt.command('stop')
+@cli_handler
+@click.argument('uuid')
+def stop(sdk, uuid):
+    """Stop a hunt permanently. Cannot be resumed.
+
+    \b
+    Examples:
+        guard hunt stop 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.put(f'hunt/{uuid}', {'status': 'stopped'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="red", bold=True)}')
+
+
+@hunt.command('delete')
+@cli_handler
+@click.argument('uuid')
+@click.confirmation_option(prompt='Delete this hunt? Findings will be preserved.')
+def delete(sdk, uuid):
+    """Delete a hunt record. Findings (risks) are preserved.
+
+    \b
+    Examples:
+        guard hunt delete 550e8400-e29b-41d4-a716-446655440000
+    """
+    sdk.delete(f'hunt/{uuid}', {}, {'uuid': uuid})
+    click.echo(f'Hunt {uuid}: {click.style("deleted", fg="red")}')
+
+
+@hunt.command('cost')
+@cli_handler
+@click.argument('uuid')
+def cost(sdk, uuid):
+    """Show AI cost breakdown for a hunt.
+
+    \b
+    Examples:
+        guard hunt cost 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.get(f'hunt/{uuid}/cost')
+    print_json(result)
+
+
+@hunt.command('active')
+@cli_handler
+def active(sdk):
+    """Quick status check on all running hunts. Use to check background hunts.
+
+    \b
+    Examples:
+        guard hunt active
+    """
+    resp = sdk.my({'key': '#hunt'})
+    hunts = resp.get('hunts', resp.get('data', []))
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
+
+    active_hunts = [h for h in hunts if h.get('status') in ('active', 'paused')]
+    if not active_hunts:
+        click.echo('No active or paused hunts.')
+        click.echo('Start one: guard hunt start "Find vulnerabilities"')
+        return
+
+    click.echo(click.style(f'{len(active_hunts)} running hunt(s)', bold=True))
+    click.echo(click.style('─' * 80, dim=True))
+    for h in active_hunts:
+        uuid = h.get('uuid', '?')
+        status = h.get('status', '?')
+        color = STATUS_COLORS.get(status, 'white')
+        prompt = (h.get('prompt', '') or '')[:50]
+        iterations = h.get('iterationCount', 0)
+        findings = h.get('findingsCount', 0)
+        click.echo(
+            f"  {uuid}  "
+            f"{click.style(status, fg=color, bold=True)}  "
+            f"i={iterations} f={findings}  "
+            f"{prompt}"
+        )
+    click.echo()
+    click.echo(click.style('Reconnect:', dim=True) + f' guard hunt interactive <uuid>')
+    click.echo(click.style('Watch:', dim=True) + f'     guard hunt watch <uuid>')
+
+
+@hunt.command('interactive')
+@cli_handler
+@click.argument('uuid_or_prompt', required=False, default=None)
+@click.option('--duration', default='24h', help='Hunt duration when starting new (e.g. 24h, 48h).', show_default=True)
+@click.option('--scope', multiple=True, help='Scope to specific assets. Repeatable.')
+def interactive(sdk, uuid_or_prompt, duration, scope):
+    """Launch the interactive Hannibal TUI.
+
+    \b
+    Opens a Claude Code-style terminal interface for managing hunts.
+    Without arguments, opens the TUI ready for commands. With a UUID,
+    connects to an existing hunt. With text, starts a new hunt.
+
+    \b
+    Examples:
+        guard hunt interactive
+        guard hunt interactive 550e8400-e29b-41d4-a716-446655440000
+        guard hunt interactive "Find SQL injection vulnerabilities"
+    """
+    from praetorian_cli.ui.hunt.app import run_hunt_tui
+
+    hunt_uuid = None
+    start_prompt = None
+
+    if uuid_or_prompt:
+        # Heuristic: UUIDs are 36 chars with dashes
+        if len(uuid_or_prompt) == 36 and uuid_or_prompt.count('-') == 4:
+            hunt_uuid = uuid_or_prompt
+        else:
+            start_prompt = uuid_or_prompt
+
+    run_hunt_tui(sdk, hunt_uuid=hunt_uuid, start_prompt=start_prompt,
+                 start_duration=duration, start_scope=list(scope) if scope else None)
+
+
+@hunt.command('watch')
+@cli_handler
+@click.argument('uuid')
+@click.option('--interval', default=10, type=int, help='Poll interval in seconds.', show_default=True)
+def watch(sdk, uuid, interval):
+    """Watch a hunt's progress in real-time. Polls for status updates.
+
+    \b
+    Press Ctrl+C to stop watching (the hunt continues running).
+
+    \b
+    Examples:
+        guard hunt watch 550e8400-e29b-41d4-a716-446655440000
+        guard hunt watch 550e8400-e29b-41d4-a716-446655440000 --interval 30
+    """
+    click.echo(click.style(f'Watching hunt {uuid}', bold=True) + f'  (Ctrl+C to stop watching)')
+    click.echo(click.style('─' * 60, dim=True))
+
+    prev_iterations = -1
+    prev_findings = -1
+
+    try:
+        while True:
+            resp = sdk.my({'key': f'#hunt#{uuid}'})
+            hunts = resp.get('hunts', resp.get('data', []))
+
+            if not isinstance(hunts, list):
+                for key in resp:
+                    if isinstance(resp[key], list):
+                        hunts = resp[key]
+                        break
+                else:
+                    hunts = []
+
+            if not hunts:
+                click.echo(click.style(f'Hunt {uuid} not found.', fg='red'))
+                return
+
+            h = hunts[0]
+            status = h.get('status', '?')
+            color = STATUS_COLORS.get(status, 'white')
+            iterations = h.get('iterationCount', 0)
+            findings = h.get('findingsCount', 0)
+
+            if iterations != prev_iterations or findings != prev_findings:
+                ts = time.strftime('%H:%M:%S')
+                click.echo(
+                    f'[{ts}]  '
+                    f'{click.style(status, fg=color, bold=True):>20s}  '
+                    f'iterations={iterations}  findings={findings}'
+                )
+                prev_iterations = iterations
+                prev_findings = findings
+
+            if status in ('completed', 'stopped', 'expired', 'errored'):
+                click.echo()
+                click.echo(click.style(f'Hunt {status}.', fg=color, bold=True))
+                last_error = h.get('lastError', '')
+                if last_error:
+                    click.echo(click.style(f'Last error: {last_error}', fg='red'))
+                return
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        click.echo()
+        click.echo('Stopped watching. The hunt continues running.')

--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -29,9 +29,11 @@ def _format_hunt_line(h):
         prompt += '...'
     iterations = h.get('iterationCount', 0)
     findings = h.get('findingsCount', 0)
+    status_padded = f"{status:>20s}"
+    styled_status = click.style(status_padded, fg=color, bold=True)
     return (
         f"{uuid}  "
-        f"{click.style(status, fg=color, bold=True):>20s}  "
+        f"{styled_status}  "
         f"iterations={iterations}  findings={findings}  "
         f"{prompt}"
     )

--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -102,6 +102,8 @@ def start(sdk, prompt, duration, scope, finish_criteria, agent, allowed_tools, j
     from datetime import datetime, timezone, timedelta
 
     hours = _parse_duration(duration)
+    if hours <= 0:
+        error('Duration must be positive', quit=True)
     if hours > 72:
         error('Maximum hunt duration is 72 hours.')
     expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -155,7 +157,7 @@ def list_hunts(sdk, filter_status, json_out):
         guard hunt list --status active
         guard hunt list --json-output
     """
-    resp = sdk.my({'key': '#hunt'})
+    resp = sdk.my({'key': '#hunt'}, pages=100)
     hunts = resp.get('hunts', resp.get('data', []))
 
     if not isinstance(hunts, list):
@@ -235,13 +237,13 @@ def show(sdk, uuid, json_out):
 
     prompt = h.get('prompt', '')
     if prompt:
-        click.echo(f'  Mandate:')
+        click.echo('  Mandate:')
         for line in prompt.split('\n'):
             click.echo(f'    {line}')
 
     scope = h.get('scope', [])
     if scope:
-        click.echo(f'  Scope:')
+        click.echo('  Scope:')
         for s in scope:
             click.echo(f'    {s}')
 
@@ -337,7 +339,7 @@ def active(sdk):
     Examples:
         guard hunt active
     """
-    resp = sdk.my({'key': '#hunt'})
+    resp = sdk.my({'key': '#hunt'}, pages=100)
     hunts = resp.get('hunts', resp.get('data', []))
     if not isinstance(hunts, list):
         for key in resp:
@@ -369,8 +371,8 @@ def active(sdk):
             f"{prompt}"
         )
     click.echo()
-    click.echo(click.style('Reconnect:', dim=True) + f' guard hunt interactive <uuid>')
-    click.echo(click.style('Watch:', dim=True) + f'     guard hunt watch <uuid>')
+    click.echo(click.style('Reconnect:', dim=True) + ' guard hunt interactive <uuid>')
+    click.echo(click.style('Watch:', dim=True) + '     guard hunt watch <uuid>')
 
 
 @hunt.command('interactive')
@@ -423,11 +425,15 @@ def watch(sdk, uuid, interval):
         guard hunt watch 550e8400-e29b-41d4-a716-446655440000
         guard hunt watch 550e8400-e29b-41d4-a716-446655440000 --interval 30
     """
-    click.echo(click.style(f'Watching hunt {uuid}', bold=True) + f'  (Ctrl+C to stop watching)')
+    if interval <= 0:
+        error('Interval must be positive', quit=True)
+
+    click.echo(click.style(f'Watching hunt {uuid}', bold=True) + '  (Ctrl+C to stop watching)')
     click.echo(click.style('─' * 60, dim=True))
 
     prev_iterations = -1
     prev_findings = -1
+    prev_status = None
 
     try:
         while True:
@@ -452,7 +458,7 @@ def watch(sdk, uuid, interval):
             iterations = h.get('iterationCount', 0)
             findings = h.get('findingsCount', 0)
 
-            if iterations != prev_iterations or findings != prev_findings:
+            if iterations != prev_iterations or findings != prev_findings or status != prev_status:
                 ts = time.strftime('%H:%M:%S')
                 click.echo(
                     f'[{ts}]  '
@@ -461,6 +467,7 @@ def watch(sdk, uuid, interval):
                 )
                 prev_iterations = iterations
                 prev_findings = findings
+                prev_status = status
 
             if status in ('completed', 'stopped', 'expired', 'errored'):
                 click.echo()

--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -1,156 +1,477 @@
+"""Hannibal hunt management — create, monitor, and control persistent hunting agents."""
+import json
+import time
+
 import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import print_json, render_list_results, pagination_size
+from praetorian_cli.handlers.utils import error, print_json
 
 
-@chariot.group()
+STATUS_COLORS = {
+    'active': 'green',
+    'paused': 'yellow',
+    'completed': 'cyan',
+    'stopped': 'red',
+    'expired': 'magenta',
+    'errored': 'red',
+}
+
+
+def _format_hunt_line(h):
+    """Format a single hunt for list display."""
+    uuid = h.get('uuid', h.get('key', '?'))
+    status = h.get('status', '?')
+    color = STATUS_COLORS.get(status, 'white')
+    prompt = (h.get('prompt', '') or '')[:60]
+    if len(h.get('prompt', '') or '') > 60:
+        prompt += '...'
+    iterations = h.get('iterationCount', 0)
+    findings = h.get('findingsCount', 0)
+    return (
+        f"{uuid}  "
+        f"{click.style(status, fg=color, bold=True):>20s}  "
+        f"iterations={iterations}  findings={findings}  "
+        f"{prompt}"
+    )
+
+
+def _parse_duration(duration_str):
+    """Parse a human-friendly duration like '24h', '12h', '72h' into hours."""
+    duration_str = duration_str.strip().lower()
+    if duration_str.endswith('h'):
+        try:
+            return int(duration_str[:-1])
+        except ValueError:
+            pass
+    if duration_str.endswith('d'):
+        try:
+            return int(duration_str[:-1]) * 24
+        except ValueError:
+            pass
+    try:
+        return int(duration_str)
+    except ValueError:
+        error(f'Invalid duration: {duration_str}. Use e.g. "24h", "48h", "72h", or "3d".')
+
+
+@chariot.group('hunt')
 def hunt():
-    """Manage Hannibal hunts — launch, monitor, and control automated vulnerability discovery."""
+    """Manage Hannibal persistent hunting agents.
+
+    \b
+    Hannibal is Guard's autonomous offensive security agent. A hunt is a
+    persistent, tenant-scoped agent instance that iterates: selecting targets,
+    planning dispatches, running exploit agents, and reporting findings.
+
+    \b
+    Examples:
+        guard hunt start "Find SQL injection in web apps" --duration 24h
+        guard hunt list
+        guard hunt show <uuid>
+        guard hunt pause <uuid>
+        guard hunt resume <uuid>
+        guard hunt stop <uuid>
+    """
     pass
 
 
-@hunt.command()
+@hunt.command('start')
 @cli_handler
-@click.option('-p', '--prompt', required=True, help='The hunt objective / central mandate')
-@click.option('-e', '--expires', type=click.IntRange(1, 72), default=72, show_default=True,
-              help='Hours until the hunt expires (1-72)')
-@click.option('-a', '--agent', type=click.Choice(['hannibal', 'hannibal-cloud', 'hannibal-webapp', 'hannibal-llm']),
-              default='hannibal', show_default=True, help='Agent type')
-@click.option('-s', '--scope', multiple=True, help='Target asset keys to restrict the hunt (repeatable)')
-@click.option('--scope-level', type=click.Choice(['normal', 'strict']), default='normal', show_default=True)
-@click.option('--aggressiveness', type=click.Choice(['cautious', 'balanced', 'aggressive']),
-              default='balanced', show_default=True)
-def launch(sdk, prompt, expires, agent, scope, scope_level, aggressiveness):
-    """Launch a new hunt against the current account.
+@click.argument('prompt')
+@click.option('--duration', default='24h', help='Hunt duration (e.g. 12h, 24h, 48h, 72h, 3d). Max 72h.', show_default=True)
+@click.option('--scope', multiple=True, help='Scope to specific assets (e.g. "#asset#example.com"). Repeatable.')
+@click.option('--finish-criteria', default=None, help='Optional criteria for the agent to self-complete.')
+@click.option('--agent', default=None, help='Agent name (default: hannibal).')
+@click.option('--allowed-tools', multiple=True, help='Restrict to specific tools. Repeatable.')
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON response.')
+def start(sdk, prompt, duration, scope, finish_criteria, agent, allowed_tools, json_out):
+    """Launch a new Hannibal hunt.
 
-    Example usages:
-        guard hunt launch --prompt "Find XSS vulnerabilities in web applications"
-        guard hunt launch --prompt "Test API endpoints" --agent hannibal-webapp --expires 24
-        guard hunt launch --prompt "Cloud misconfigs" --agent hannibal-cloud --scope "#asset#example.com#1.2.3.4"
+    \b
+    PROMPT is the hunt mandate — what Hannibal should look for.
+
+    \b
+    Examples:
+        guard hunt start "Find critical web vulnerabilities"
+        guard hunt start "Test OAuth flows on api.example.com" --scope "#asset#api.example.com"
+        guard hunt start "Hunt for RCE in Java services" --duration 48h
+        guard hunt start "Find SQLi" --finish-criteria "At least 3 confirmed SQL injection findings"
     """
-    result = sdk.hunts.create(
-        prompt=prompt,
-        expires_hours=expires,
-        agent=agent,
-        scope=list(scope) if scope else None,
-        scope_level=scope_level,
-        aggressiveness=aggressiveness,
-    )
-    print_json(result)
+    from datetime import datetime, timezone, timedelta
+
+    hours = _parse_duration(duration)
+    if hours > 72:
+        error('Maximum hunt duration is 72 hours.')
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    body = {
+        'prompt': prompt,
+        'expiresAt': expires_at,
+    }
+    if scope:
+        body['scope'] = list(scope)
+    if finish_criteria:
+        body['finishCriteria'] = finish_criteria
+    if agent:
+        body['agent'] = agent
+    if allowed_tools:
+        body['allowedTools'] = list(allowed_tools)
+
+    result = sdk.post('hunt', body)
+
+    if json_out:
+        print_json(result)
+        return
+
+    uuid = result.get('uuid', '?')
+    status = result.get('status', '?')
+    click.echo(click.style('Hannibal is at the gates!', fg='red', bold=True))
+    click.echo()
+    click.echo(f'  Hunt:     {uuid}')
+    click.echo(f'  Status:   {click.style(status, fg="green", bold=True)}')
+    click.echo(f'  Expires:  {expires_at}')
+    click.echo(f'  Mandate:  {prompt}')
+    if scope:
+        click.echo(f'  Scope:    {", ".join(scope)}')
+    click.echo()
+    click.echo(f'Track progress: guard hunt show {uuid}')
+    click.echo(f'Watch live:     guard hunt watch {uuid}')
 
 
 @hunt.command('list')
 @cli_handler
-@click.option('-s', '--status', type=click.Choice(['active', 'paused', 'completed', 'stopped', 'expired', 'errored']),
-              default=None, help='Filter by hunt status')
-@click.option('-d', '--details', is_flag=True, default=False, help='Show detailed information')
-@click.option('-p', '--page', type=click.Choice(['first', 'all']), default='first', show_default=True)
-def list_hunts(sdk, status, details, page):
-    """List hunts for the current account.
+@click.option('--status', 'filter_status', default=None,
+              type=click.Choice(['active', 'paused', 'completed', 'stopped', 'expired', 'errored']),
+              help='Filter by hunt status.')
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON.')
+def list_hunts(sdk, filter_status, json_out):
+    """List all hunts for the current account.
 
-    Example usages:
+    \b
+    Examples:
         guard hunt list
-        guard hunt list --status active --details
-        guard hunt list --page all
+        guard hunt list --status active
+        guard hunt list --json-output
     """
-    render_list_results(sdk.hunts.list(status=status, pages=pagination_size(page)), details)
+    resp = sdk.my({'key': '#hunt'})
+    hunts = resp.get('hunts', resp.get('data', []))
 
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
 
-@hunt.command()
-@cli_handler
-@click.argument('uuid')
-def status(sdk, uuid):
-    """Show detailed status of a hunt.
+    if filter_status:
+        hunts = [h for h in hunts if h.get('status') == filter_status]
 
-    Argument:
-        UUID: the hunt's UUID
-
-    Example usage:
-        guard hunt status a1b2c3d4-e5f6-7890-abcd-ef1234567890
-    """
-    result = sdk.hunts.get(uuid)
-    if not result:
-        click.secho(f'Hunt {uuid} not found.', fg='red', err=True)
+    if json_out:
+        print_json({'hunts': hunts, 'count': len(hunts)})
         return
-    fields = {
-        'uuid': result.get('uuid', result.get('key', '').replace('#hunt#', '')),
-        'status': result.get('status'),
-        'agent': result.get('agent'),
-        'prompt': result.get('prompt', '')[:120],
-        'iterations': result.get('iterationCount', 0),
-        'findings': result.get('findingsCount', 0),
-        'created': result.get('created'),
-        'expires': result.get('expiresAt'),
-        'lastError': result.get('lastError', ''),
-    }
-    print_json(fields)
+
+    if not hunts:
+        click.echo('No hunts found.' + (f' (filter: {filter_status})' if filter_status else ''))
+        return
+
+    click.echo(click.style(f'{len(hunts)} hunt(s)', bold=True))
+    click.echo(click.style('─' * 80, dim=True))
+    for h in hunts:
+        click.echo(_format_hunt_line(h))
 
 
-@hunt.command()
+@hunt.command('show')
 @cli_handler
 @click.argument('uuid')
-def stop(sdk, uuid):
-    """Stop a running hunt permanently.
+@click.option('--json-output', 'json_out', is_flag=True, default=False, help='Output raw JSON.')
+def show(sdk, uuid, json_out):
+    """Show details of a specific hunt.
 
-    Argument:
-        UUID: the hunt's UUID
+    \b
+    UUID is the hunt identifier.
 
-    Example usage:
-        guard hunt stop a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    \b
+    Examples:
+        guard hunt show 550e8400-e29b-41d4-a716-446655440000
     """
-    result = sdk.hunts.stop(uuid)
-    click.echo(f'Hunt {uuid} stopped.')
-    print_json(result)
+    resp = sdk.my({'key': f'#hunt#{uuid}'})
+    hunts = resp.get('hunts', resp.get('data', []))
+
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
+
+    if not hunts:
+        error(f'Hunt {uuid} not found.')
+
+    h = hunts[0]
+
+    if json_out:
+        print_json(h)
+        return
+
+    status = h.get('status', '?')
+    color = STATUS_COLORS.get(status, 'white')
+
+    click.echo(click.style('Hunt Details', bold=True))
+    click.echo(click.style('─' * 60, dim=True))
+    click.echo(f'  UUID:           {h.get("uuid", "?")}')
+    click.echo(f'  Status:         {click.style(status, fg=color, bold=True)}')
+    click.echo(f'  Created:        {h.get("created", "?")}')
+    click.echo(f'  Created By:     {h.get("createdBy", "?")}')
+    click.echo(f'  Expires:        {h.get("expiresAt", "?")}')
+    click.echo(f'  Agent:          {h.get("agent", "hannibal")}')
+    click.echo(f'  Iterations:     {h.get("iterationCount", 0)}')
+    click.echo(f'  Findings:       {h.get("findingsCount", 0)}')
+    click.echo(f'  Last Started:   {h.get("lastStartedAt", "—")}')
+    click.echo(f'  Last Completed: {h.get("lastCompletedAt", "—")}')
+
+    prompt = h.get('prompt', '')
+    if prompt:
+        click.echo(f'  Mandate:')
+        for line in prompt.split('\n'):
+            click.echo(f'    {line}')
+
+    scope = h.get('scope', [])
+    if scope:
+        click.echo(f'  Scope:')
+        for s in scope:
+            click.echo(f'    {s}')
+
+    finish = h.get('finishCriteria', '')
+    if finish:
+        click.echo(f'  Finish Criteria: {finish}')
+
+    last_error = h.get('lastError', '')
+    if last_error:
+        click.echo(f'  Last Error:     {click.style(last_error, fg="red")}')
 
 
-@hunt.command()
+@hunt.command('pause')
 @cli_handler
 @click.argument('uuid')
 def pause(sdk, uuid):
-    """Pause an active hunt.
+    """Pause an active hunt. The hunt can be resumed later.
 
-    Argument:
-        UUID: the hunt's UUID
-
-    Example usage:
-        guard hunt pause a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    \b
+    Examples:
+        guard hunt pause 550e8400-e29b-41d4-a716-446655440000
     """
-    result = sdk.hunts.pause(uuid)
-    click.echo(f'Hunt {uuid} paused.')
-    print_json(result)
+    result = sdk.put(f'hunt/{uuid}', {'status': 'paused'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="yellow", bold=True)}')
 
 
-@hunt.command()
+@hunt.command('resume')
 @cli_handler
 @click.argument('uuid')
 def resume(sdk, uuid):
     """Resume a paused hunt.
 
-    Argument:
-        UUID: the hunt's UUID
-
-    Example usage:
-        guard hunt resume a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    \b
+    Examples:
+        guard hunt resume 550e8400-e29b-41d4-a716-446655440000
     """
-    result = sdk.hunts.resume(uuid)
-    click.echo(f'Hunt {uuid} resumed.')
-    print_json(result)
+    result = sdk.put(f'hunt/{uuid}', {'status': 'active'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="green", bold=True)}')
+
+
+@hunt.command('stop')
+@cli_handler
+@click.argument('uuid')
+def stop(sdk, uuid):
+    """Stop a hunt permanently. Cannot be resumed.
+
+    \b
+    Examples:
+        guard hunt stop 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.put(f'hunt/{uuid}', {'status': 'stopped'})
+    status = result.get('status', '?')
+    click.echo(f'Hunt {uuid}: {click.style(status, fg="red", bold=True)}')
 
 
 @hunt.command('delete')
 @cli_handler
 @click.argument('uuid')
-@click.confirmation_option(prompt='This will delete the hunt and its artifacts. Findings are preserved. Continue?')
-def delete_hunt(sdk, uuid):
-    """Delete a hunt. Findings are preserved.
+@click.confirmation_option(prompt='Delete this hunt? Findings will be preserved.')
+def delete(sdk, uuid):
+    """Delete a hunt record. Findings (risks) are preserved.
 
-    Argument:
-        UUID: the hunt's UUID
-
-    Example usage:
-        guard hunt delete a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    \b
+    Examples:
+        guard hunt delete 550e8400-e29b-41d4-a716-446655440000
     """
-    sdk.hunts.delete(uuid)
-    click.echo(f'Hunt {uuid} deleted.')
+    sdk.delete(f'hunt/{uuid}', {}, {'uuid': uuid})
+    click.echo(f'Hunt {uuid}: {click.style("deleted", fg="red")}')
+
+
+@hunt.command('cost')
+@cli_handler
+@click.argument('uuid')
+def cost(sdk, uuid):
+    """Show AI cost breakdown for a hunt.
+
+    \b
+    Examples:
+        guard hunt cost 550e8400-e29b-41d4-a716-446655440000
+    """
+    result = sdk.get(f'hunt/{uuid}/cost')
+    print_json(result)
+
+
+@hunt.command('active')
+@cli_handler
+def active(sdk):
+    """Quick status check on all running hunts. Use to check background hunts.
+
+    \b
+    Examples:
+        guard hunt active
+    """
+    resp = sdk.my({'key': '#hunt'})
+    hunts = resp.get('hunts', resp.get('data', []))
+    if not isinstance(hunts, list):
+        for key in resp:
+            if isinstance(resp[key], list):
+                hunts = resp[key]
+                break
+        else:
+            hunts = []
+
+    active_hunts = [h for h in hunts if h.get('status') in ('active', 'paused')]
+    if not active_hunts:
+        click.echo('No active or paused hunts.')
+        click.echo('Start one: guard hunt start "Find vulnerabilities"')
+        return
+
+    click.echo(click.style(f'{len(active_hunts)} running hunt(s)', bold=True))
+    click.echo(click.style('─' * 80, dim=True))
+    for h in active_hunts:
+        uuid = h.get('uuid', '?')
+        status = h.get('status', '?')
+        color = STATUS_COLORS.get(status, 'white')
+        prompt = (h.get('prompt', '') or '')[:50]
+        iterations = h.get('iterationCount', 0)
+        findings = h.get('findingsCount', 0)
+        click.echo(
+            f"  {uuid}  "
+            f"{click.style(status, fg=color, bold=True)}  "
+            f"i={iterations} f={findings}  "
+            f"{prompt}"
+        )
+    click.echo()
+    click.echo(click.style('Reconnect:', dim=True) + f' guard hunt interactive <uuid>')
+    click.echo(click.style('Watch:', dim=True) + f'     guard hunt watch <uuid>')
+
+
+@hunt.command('interactive')
+@cli_handler
+@click.argument('uuid_or_prompt', required=False, default=None)
+@click.option('--duration', default='24h', help='Hunt duration when starting new (e.g. 24h, 48h).', show_default=True)
+@click.option('--scope', multiple=True, help='Scope to specific assets. Repeatable.')
+def interactive(sdk, uuid_or_prompt, duration, scope):
+    """Launch the interactive Hannibal TUI.
+
+    \b
+    Opens a Claude Code-style terminal interface for managing hunts.
+    Without arguments, opens the TUI ready for commands. With a UUID,
+    connects to an existing hunt. With text, starts a new hunt.
+
+    \b
+    Examples:
+        guard hunt interactive
+        guard hunt interactive 550e8400-e29b-41d4-a716-446655440000
+        guard hunt interactive "Find SQL injection vulnerabilities"
+    """
+    from praetorian_cli.ui.hunt.app import run_hunt_tui
+
+    hunt_uuid = None
+    start_prompt = None
+
+    if uuid_or_prompt:
+        # Heuristic: UUIDs are 36 chars with dashes
+        if len(uuid_or_prompt) == 36 and uuid_or_prompt.count('-') == 4:
+            hunt_uuid = uuid_or_prompt
+        else:
+            start_prompt = uuid_or_prompt
+
+    run_hunt_tui(sdk, hunt_uuid=hunt_uuid, start_prompt=start_prompt,
+                 start_duration=duration, start_scope=list(scope) if scope else None)
+
+
+@hunt.command('watch')
+@cli_handler
+@click.argument('uuid')
+@click.option('--interval', default=10, type=int, help='Poll interval in seconds.', show_default=True)
+def watch(sdk, uuid, interval):
+    """Watch a hunt's progress in real-time. Polls for status updates.
+
+    \b
+    Press Ctrl+C to stop watching (the hunt continues running).
+
+    \b
+    Examples:
+        guard hunt watch 550e8400-e29b-41d4-a716-446655440000
+        guard hunt watch 550e8400-e29b-41d4-a716-446655440000 --interval 30
+    """
+    click.echo(click.style(f'Watching hunt {uuid}', bold=True) + f'  (Ctrl+C to stop watching)')
+    click.echo(click.style('─' * 60, dim=True))
+
+    prev_iterations = -1
+    prev_findings = -1
+
+    try:
+        while True:
+            resp = sdk.my({'key': f'#hunt#{uuid}'})
+            hunts = resp.get('hunts', resp.get('data', []))
+
+            if not isinstance(hunts, list):
+                for key in resp:
+                    if isinstance(resp[key], list):
+                        hunts = resp[key]
+                        break
+                else:
+                    hunts = []
+
+            if not hunts:
+                click.echo(click.style(f'Hunt {uuid} not found.', fg='red'))
+                return
+
+            h = hunts[0]
+            status = h.get('status', '?')
+            color = STATUS_COLORS.get(status, 'white')
+            iterations = h.get('iterationCount', 0)
+            findings = h.get('findingsCount', 0)
+
+            if iterations != prev_iterations or findings != prev_findings:
+                ts = time.strftime('%H:%M:%S')
+                click.echo(
+                    f'[{ts}]  '
+                    f'{click.style(status, fg=color, bold=True):>20s}  '
+                    f'iterations={iterations}  findings={findings}'
+                )
+                prev_iterations = iterations
+                prev_findings = findings
+
+            if status in ('completed', 'stopped', 'expired', 'errored'):
+                click.echo()
+                click.echo(click.style(f'Hunt {status}.', fg=color, bold=True))
+                last_error = h.get('lastError', '')
+                if last_error:
+                    click.echo(click.style(f'Last error: {last_error}', fg='red'))
+                return
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        click.echo()
+        click.echo('Stopped watching. The hunt continues running.')

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -11,6 +11,7 @@ import praetorian_cli.handlers.engagement
 import praetorian_cli.handlers.find
 import praetorian_cli.handlers.export
 import praetorian_cli.handlers.get
+import praetorian_cli.handlers.hunt
 import praetorian_cli.handlers.run
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.link

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -499,5 +499,99 @@ class MarcusCommands:
         self._cmd_critfinder(args)
 
     def _cmd_hunt(self, args):
-        """Alias for critfinder."""
-        self._cmd_critfinder(args)
+        """Manage Hannibal persistent hunting agents."""
+        if not args:
+            self.console.print('[bold]Hannibal Hunt Management[/bold]')
+            self.console.print('[dim]  hunt start "<prompt>"     Start a new hunt[/dim]')
+            self.console.print('[dim]  hunt list                List all hunts[/dim]')
+            self.console.print('[dim]  hunt show <uuid>         Show hunt details[/dim]')
+            self.console.print('[dim]  hunt pause <uuid>        Pause a hunt[/dim]')
+            self.console.print('[dim]  hunt resume <uuid>       Resume a hunt[/dim]')
+            self.console.print('[dim]  hunt stop <uuid>         Stop a hunt[/dim]')
+            self.console.print('[dim]  hunt interactive [uuid]  Open interactive TUI[/dim]')
+            return
+
+        subcmd = args[0].lower()
+        rest = args[1:]
+
+        if subcmd == 'start':
+            if not rest:
+                self.console.print('[error]Usage: hunt start "<prompt>" [--duration 24h] [--scope #asset#...][/error]')
+                return
+            prompt = ' '.join(rest)
+            from datetime import datetime, timezone, timedelta
+            expires_at = (datetime.now(timezone.utc) + timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            with self.console.status('Launching hunt...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.post('hunt', {'prompt': prompt, 'expiresAt': expires_at})
+            uuid = result.get('uuid', '?')
+            status = result.get('status', '?')
+            self.console.print(f'[bold red]Hannibal is at the gates![/bold red]')
+            self.console.print(f'  Hunt:   {uuid}')
+            self.console.print(f'  Status: [green]{status}[/green]')
+            self.console.print(f'  Track:  hunt show {uuid}')
+        elif subcmd == 'list':
+            with self.console.status('Loading hunts...', spinner='dots', spinner_style=self.colors['primary']):
+                resp = self.sdk.my({'key': '#hunt'})
+            hunts = self._extract_console_hunts(resp)
+            if not hunts:
+                self.console.print('[dim]No hunts found.[/dim]')
+                return
+            self.console.print(f'[bold]{len(hunts)} hunt(s)[/bold]')
+            for h in hunts:
+                uuid = h.get('uuid', '?')
+                status = h.get('status', '?')
+                prompt = (h.get('prompt', '') or '')[:50]
+                iters = h.get('iterationCount', 0)
+                finds = h.get('findingsCount', 0)
+                self.console.print(f'  {uuid[:12]}...  [{self._hunt_color(status)}]{status}[/]  i={iters} f={finds}  {prompt}')
+        elif subcmd == 'show' and rest:
+            uuid = rest[0]
+            with self.console.status('Loading...', spinner='dots', spinner_style=self.colors['primary']):
+                resp = self.sdk.my({'key': f'#hunt#{uuid}'})
+            hunts = self._extract_console_hunts(resp)
+            if not hunts:
+                self.console.print(f'[error]Hunt {uuid} not found.[/error]')
+                return
+            h = hunts[0]
+            self.console.print(f'[bold]Hunt {h.get("uuid", "?")}[/bold]')
+            self.console.print(f'  Status:     [{self._hunt_color(h.get("status", ""))}]{h.get("status", "?")}[/]')
+            self.console.print(f'  Created:    {h.get("created", "?")}')
+            self.console.print(f'  Expires:    {h.get("expiresAt", "?")}')
+            self.console.print(f'  Iterations: {h.get("iterationCount", 0)}')
+            self.console.print(f'  Findings:   {h.get("findingsCount", 0)}')
+            self.console.print(f'  Mandate:    {h.get("prompt", "")}')
+        elif subcmd == 'pause' and rest:
+            with self.console.status('Pausing...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'paused'})
+            self.console.print(f'Hunt {rest[0]}: [yellow]paused[/yellow]')
+        elif subcmd == 'resume' and rest:
+            with self.console.status('Resuming...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'active'})
+            self.console.print(f'Hunt {rest[0]}: [green]active[/green]')
+        elif subcmd == 'stop' and rest:
+            with self.console.status('Stopping...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'stopped'})
+            self.console.print(f'Hunt {rest[0]}: [red]stopped[/red]')
+        elif subcmd == 'interactive':
+            from praetorian_cli.ui.hunt.app import run_hunt_tui
+            uuid = rest[0] if rest else None
+            run_hunt_tui(self.sdk, hunt_uuid=uuid)
+        else:
+            self.console.print(f'[error]Unknown hunt subcommand: {subcmd}. Type "hunt" for help.[/error]')
+
+    @staticmethod
+    def _extract_console_hunts(resp):
+        if isinstance(resp, list):
+            return resp
+        for key in ('hunts', 'data'):
+            if key in resp and isinstance(resp[key], list):
+                return resp[key]
+        for key in resp:
+            if isinstance(resp[key], list):
+                return resp[key]
+        return []
+
+    @staticmethod
+    def _hunt_color(status):
+        return {'active': 'green', 'paused': 'yellow', 'completed': 'cyan',
+                'stopped': 'red', 'expired': 'magenta', 'errored': 'red'}.get(status, 'white')

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -680,5 +680,99 @@ class MarcusCommands:
         self._cmd_critfinder(args)
 
     def _cmd_hunt(self, args):
-        """Alias for critfinder."""
-        self._cmd_critfinder(args)
+        """Manage Hannibal persistent hunting agents."""
+        if not args:
+            self.console.print('[bold]Hannibal Hunt Management[/bold]')
+            self.console.print('[dim]  hunt start "<prompt>"     Start a new hunt[/dim]')
+            self.console.print('[dim]  hunt list                List all hunts[/dim]')
+            self.console.print('[dim]  hunt show <uuid>         Show hunt details[/dim]')
+            self.console.print('[dim]  hunt pause <uuid>        Pause a hunt[/dim]')
+            self.console.print('[dim]  hunt resume <uuid>       Resume a hunt[/dim]')
+            self.console.print('[dim]  hunt stop <uuid>         Stop a hunt[/dim]')
+            self.console.print('[dim]  hunt interactive [uuid]  Open interactive TUI[/dim]')
+            return
+
+        subcmd = args[0].lower()
+        rest = args[1:]
+
+        if subcmd == 'start':
+            if not rest:
+                self.console.print('[error]Usage: hunt start "<prompt>" [--duration 24h] [--scope #asset#...][/error]')
+                return
+            prompt = ' '.join(rest)
+            from datetime import datetime, timezone, timedelta
+            expires_at = (datetime.now(timezone.utc) + timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            with self.console.status('Launching hunt...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.post('hunt', {'prompt': prompt, 'expiresAt': expires_at})
+            uuid = result.get('uuid', '?')
+            status = result.get('status', '?')
+            self.console.print(f'[bold red]Hannibal is at the gates![/bold red]')
+            self.console.print(f'  Hunt:   {uuid}')
+            self.console.print(f'  Status: [green]{status}[/green]')
+            self.console.print(f'  Track:  hunt show {uuid}')
+        elif subcmd == 'list':
+            with self.console.status('Loading hunts...', spinner='dots', spinner_style=self.colors['primary']):
+                resp = self.sdk.my({'key': '#hunt'})
+            hunts = self._extract_console_hunts(resp)
+            if not hunts:
+                self.console.print('[dim]No hunts found.[/dim]')
+                return
+            self.console.print(f'[bold]{len(hunts)} hunt(s)[/bold]')
+            for h in hunts:
+                uuid = h.get('uuid', '?')
+                status = h.get('status', '?')
+                prompt = (h.get('prompt', '') or '')[:50]
+                iters = h.get('iterationCount', 0)
+                finds = h.get('findingsCount', 0)
+                self.console.print(f'  {uuid[:12]}...  [{self._hunt_color(status)}]{status}[/]  i={iters} f={finds}  {prompt}')
+        elif subcmd == 'show' and rest:
+            uuid = rest[0]
+            with self.console.status('Loading...', spinner='dots', spinner_style=self.colors['primary']):
+                resp = self.sdk.my({'key': f'#hunt#{uuid}'})
+            hunts = self._extract_console_hunts(resp)
+            if not hunts:
+                self.console.print(f'[error]Hunt {uuid} not found.[/error]')
+                return
+            h = hunts[0]
+            self.console.print(f'[bold]Hunt {h.get("uuid", "?")}[/bold]')
+            self.console.print(f'  Status:     [{self._hunt_color(h.get("status", ""))}]{h.get("status", "?")}[/]')
+            self.console.print(f'  Created:    {h.get("created", "?")}')
+            self.console.print(f'  Expires:    {h.get("expiresAt", "?")}')
+            self.console.print(f'  Iterations: {h.get("iterationCount", 0)}')
+            self.console.print(f'  Findings:   {h.get("findingsCount", 0)}')
+            self.console.print(f'  Mandate:    {h.get("prompt", "")}')
+        elif subcmd == 'pause' and rest:
+            with self.console.status('Pausing...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'paused'})
+            self.console.print(f'Hunt {rest[0]}: [yellow]paused[/yellow]')
+        elif subcmd == 'resume' and rest:
+            with self.console.status('Resuming...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'active'})
+            self.console.print(f'Hunt {rest[0]}: [green]active[/green]')
+        elif subcmd == 'stop' and rest:
+            with self.console.status('Stopping...', spinner='dots', spinner_style=self.colors['primary']):
+                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'stopped'})
+            self.console.print(f'Hunt {rest[0]}: [red]stopped[/red]')
+        elif subcmd == 'interactive':
+            from praetorian_cli.ui.hunt.app import run_hunt_tui
+            uuid = rest[0] if rest else None
+            run_hunt_tui(self.sdk, hunt_uuid=uuid)
+        else:
+            self.console.print(f'[error]Unknown hunt subcommand: {subcmd}. Type "hunt" for help.[/error]')
+
+    @staticmethod
+    def _extract_console_hunts(resp):
+        if isinstance(resp, list):
+            return resp
+        for key in ('hunts', 'data'):
+            if key in resp and isinstance(resp[key], list):
+                return resp[key]
+        for key in resp:
+            if isinstance(resp[key], list):
+                return resp[key]
+        return []
+
+    @staticmethod
+    def _hunt_color(status):
+        return {'active': 'green', 'paused': 'yellow', 'completed': 'cyan',
+                'stopped': 'red', 'expired': 'magenta', 'errored': 'red'}.get(status, 'white')

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -68,12 +68,12 @@ class MarcusCommands:
             self.context.mode = 'query'
 
         self.console.print('[primary]Entering conversation mode[/primary] [dim](type "/back" to return)[/dim]')
-        self.console.print(f'[dim]Commands: /back, /new, /query, /agent, /skill <path>, /skills, /unskill <name>, or just chat[/dim]')
+        self.console.print('[dim]Commands: /back, /new, /query, /agent, /skill <path>, /skills, /unskill <name>, or just chat[/dim]')
         self.console.print(f'[dim]Context: {self.context.summary()}[/dim]')
         if self.context.skills:
             self.console.print(f'[dim]Skills: {", ".join(os.path.basename(s) for s in self.context.skills)}[/dim]')
         if not self.context.account:
-            self.console.print(f'[warning]No account set -- Marcus will query your personal account. Use "set account <email>" first.[/warning]')
+            self.console.print('[warning]No account set -- Marcus will query your personal account. Use "set account <email>" first.[/warning]')
         self.console.print()
 
         while True:
@@ -263,7 +263,7 @@ class MarcusCommands:
                     if result_summary:
                         self.console.print(f'    [dim]-- {result_summary}[/dim] [success]done[/success]')
                     else:
-                        self.console.print(f'    [success]done[/success]')
+                        self.console.print('    [success]done[/success]')
                     if self.context.verbose:
                         self._print_verbose_tool_response(content)
         except KeyboardInterrupt:

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -699,20 +699,66 @@ class MarcusCommands:
             if not rest:
                 self.console.print('[error]Usage: hunt start "<prompt>" [--duration 24h] [--scope #asset#...][/error]')
                 return
-            prompt = ' '.join(rest)
+
+            # Pull --duration/--scope flags out of rest before treating the
+            # remainder as the hunt mandate (prompt) text.
+            prompt_parts = []
+            duration = '24h'
+            scope = []
+            i = 0
+            while i < len(rest):
+                token = rest[i]
+                if token == '--duration' and i + 1 < len(rest):
+                    duration = rest[i + 1]
+                    i += 2
+                elif token == '--scope' and i + 1 < len(rest):
+                    scope.append(rest[i + 1])
+                    i += 2
+                else:
+                    prompt_parts.append(token)
+                    i += 1
+
+            prompt = ' '.join(prompt_parts)
+            if not prompt:
+                self.console.print('[error]Usage: hunt start "<prompt>" [--duration 24h] [--scope #asset#...][/error]')
+                return
+
             from datetime import datetime, timezone, timedelta
-            expires_at = (datetime.now(timezone.utc) + timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            duration_str = duration.strip().lower()
+            try:
+                if duration_str.endswith('h'):
+                    hours = int(duration_str[:-1])
+                elif duration_str.endswith('d'):
+                    hours = int(duration_str[:-1]) * 24
+                else:
+                    hours = int(duration_str)
+            except ValueError:
+                self.console.print(f'[error]Invalid duration: {duration}[/error]')
+                return
+
+            if hours <= 0:
+                self.console.print('[error]Duration must be positive[/error]')
+                return
+            if hours > 72:
+                self.console.print('[error]Maximum hunt duration is 72 hours.[/error]')
+                return
+
+            expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            body = {'prompt': prompt, 'expiresAt': expires_at}
+            if scope:
+                body['scope'] = scope
+
             with self.console.status('Launching hunt...', spinner='dots', spinner_style=self.colors['primary']):
-                result = self.sdk.post('hunt', {'prompt': prompt, 'expiresAt': expires_at})
+                result = self.sdk.post('hunt', body)
             uuid = result.get('uuid', '?')
             status = result.get('status', '?')
-            self.console.print(f'[bold red]Hannibal is at the gates![/bold red]')
+            self.console.print('[bold red]Hannibal is at the gates![/bold red]')
             self.console.print(f'  Hunt:   {uuid}')
             self.console.print(f'  Status: [green]{status}[/green]')
             self.console.print(f'  Track:  hunt show {uuid}')
         elif subcmd == 'list':
             with self.console.status('Loading hunts...', spinner='dots', spinner_style=self.colors['primary']):
-                resp = self.sdk.my({'key': '#hunt'})
+                resp = self.sdk.my({'key': '#hunt'}, pages=100)
             hunts = self._extract_console_hunts(resp)
             if not hunts:
                 self.console.print('[dim]No hunts found.[/dim]')

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -771,34 +771,46 @@ class MarcusCommands:
                 iters = h.get('iterationCount', 0)
                 finds = h.get('findingsCount', 0)
                 self.console.print(f'  {uuid[:12]}...  [{self._hunt_color(status)}]{status}[/]  i={iters} f={finds}  {prompt}')
-        elif subcmd == 'show' and rest:
-            uuid = rest[0]
-            with self.console.status('Loading...', spinner='dots', spinner_style=self.colors['primary']):
-                resp = self.sdk.my({'key': f'#hunt#{uuid}'})
-            hunts = self._extract_console_hunts(resp)
-            if not hunts:
-                self.console.print(f'[error]Hunt {uuid} not found.[/error]')
-                return
-            h = hunts[0]
-            self.console.print(f'[bold]Hunt {h.get("uuid", "?")}[/bold]')
-            self.console.print(f'  Status:     [{self._hunt_color(h.get("status", ""))}]{h.get("status", "?")}[/]')
-            self.console.print(f'  Created:    {h.get("created", "?")}')
-            self.console.print(f'  Expires:    {h.get("expiresAt", "?")}')
-            self.console.print(f'  Iterations: {h.get("iterationCount", 0)}')
-            self.console.print(f'  Findings:   {h.get("findingsCount", 0)}')
-            self.console.print(f'  Mandate:    {h.get("prompt", "")}')
-        elif subcmd == 'pause' and rest:
-            with self.console.status('Pausing...', spinner='dots', spinner_style=self.colors['primary']):
-                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'paused'})
-            self.console.print(f'Hunt {rest[0]}: [yellow]paused[/yellow]')
-        elif subcmd == 'resume' and rest:
-            with self.console.status('Resuming...', spinner='dots', spinner_style=self.colors['primary']):
-                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'active'})
-            self.console.print(f'Hunt {rest[0]}: [green]active[/green]')
-        elif subcmd == 'stop' and rest:
-            with self.console.status('Stopping...', spinner='dots', spinner_style=self.colors['primary']):
-                result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'stopped'})
-            self.console.print(f'Hunt {rest[0]}: [red]stopped[/red]')
+        elif subcmd == 'show':
+            if not rest:
+                self.console.print('Usage: hunt show <uuid>')
+            else:
+                uuid = rest[0]
+                with self.console.status('Loading...', spinner='dots', spinner_style=self.colors['primary']):
+                    resp = self.sdk.my({'key': f'#hunt#{uuid}'})
+                hunts = self._extract_console_hunts(resp)
+                if not hunts:
+                    self.console.print(f'[error]Hunt {uuid} not found.[/error]')
+                    return
+                h = hunts[0]
+                self.console.print(f'[bold]Hunt {h.get("uuid", "?")}[/bold]')
+                self.console.print(f'  Status:     [{self._hunt_color(h.get("status", ""))}]{h.get("status", "?")}[/]')
+                self.console.print(f'  Created:    {h.get("created", "?")}')
+                self.console.print(f'  Expires:    {h.get("expiresAt", "?")}')
+                self.console.print(f'  Iterations: {h.get("iterationCount", 0)}')
+                self.console.print(f'  Findings:   {h.get("findingsCount", 0)}')
+                self.console.print(f'  Mandate:    {h.get("prompt", "")}')
+        elif subcmd == 'pause':
+            if not rest:
+                self.console.print('Usage: hunt pause <uuid>')
+            else:
+                with self.console.status('Pausing...', spinner='dots', spinner_style=self.colors['primary']):
+                    result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'paused'})
+                self.console.print(f'Hunt {rest[0]}: [yellow]paused[/yellow]')
+        elif subcmd == 'resume':
+            if not rest:
+                self.console.print('Usage: hunt resume <uuid>')
+            else:
+                with self.console.status('Resuming...', spinner='dots', spinner_style=self.colors['primary']):
+                    result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'active'})
+                self.console.print(f'Hunt {rest[0]}: [green]active[/green]')
+        elif subcmd == 'stop':
+            if not rest:
+                self.console.print('Usage: hunt stop <uuid>')
+            else:
+                with self.console.status('Stopping...', spinner='dots', spinner_style=self.colors['primary']):
+                    result = self.sdk.put(f'hunt/{rest[0]}', {'status': 'stopped'})
+                self.console.print(f'Hunt {rest[0]}: [red]stopped[/red]')
         elif subcmd == 'interactive':
             from praetorian_cli.ui.hunt.app import run_hunt_tui
             uuid = rest[0] if rest else None

--- a/praetorian_cli/ui/hunt/app.py
+++ b/praetorian_cli/ui/hunt/app.py
@@ -13,10 +13,33 @@ from textual import on, work
 from praetorian_cli.sdk.chariot import Chariot
 
 
-HUNT_LOGO = r"""[bold red]
-  ╦ ╦╔═╗╔╗╔╔╗╔╦╗╔╗ ╔═╗╦
-  ╠═╣╠═╣║║║║║║║╠╩╗╠═╣║
-  ╩ ╩╩ ╩╝╚╝╝╚╝╩╚═╝╩ ╩╩═╝[/bold red]"""
+HUNT_BANNER = """[bold red]                                    ██ ████                     ████ ██
+                                 ██ ███                             ███ ██
+                                 ███                                   ███
+                              █  █████                               █████  █
+                             ████                                         ████
+                              █████                                     █████
+                           █████                                           █████
+                           ████████                                     ████████
+                             ███                                           ███
+                         ███ █  ███                                     ████ █ ███
+                          ████████                                       ████████
+                           █████   █                                    █  █████
+                              █ ███                                     ███ █
+                          █████████                                     █████████
+                           ███████  ██                               ██  ███████
+                                ██ ███  ██                        █  ███ ██
+                                 █████ ███  ██               ██  ███ █████
+                            █████████  ████████             ████ ████ █████████
+                               ████  ███████████           █████ ██████ ████
+                                   ████████ ████           ████ ████████
+                                █████████  █████           ██████ █████████
+                                        ████████████   ████████████
+                                      ████████     █████     ████████
+                                        ██        ███ ████       ██
+                                                ██       ██[/bold red]"""
+
+HUNT_TITLE = "[bold red]Hannibal[/bold red] [dim]—[/dim] [bold #d4a017]Persistent Hunting Agent[/bold #d4a017]"
 
 STATUS_STYLE = {
     'active': '[bold green]● active[/bold green]',
@@ -129,7 +152,10 @@ class HuntApp(App):
     def on_mount(self) -> None:
         self._update_context_bar()
         log = self.query_one("#activity-log", RichLog)
-        log.write(HUNT_LOGO)
+        log.write(HUNT_BANNER)
+        log.write("")
+        log.write(HUNT_TITLE)
+        log.write(f"[dim]Praetorian Offensive Security Platform[/dim]")
         log.write("")
 
         if self._initial_uuid:
@@ -140,8 +166,6 @@ class HuntApp(App):
             log.write("[dim]Launching new hunt...[/dim]")
             self._launch_hunt()
         else:
-            log.write("[bold]Welcome to Hannibal[/bold]")
-            log.write("")
             log.write("Start a hunt or connect to an existing one:")
             log.write("  [cyan]/start[/cyan] <prompt>  — launch a new hunt")
             log.write("  [cyan]/connect[/cyan] <uuid>  — connect to a running hunt")

--- a/praetorian_cli/ui/hunt/app.py
+++ b/praetorian_cli/ui/hunt/app.py
@@ -1,0 +1,527 @@
+"""Hannibal Hunt TUI — Claude Code-style interactive hunt interface."""
+import asyncio
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.widgets import Header, Footer, Input, Static, RichLog
+from textual.reactive import reactive
+from textual import on, work
+
+from praetorian_cli.sdk.chariot import Chariot
+
+
+HUNT_LOGO = r"""[bold red]
+  ╦ ╦╔═╗╔╗╔╔╗╔╦╗╔╗ ╔═╗╦
+  ╠═╣╠═╣║║║║║║║╠╩╗╠═╣║
+  ╩ ╩╩ ╩╝╚╝╝╚╝╩╚═╝╩ ╩╩═╝[/bold red]"""
+
+STATUS_STYLE = {
+    'active': '[bold green]● active[/bold green]',
+    'paused': '[bold yellow]● paused[/bold yellow]',
+    'completed': '[bold cyan]● completed[/bold cyan]',
+    'stopped': '[bold red]● stopped[/bold red]',
+    'expired': '[bold magenta]● expired[/bold magenta]',
+    'errored': '[bold red]● errored[/bold red]',
+}
+
+
+class HuntApp(App):
+    """Interactive Hannibal hunt management TUI."""
+
+    TITLE = "Hannibal"
+
+    CSS = """
+    Screen {
+        layout: vertical;
+        background: $surface;
+    }
+
+    #context-bar {
+        height: 3;
+        background: $primary-background;
+        color: $text;
+        padding: 0 2;
+        border-bottom: solid $primary;
+    }
+
+    #activity-log {
+        height: 1fr;
+        margin: 0 1;
+        scrollbar-size: 1 1;
+    }
+
+    #input-container {
+        height: 3;
+        margin: 0 1 0 1;
+        border-top: solid $primary;
+    }
+
+    #hunt-input {
+        width: 1fr;
+    }
+
+    #status-bar {
+        height: 1;
+        background: $primary-background;
+        color: $text-muted;
+        padding: 0 2;
+        border-top: solid $primary;
+    }
+
+    .activity-info {
+        color: $text-muted;
+    }
+
+    .activity-finding {
+        color: $warning;
+    }
+
+    .activity-error {
+        color: $error;
+    }
+
+    .activity-action {
+        color: $accent;
+    }
+    """
+
+    BINDINGS = [
+        ("ctrl+c", "quit", "Quit"),
+        ("ctrl+p", "pause_resume", "Pause/Resume"),
+        ("ctrl+s", "stop_hunt", "Stop Hunt"),
+    ]
+
+    hunt_uuid: reactive[Optional[str]] = reactive(None)
+    hunt_status: reactive[str] = reactive("")
+
+    def __init__(self, sdk: Chariot, hunt_uuid: str = None, start_prompt: str = None,
+                 start_duration: str = '24h', start_scope: list = None):
+        super().__init__()
+        self.sdk = sdk
+        self._initial_uuid = hunt_uuid
+        self._start_prompt = start_prompt
+        self._start_duration = start_duration
+        self._start_scope = start_scope or []
+        self._prev_iteration_count = -1
+        self._prev_findings_count = -1
+        self._poll_interval = 5
+
+        try:
+            self.user_email, self.username = self.sdk.get_current_user()
+        except Exception:
+            self.user_email = 'unknown'
+            self.username = 'unknown'
+
+        self._account = getattr(self.sdk.keychain, '_account', None) or ''
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(id="context-bar")
+        yield RichLog(id="activity-log", highlight=True, markup=True, wrap=True)
+        with Container(id="input-container"):
+            yield Input(placeholder="Type a command... (/help for commands)", id="hunt-input")
+        yield Static(id="status-bar")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._update_context_bar()
+        log = self.query_one("#activity-log", RichLog)
+        log.write(HUNT_LOGO)
+        log.write("")
+
+        if self._initial_uuid:
+            self.hunt_uuid = self._initial_uuid
+            log.write(f"[dim]Connecting to hunt {self._initial_uuid}...[/dim]")
+            self._poll_hunt()
+        elif self._start_prompt:
+            log.write("[dim]Launching new hunt...[/dim]")
+            self._launch_hunt()
+        else:
+            log.write("[bold]Welcome to Hannibal[/bold]")
+            log.write("")
+            log.write("Start a hunt or connect to an existing one:")
+            log.write("  [cyan]/start[/cyan] <prompt>  — launch a new hunt")
+            log.write("  [cyan]/connect[/cyan] <uuid>  — connect to a running hunt")
+            log.write("  [cyan]/list[/cyan]            — show all hunts")
+            log.write("  [cyan]/help[/cyan]            — all commands")
+            log.write("")
+
+        self.query_one("#hunt-input").focus()
+        self._start_polling()
+
+    def _update_context_bar(self) -> None:
+        bar = self.query_one("#context-bar", Static)
+        parts = [f"[bold]Hannibal[/bold]"]
+        if self.user_email and self.user_email != 'unknown':
+            parts.append(f"[dim]user:[/dim] {self.user_email}")
+        if self._account:
+            parts.append(f"[dim]account:[/dim] {self._account}")
+        if self.hunt_uuid:
+            parts.append(f"[dim]hunt:[/dim] {self.hunt_uuid[:8]}...")
+        if self.hunt_status:
+            parts.append(STATUS_STYLE.get(self.hunt_status, self.hunt_status))
+        bar.update("  ".join(parts))
+
+    def _update_status_bar(self, hunt_data: dict = None) -> None:
+        bar = self.query_one("#status-bar", Static)
+        if not hunt_data:
+            bar.update("[dim]No active hunt · /start to begin · /help for commands[/dim]")
+            return
+        iterations = hunt_data.get('iterationCount', 0)
+        findings = hunt_data.get('findingsCount', 0)
+        expires = hunt_data.get('expiresAt', '')
+        remaining = ''
+        if expires:
+            try:
+                exp = datetime.fromisoformat(expires.replace('Z', '+00:00'))
+                delta = exp - datetime.now(timezone.utc)
+                hours = int(delta.total_seconds() // 3600)
+                mins = int((delta.total_seconds() % 3600) // 60)
+                if delta.total_seconds() > 0:
+                    remaining = f"{hours}h{mins}m remaining"
+                else:
+                    remaining = "expired"
+            except Exception:
+                remaining = ''
+        parts = [
+            f"iterations: {iterations}",
+            f"findings: {findings}",
+        ]
+        if remaining:
+            parts.append(remaining)
+        parts.append("/help for commands")
+        bar.update("[dim]" + " · ".join(parts) + "[/dim]")
+
+    @work(thread=True)
+    def _launch_hunt(self) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        try:
+            from datetime import timedelta
+            hours = _parse_duration_int(self._start_duration)
+            expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            body = {'prompt': self._start_prompt, 'expiresAt': expires_at}
+            if self._start_scope:
+                body['scope'] = self._start_scope
+
+            result = self.sdk.post('hunt', body)
+            self.hunt_uuid = result.get('uuid', '')
+            self.hunt_status = result.get('status', 'active')
+            self._update_context_bar()
+
+            log.write(f"[bold green]Hunt launched![/bold green]")
+            log.write(f"  [dim]UUID:[/dim]    {self.hunt_uuid}")
+            log.write(f"  [dim]Mandate:[/dim] {self._start_prompt}")
+            log.write(f"  [dim]Expires:[/dim] {expires_at}")
+            log.write("")
+            self._update_status_bar(result)
+        except Exception as e:
+            log.write(f"[bold red]Failed to launch hunt:[/bold red] {e}")
+
+    @work(thread=True)
+    def _poll_hunt(self) -> None:
+        if not self.hunt_uuid:
+            return
+        try:
+            resp = self.sdk.my({'key': f'#hunt#{self.hunt_uuid}'})
+            hunts = _extract_hunts(resp)
+            if not hunts:
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Hunt {self.hunt_uuid} not found.[/red]")
+                return
+            h = hunts[0]
+            self.hunt_status = h.get('status', '')
+            self._update_context_bar()
+            self._update_status_bar(h)
+            self._emit_changes(h)
+        except Exception:
+            pass
+
+    def _emit_changes(self, h: dict) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        iterations = h.get('iterationCount', 0)
+        findings = h.get('findingsCount', 0)
+
+        if iterations != self._prev_iteration_count and self._prev_iteration_count >= 0:
+            ts = time.strftime('%H:%M:%S')
+            log.write(f"[dim]{ts}[/dim]  [cyan]Iteration {iterations} started[/cyan]")
+
+        if findings != self._prev_findings_count and self._prev_findings_count >= 0:
+            ts = time.strftime('%H:%M:%S')
+            delta = findings - self._prev_findings_count
+            log.write(f"[dim]{ts}[/dim]  [bold yellow]⚠ {delta} new finding(s)[/bold yellow] (total: {findings})")
+
+        status = h.get('status', '')
+        if status in ('completed', 'stopped', 'expired', 'errored') and self.hunt_status != status:
+            ts = time.strftime('%H:%M:%S')
+            log.write(f"[dim]{ts}[/dim]  {STATUS_STYLE.get(status, status)}")
+            last_error = h.get('lastError', '')
+            if last_error:
+                log.write(f"  [red]{last_error}[/red]")
+
+        self._prev_iteration_count = iterations
+        self._prev_findings_count = findings
+
+    def _start_polling(self) -> None:
+        self.set_interval(self._poll_interval, self._poll_hunt)
+
+    @on(Input.Submitted, "#hunt-input")
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        text = event.value.strip()
+        if not text:
+            return
+        event.input.clear()
+        self._handle_command(text)
+
+    def _handle_command(self, text: str) -> None:
+        log = self.query_one("#activity-log", RichLog)
+
+        if text.startswith('/'):
+            parts = text[1:].split(None, 1)
+            cmd = parts[0].lower()
+            args = parts[1] if len(parts) > 1 else ''
+
+            if cmd == 'help':
+                self._show_help()
+            elif cmd == 'start':
+                if not args:
+                    log.write("[red]Usage: /start <prompt>[/red]")
+                    return
+                self._start_prompt = args
+                self._launch_hunt()
+            elif cmd == 'connect':
+                if not args:
+                    log.write("[red]Usage: /connect <uuid>[/red]")
+                    return
+                self.hunt_uuid = args.strip()
+                self._prev_iteration_count = -1
+                self._prev_findings_count = -1
+                log.write(f"[dim]Connecting to {self.hunt_uuid}...[/dim]")
+                self._poll_hunt()
+            elif cmd == 'list':
+                self._list_hunts()
+            elif cmd == 'pause':
+                self._set_status('paused')
+            elif cmd == 'resume':
+                self._set_status('active')
+            elif cmd == 'stop':
+                self._set_status('stopped')
+            elif cmd == 'status':
+                self._poll_hunt()
+            elif cmd == 'cost':
+                self._show_cost()
+            elif cmd == 'show':
+                self._show_details()
+            elif cmd in ('ask', 'marcus'):
+                if not args:
+                    log.write("[red]Usage: /ask <question>[/red]")
+                    return
+                self._ask_marcus(args)
+            elif cmd == 'quit' or cmd == 'exit':
+                self.exit()
+            elif cmd == 'clear':
+                log.clear()
+            else:
+                log.write(f"[red]Unknown command: /{cmd}[/red] — type /help for commands")
+        else:
+            log.write(f"[dim]Type /help for commands. Prefix commands with /[/dim]")
+
+    def _show_help(self) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        log.write("")
+        log.write("[bold]Hunt Commands[/bold]")
+        log.write("  [cyan]/start[/cyan]   <prompt>  Launch a new hunt")
+        log.write("  [cyan]/connect[/cyan] <uuid>   Connect to an existing hunt")
+        log.write("  [cyan]/list[/cyan]             List all hunts")
+        log.write("  [cyan]/show[/cyan]             Show current hunt details")
+        log.write("  [cyan]/status[/cyan]           Refresh hunt status")
+        log.write("  [cyan]/cost[/cyan]             Show AI cost breakdown")
+        log.write("")
+        log.write("[bold]Hunt Control[/bold]")
+        log.write("  [cyan]/pause[/cyan]            Pause the current hunt")
+        log.write("  [cyan]/resume[/cyan]           Resume a paused hunt")
+        log.write("  [cyan]/stop[/cyan]             Stop the hunt permanently")
+        log.write("")
+        log.write("[bold]General[/bold]")
+        log.write("[bold]Marcus AI[/bold]")
+        log.write("  [cyan]/ask[/cyan]    <question>  Ask Marcus a question")
+        log.write("  [cyan]/marcus[/cyan] <question>  Same as /ask")
+        log.write("")
+        log.write("[bold]General[/bold]")
+        log.write("  [cyan]/clear[/cyan]            Clear the activity log")
+        log.write("  [cyan]/quit[/cyan]             Exit (hunt continues running)")
+        log.write("")
+        log.write("[bold]Keyboard Shortcuts[/bold]")
+        log.write("  [cyan]Ctrl+P[/cyan]  Pause/Resume")
+        log.write("  [cyan]Ctrl+S[/cyan]  Stop hunt")
+        log.write("  [cyan]Ctrl+C[/cyan]  Quit")
+        log.write("")
+
+    @work(thread=True)
+    def _list_hunts(self) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        try:
+            resp = self.sdk.my({'key': '#hunt'})
+            hunts = _extract_hunts(resp)
+            if not hunts:
+                log.write("[dim]No hunts found.[/dim]")
+                return
+            log.write(f"[bold]{len(hunts)} hunt(s)[/bold]")
+            for h in hunts:
+                uuid = h.get('uuid', '?')
+                status = h.get('status', '?')
+                style = STATUS_STYLE.get(status, status)
+                prompt = (h.get('prompt', '') or '')[:50]
+                iters = h.get('iterationCount', 0)
+                finds = h.get('findingsCount', 0)
+                log.write(f"  {uuid[:12]}...  {style}  i={iters} f={finds}  {prompt}")
+        except Exception as e:
+            log.write(f"[red]Error listing hunts: {e}[/red]")
+
+    @work(thread=True)
+    def _set_status(self, new_status: str) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        if not self.hunt_uuid:
+            log.write("[red]No hunt connected. Use /connect <uuid> or /start <prompt>[/red]")
+            return
+        try:
+            result = self.sdk.put(f'hunt/{self.hunt_uuid}', {'status': new_status})
+            self.hunt_status = result.get('status', new_status)
+            self._update_context_bar()
+            ts = time.strftime('%H:%M:%S')
+            log.write(f"[dim]{ts}[/dim]  Hunt {STATUS_STYLE.get(new_status, new_status)}")
+            self._update_status_bar(result)
+        except Exception as e:
+            log.write(f"[red]Failed to {new_status} hunt: {e}[/red]")
+
+    @work(thread=True)
+    def _show_cost(self) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        if not self.hunt_uuid:
+            log.write("[red]No hunt connected.[/red]")
+            return
+        try:
+            result = self.sdk.get(f'hunt/{self.hunt_uuid}/cost')
+            total = result.get('total', {})
+            cost = total.get('cost', 0)
+            calls = total.get('call_count', 0)
+            input_tok = total.get('input_tokens', 0)
+            output_tok = total.get('output_tokens', 0)
+            log.write("")
+            log.write(f"[bold]AI Cost[/bold]  ${cost:.4f}")
+            log.write(f"  API calls:     {calls}")
+            log.write(f"  Input tokens:  {input_tok:,}")
+            log.write(f"  Output tokens: {output_tok:,}")
+
+            by_model = result.get('by_model') or []
+            if by_model:
+                log.write(f"  [dim]By model:[/dim]")
+                for m in by_model:
+                    log.write(f"    {m.get('model', '?')}: ${m.get('cost', 0):.4f} ({m.get('call_count', 0)} calls)")
+            log.write("")
+        except Exception as e:
+            log.write(f"[red]Failed to get cost: {e}[/red]")
+
+    @work(thread=True)
+    def _show_details(self) -> None:
+        log = self.query_one("#activity-log", RichLog)
+        if not self.hunt_uuid:
+            log.write("[red]No hunt connected.[/red]")
+            return
+        try:
+            resp = self.sdk.my({'key': f'#hunt#{self.hunt_uuid}'})
+            hunts = _extract_hunts(resp)
+            if not hunts:
+                log.write(f"[red]Hunt {self.hunt_uuid} not found.[/red]")
+                return
+            h = hunts[0]
+            log.write("")
+            log.write(f"[bold]Hunt Details[/bold]")
+            log.write(f"  UUID:        {h.get('uuid', '?')}")
+            log.write(f"  Status:      {STATUS_STYLE.get(h.get('status', ''), '?')}")
+            log.write(f"  Created:     {h.get('created', '?')}")
+            log.write(f"  Created By:  {h.get('createdBy', '?')}")
+            log.write(f"  Expires:     {h.get('expiresAt', '?')}")
+            log.write(f"  Agent:       {h.get('agent', 'hannibal')}")
+            log.write(f"  Iterations:  {h.get('iterationCount', 0)}")
+            log.write(f"  Findings:    {h.get('findingsCount', 0)}")
+            prompt = h.get('prompt', '')
+            if prompt:
+                log.write(f"  Mandate:     {prompt}")
+            scope = h.get('scope', [])
+            if scope:
+                log.write(f"  Scope:       {', '.join(scope)}")
+            finish = h.get('finishCriteria', '')
+            if finish:
+                log.write(f"  Finish:      {finish}")
+            last_error = h.get('lastError', '')
+            if last_error:
+                log.write(f"  Last Error:  [red]{last_error}[/red]")
+            log.write("")
+        except Exception as e:
+            log.write(f"[red]Error: {e}[/red]")
+
+    @work(thread=True)
+    def _ask_marcus(self, question: str) -> None:
+        """Send a question to Marcus and display the response."""
+        log = self.query_one("#activity-log", RichLog)
+        log.write(f"[dim]You:[/dim] {question}")
+        log.write("[dim]Marcus is thinking...[/dim]")
+        try:
+            result = self.sdk.agents.ask(question, mode='agent')
+            response = result.get('response', '')
+            if response:
+                log.write("")
+                log.write("[bold]Marcus:[/bold]")
+                for line in response.split('\n'):
+                    log.write(f"  {line}")
+                log.write("")
+            else:
+                log.write("[yellow]No response from Marcus.[/yellow]")
+        except Exception as e:
+            log.write(f"[red]Marcus error: {e}[/red]")
+
+    def action_pause_resume(self) -> None:
+        if self.hunt_status == 'active':
+            self._set_status('paused')
+        elif self.hunt_status == 'paused':
+            self._set_status('active')
+
+    def action_stop_hunt(self) -> None:
+        self._set_status('stopped')
+
+    def action_quit(self) -> None:
+        self.exit()
+
+
+def _extract_hunts(resp: dict) -> list:
+    """Extract hunt list from API response regardless of key name."""
+    if isinstance(resp, list):
+        return resp
+    for key in ('hunts', 'data'):
+        if key in resp and isinstance(resp[key], list):
+            return resp[key]
+    for key in resp:
+        if isinstance(resp[key], list):
+            return resp[key]
+    return []
+
+
+def _parse_duration_int(duration_str: str) -> int:
+    """Parse duration to hours."""
+    duration_str = duration_str.strip().lower()
+    if duration_str.endswith('h'):
+        return int(duration_str[:-1])
+    if duration_str.endswith('d'):
+        return int(duration_str[:-1]) * 24
+    return int(duration_str)
+
+
+def run_hunt_tui(sdk: Chariot, hunt_uuid: str = None, start_prompt: str = None,
+                 start_duration: str = '24h', start_scope: list = None) -> None:
+    """Launch the Hannibal hunt TUI."""
+    app = HuntApp(sdk, hunt_uuid=hunt_uuid, start_prompt=start_prompt,
+                  start_duration=start_duration, start_scope=start_scope)
+    app.run()

--- a/praetorian_cli/ui/hunt/app.py
+++ b/praetorian_cli/ui/hunt/app.py
@@ -156,7 +156,7 @@ class HuntApp(App):
         log.write(HUNT_BANNER)
         log.write("")
         log.write(HUNT_TITLE)
-        log.write(f"[dim]Praetorian Offensive Security Platform[/dim]")
+        log.write("[dim]Praetorian Offensive Security Platform[/dim]")
         log.write("")
 
         if self._initial_uuid:
@@ -179,7 +179,7 @@ class HuntApp(App):
 
     def _update_context_bar(self) -> None:
         bar = self.query_one("#context-bar", Static)
-        parts = [f"[bold]Hannibal[/bold]"]
+        parts = ["[bold]Hannibal[/bold]"]
         if self.user_email and self.user_email != 'unknown':
             parts.append(f"[dim]user:[/dim] {self.user_email}")
         if self._account:
@@ -398,7 +398,7 @@ class HuntApp(App):
             else:
                 log.write(f"[red]Unknown command: /{cmd}[/red] — type /help for commands")
         else:
-            log.write(f"[dim]Type /help for commands. Prefix commands with /[/dim]")
+            log.write("[dim]Type /help for commands. Prefix commands with /[/dim]")
 
     def _show_help(self) -> None:
         log = self.query_one("#activity-log", RichLog)

--- a/praetorian_cli/ui/hunt/app.py
+++ b/praetorian_cli/ui/hunt/app.py
@@ -130,6 +130,7 @@ class HuntApp(App):
         self._start_scope = start_scope or []
         self._prev_iteration_count = -1
         self._prev_findings_count = -1
+        self._invalid_uuid_logged = False
         self._poll_interval = 5
 
         try:
@@ -221,7 +222,6 @@ class HuntApp(App):
 
     @work(thread=True)
     def _launch_hunt(self) -> None:
-        log = self.query_one("#activity-log", RichLog)
         try:
             from datetime import timedelta
             hours = _parse_duration_int(self._start_duration)
@@ -231,18 +231,32 @@ class HuntApp(App):
                 body['scope'] = self._start_scope
 
             result = self.sdk.post('hunt', body)
+        except Exception as e:
+            def _fail():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[bold red]Failed to launch hunt:[/bold red] {e}")
+            self.call_from_thread(_fail)
+            return
+
+        def _apply():
             self.hunt_uuid = result.get('uuid', '')
             self.hunt_status = result.get('status', 'active')
+            # Reset per-hunt counters so /start after a previous hunt doesn't
+            # carry over stale iteration/finding deltas.
+            self._prev_iteration_count = -1
+            self._prev_findings_count = -1
+            self._invalid_uuid_logged = False
             self._update_context_bar()
 
-            log.write(f"[bold green]Hunt launched![/bold green]")
+            log = self.query_one("#activity-log", RichLog)
+            log.write("[bold green]Hunt launched![/bold green]")
             log.write(f"  [dim]UUID:[/dim]    {self.hunt_uuid}")
             log.write(f"  [dim]Mandate:[/dim] {self._start_prompt}")
             log.write(f"  [dim]Expires:[/dim] {expires_at}")
             log.write("")
             self._update_status_bar(result)
-        except Exception as e:
-            log.write(f"[bold red]Failed to launch hunt:[/bold red] {e}")
+
+        self.call_from_thread(_apply)
 
     @work(thread=True)
     def _poll_hunt(self) -> None:
@@ -251,17 +265,38 @@ class HuntApp(App):
         try:
             resp = self.sdk.my({'key': f'#hunt#{self.hunt_uuid}'})
             hunts = _extract_hunts(resp)
-            if not hunts:
+        except Exception as e:
+            def _log_error():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Polling error: {e}[/red]")
+            self.call_from_thread(_log_error)
+            return
+
+        if not hunts:
+            def _not_found():
+                # Only log "not found" once until the hunt resolves, so a
+                # bad/expired UUID doesn't spam the log every poll interval.
+                if self._invalid_uuid_logged:
+                    return
+                self._invalid_uuid_logged = True
                 log = self.query_one("#activity-log", RichLog)
                 log.write(f"[red]Hunt {self.hunt_uuid} not found.[/red]")
-                return
-            h = hunts[0]
+            self.call_from_thread(_not_found)
+            return
+
+        h = hunts[0]
+
+        def _apply():
+            self._invalid_uuid_logged = False
+            # Emit change notifications before updating hunt_status, since
+            # _emit_changes compares the incoming status against the
+            # previous self.hunt_status to detect status transitions.
+            self._emit_changes(h)
             self.hunt_status = h.get('status', '')
             self._update_context_bar()
             self._update_status_bar(h)
-            self._emit_changes(h)
-        except Exception:
-            pass
+
+        self.call_from_thread(_apply)
 
     def _emit_changes(self, h: dict) -> None:
         log = self.query_one("#activity-log", RichLog)
@@ -322,6 +357,7 @@ class HuntApp(App):
                 self.hunt_uuid = args.strip()
                 self._prev_iteration_count = -1
                 self._prev_findings_count = -1
+                self._invalid_uuid_logged = False
                 log.write(f"[dim]Connecting to {self.hunt_uuid}...[/dim]")
                 self._poll_hunt()
             elif cmd == 'list':
@@ -385,10 +421,18 @@ class HuntApp(App):
 
     @work(thread=True)
     def _list_hunts(self) -> None:
-        log = self.query_one("#activity-log", RichLog)
         try:
-            resp = self.sdk.my({'key': '#hunt'})
+            resp = self.sdk.my({'key': '#hunt'}, pages=100)
             hunts = _extract_hunts(resp)
+        except Exception as e:
+            def _err():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Error listing hunts: {e}[/red]")
+            self.call_from_thread(_err)
+            return
+
+        def _apply():
+            log = self.query_one("#activity-log", RichLog)
             if not hunts:
                 log.write("[dim]No hunts found.[/dim]")
                 return
@@ -401,33 +445,55 @@ class HuntApp(App):
                 iters = h.get('iterationCount', 0)
                 finds = h.get('findingsCount', 0)
                 log.write(f"  {uuid[:12]}...  {style}  i={iters} f={finds}  {prompt}")
-        except Exception as e:
-            log.write(f"[red]Error listing hunts: {e}[/red]")
+
+        self.call_from_thread(_apply)
 
     @work(thread=True)
     def _set_status(self, new_status: str) -> None:
-        log = self.query_one("#activity-log", RichLog)
         if not self.hunt_uuid:
-            log.write("[red]No hunt connected. Use /connect <uuid> or /start <prompt>[/red]")
+            def _no_hunt():
+                log = self.query_one("#activity-log", RichLog)
+                log.write("[red]No hunt connected. Use /connect <uuid> or /start <prompt>[/red]")
+            self.call_from_thread(_no_hunt)
             return
         try:
             result = self.sdk.put(f'hunt/{self.hunt_uuid}', {'status': new_status})
+        except Exception as e:
+            def _err():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Failed to {new_status} hunt: {e}[/red]")
+            self.call_from_thread(_err)
+            return
+
+        def _apply():
             self.hunt_status = result.get('status', new_status)
             self._update_context_bar()
             ts = time.strftime('%H:%M:%S')
+            log = self.query_one("#activity-log", RichLog)
             log.write(f"[dim]{ts}[/dim]  Hunt {STATUS_STYLE.get(new_status, new_status)}")
             self._update_status_bar(result)
-        except Exception as e:
-            log.write(f"[red]Failed to {new_status} hunt: {e}[/red]")
+
+        self.call_from_thread(_apply)
 
     @work(thread=True)
     def _show_cost(self) -> None:
-        log = self.query_one("#activity-log", RichLog)
         if not self.hunt_uuid:
-            log.write("[red]No hunt connected.[/red]")
+            def _no_hunt():
+                log = self.query_one("#activity-log", RichLog)
+                log.write("[red]No hunt connected.[/red]")
+            self.call_from_thread(_no_hunt)
             return
         try:
             result = self.sdk.get(f'hunt/{self.hunt_uuid}/cost')
+        except Exception as e:
+            def _err():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Failed to get cost: {e}[/red]")
+            self.call_from_thread(_err)
+            return
+
+        def _apply():
+            log = self.query_one("#activity-log", RichLog)
             total = result.get('total', {})
             cost = total.get('cost', 0)
             calls = total.get('call_count', 0)
@@ -441,28 +507,44 @@ class HuntApp(App):
 
             by_model = result.get('by_model') or []
             if by_model:
-                log.write(f"  [dim]By model:[/dim]")
+                log.write("  [dim]By model:[/dim]")
                 for m in by_model:
                     log.write(f"    {m.get('model', '?')}: ${m.get('cost', 0):.4f} ({m.get('call_count', 0)} calls)")
             log.write("")
-        except Exception as e:
-            log.write(f"[red]Failed to get cost: {e}[/red]")
+
+        self.call_from_thread(_apply)
 
     @work(thread=True)
     def _show_details(self) -> None:
-        log = self.query_one("#activity-log", RichLog)
         if not self.hunt_uuid:
-            log.write("[red]No hunt connected.[/red]")
+            def _no_hunt():
+                log = self.query_one("#activity-log", RichLog)
+                log.write("[red]No hunt connected.[/red]")
+            self.call_from_thread(_no_hunt)
             return
         try:
             resp = self.sdk.my({'key': f'#hunt#{self.hunt_uuid}'})
             hunts = _extract_hunts(resp)
-            if not hunts:
+        except Exception as e:
+            def _err():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Error: {e}[/red]")
+            self.call_from_thread(_err)
+            return
+
+        if not hunts:
+            def _not_found():
+                log = self.query_one("#activity-log", RichLog)
                 log.write(f"[red]Hunt {self.hunt_uuid} not found.[/red]")
-                return
-            h = hunts[0]
+            self.call_from_thread(_not_found)
+            return
+
+        h = hunts[0]
+
+        def _apply():
+            log = self.query_one("#activity-log", RichLog)
             log.write("")
-            log.write(f"[bold]Hunt Details[/bold]")
+            log.write("[bold]Hunt Details[/bold]")
             log.write(f"  UUID:        {h.get('uuid', '?')}")
             log.write(f"  Status:      {STATUS_STYLE.get(h.get('status', ''), '?')}")
             log.write(f"  Created:     {h.get('created', '?')}")
@@ -484,17 +566,30 @@ class HuntApp(App):
             if last_error:
                 log.write(f"  Last Error:  [red]{last_error}[/red]")
             log.write("")
-        except Exception as e:
-            log.write(f"[red]Error: {e}[/red]")
+
+        self.call_from_thread(_apply)
 
     @work(thread=True)
     def _ask_marcus(self, question: str) -> None:
         """Send a question to Marcus and display the response."""
-        log = self.query_one("#activity-log", RichLog)
-        log.write(f"[dim]You:[/dim] {question}")
-        log.write("[dim]Marcus is thinking...[/dim]")
+        def _echo_question():
+            log = self.query_one("#activity-log", RichLog)
+            log.write(f"[dim]You:[/dim] {question}")
+            log.write("[dim]Marcus is thinking...[/dim]")
+
+        self.call_from_thread(_echo_question)
+
         try:
             result = self.sdk.agents.ask(question, mode='agent')
+        except Exception as e:
+            def _err():
+                log = self.query_one("#activity-log", RichLog)
+                log.write(f"[red]Marcus error: {e}[/red]")
+            self.call_from_thread(_err)
+            return
+
+        def _apply():
+            log = self.query_one("#activity-log", RichLog)
             response = result.get('response', '')
             if response:
                 log.write("")
@@ -504,8 +599,8 @@ class HuntApp(App):
                 log.write("")
             else:
                 log.write("[yellow]No response from Marcus.[/yellow]")
-        except Exception as e:
-            log.write(f"[red]Marcus error: {e}[/red]")
+
+        self.call_from_thread(_apply)
 
     def action_pause_resume(self) -> None:
         if self.hunt_status == 'active':

--- a/praetorian_cli/ui/hunt/app.py
+++ b/praetorian_cli/ui/hunt/app.py
@@ -225,6 +225,18 @@ class HuntApp(App):
         try:
             from datetime import timedelta
             hours = _parse_duration_int(self._start_duration)
+            if hours <= 0:
+                def _invalid_duration():
+                    log = self.query_one("#activity-log", RichLog)
+                    log.write("[bold red]Duration must be positive[/bold red]")
+                self.call_from_thread(_invalid_duration)
+                return
+            if hours > 72:
+                def _invalid_duration():
+                    log = self.query_one("#activity-log", RichLog)
+                    log.write("[bold red]Duration cannot exceed 72 hours[/bold red]")
+                self.call_from_thread(_invalid_duration)
+                return
             expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
             body = {'prompt': self._start_prompt, 'expiresAt': expires_at}
             if self._start_scope:
@@ -404,7 +416,6 @@ class HuntApp(App):
         log.write("  [cyan]/resume[/cyan]           Resume a paused hunt")
         log.write("  [cyan]/stop[/cyan]             Stop the hunt permanently")
         log.write("")
-        log.write("[bold]General[/bold]")
         log.write("[bold]Marcus AI[/bold]")
         log.write("  [cyan]/ask[/cyan]    <question>  Ask Marcus a question")
         log.write("  [cyan]/marcus[/cyan] <question>  Same as /ask")


### PR DESCRIPTION
> **PR Stack (10/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> 3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)
> 4. #268 Knossos, Aegis management (st7-st9)
> 5. #269 Red Team CLI (st5)
> 6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> 8. #272 share, leaderboard, misc, multipart (st18-st21)
> 9. #244 skills, risk-status, conversation UX
> **10. #243 Hannibal hunt CLI + TUI** (this PR)
> 11. #228 Marcus terminal hardening
> 12. #226 module management system


## Summary

- **`guard hunt` command group** — full lifecycle management for Hannibal persistent hunting agents: `start`, `list`, `show`, `pause`, `resume`, `stop`, `delete`, `cost`, `watch`, `active`
- **`guard hunt interactive`** — Claude Code-style TUI with real-time status polling, slash commands (`/start`, `/pause`, `/resume`, `/stop`, `/cost`, `/ask`), keyboard shortcuts (Ctrl+P, Ctrl+S), and integrated Marcus AI via `/ask`
- **`guard hunt active`** — quick background status check for running hunts with reconnect instructions
- **Console integration** — `hunt` command in the `guard console` TUI now manages hunts instead of aliasing critfinder
- **Critfinder deprecated** — `guard critfinder` shows deprecation warning pointing to `guard hunt start`
- **Background/reconnect workflow** — exit TUI with Ctrl+C (hunt keeps running), check with `guard hunt active`, reconnect with `guard hunt interactive <uuid>`

### New files
- `praetorian_cli/handlers/hunt.py` — CLI command group (11 subcommands)
- `praetorian_cli/ui/hunt/app.py` — Textual-based interactive TUI with Guard helmet banner

### Modified files
- `praetorian_cli/main.py` — register hunt import
- `praetorian_cli/handlers/critfinder.py` — deprecation warning
- `praetorian_cli/ui/console/commands/marcus.py` — hunt management in console TUI

### Tested end-to-end against Guard API
- `guard hunt start` — creates hunt, returns UUID ✅
- `guard hunt list` — lists hunts with status/iterations/findings ✅
- `guard hunt show <uuid>` — detailed hunt view ✅
- `guard hunt pause/resume/stop` — status transitions ✅
- `guard hunt active` — background check ✅
- `guard hunt cost` — AI cost breakdown ✅
- `guard hunt interactive` — TUI launches and connects ✅
- `guard critfinder` — deprecation warning shown ✅

## Test plan

- [x] `guard hunt --help` shows all subcommands
- [x] `guard hunt start "test"` creates a hunt against live API
- [x] `guard hunt list` returns hunts
- [x] `guard hunt show <uuid>` displays details
- [x] `guard hunt pause/resume/stop` transitions work
- [x] `guard hunt active` shows running hunts
- [x] `guard hunt cost <uuid>` returns cost data
- [x] `guard hunt interactive --help` loads correctly
- [x] `guard critfinder` shows deprecation warning
- [x] Python imports clean (`from praetorian_cli.ui.hunt.app import HuntApp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)