### PR TITLE
chore: remove `guard purge` command (backend endpoint removed)

### DIFF
--- a/praetorian_cli/handlers/delete.py
+++ b/praetorian_cli/handlers/delete.py
@@ -115,23 +115,6 @@ def file(chariot, filepath):
     chariot.files.delete(filepath)
 
 
-# Special command for deleting your account and all related information.
-@chariot.command()
-@cli_handler
-def purge(controller):
-    """ Delete account and all related information
-
-    Example usage:
-        - guard purge
-    """
-    if click.confirm('This will delete all your data and revoke access, are you sure?', default=False):
-        controller.purge()
-    else:
-        click.echo('Purge cancelled')
-        return
-    click.echo('Account deleted successfully')
-
-
 @delete.command()
 @cli_handler
 @click.argument('name', required=True)

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -267,9 +267,6 @@ class Chariot:
         filename = f'{id}.json' if type == 'cve' else id
         return json.loads(self.download(f'enrichments/{type}/{filename}', True).decode('utf-8'))
 
-    def purge(self):
-        self.chariot_request('DELETE', self.url('/account/purge'))
-
     def agent(self, agent: str, body: dict) -> dict:
         body = body | dict(agent=agent)
         resp = self.chariot_request('PUT', self.url('/agent'), json=body)

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -418,7 +418,6 @@ class TestZCli:
 
         self.verify('search --help', ignore_stdout=True)
         self.verify('script --help', ignore_stdout=True)
-        self.verify('purge --help', ignore_stdout=True)
 
         self.verify('agent --help', ignore_stdout=True)
         self.verify('agent affiliation --help', ignore_stdout=True)


### PR DESCRIPTION
## Summary

Removes the `guard purge` CLI command and its SDK method. The backing endpoint (`DELETE /account/purge`) is being removed from the Guard platform in https://github.com/praetorian-inc/guard/pull/6489.

**Why removed rather than migrated:** the legacy endpoint performed a *partial* purge — S3 file deletion + Cognito deactivation only, leaving DynamoDB, Neo4j, SSM, API keys, and SSO trust intact — while this command told the user "Account deleted successfully". Full tenant deletion is now a Praetorian-SuperAdmin-administered flow (`/account/deletion`, with audit record + verified deletion certificate) that is intentionally not self-service, so there is no replacement endpoint for a customer-facing command.

## Changes
- `praetorian_cli/handlers/delete.py` — remove the standalone `purge` command
- `praetorian_cli/sdk/chariot.py` — remove the `purge()` SDK method
- `praetorian_cli/sdk/test/test_z_cli.py` — remove the `purge --help` verification entry

Repo-wide sweep confirms no other references (`docs/`, `README.md`, `CHANGELOG.md` clean). Package imports verified clean; `guard --help` renders without the command.

## Sequencing note
Released CLI versions in the wild will receive a 404 on `guard purge` once the backend change deploys — that is the intended outcome of removing the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)