### PR TITLE
fix upload files

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -61,16 +61,16 @@ def asset(sdk, identifier, group, asset_type, status, surface, resource_type):
 @add.command()
 @cli_handler
 @click.argument('path')
-@click.option('-n', '--name', help='The file name in Guard. Default: the full path of the uploaded file')
-def file(sdk, path, name):
+@click.option('-n', '--name', help='Destination path in Guard storage. Without this flag, the file is placed automatically')
+@click.option('--public', 'is_public', is_flag=True, default=False, help='Share file with the customer (Praetorian users only)')
+def file(sdk, path, name, is_public):
     """ Upload a file
 
     This commands takes the path to a local file and uploads it to the
     Guard file system. The Guard file system is where the platform
     stores proofs of exploit, risk definitions, and other supporting data.
 
-    User files reside in the "home/" folder. Those files appear in the app
-    at https://guard.praetorian.com/app/files
+    User files appear in the app at https://guard.praetorian.com/app/files
 
     \b
     Arguments:
@@ -79,10 +79,28 @@ def file(sdk, path, name):
     \b
     Example usages:
         - guard add file ./file.txt
-        - guard add file ./file.txt --name "home/file.txt"
+        - guard add file ./file.txt --public
+        - guard add file ./file.txt --name "custom/path/file.txt"
     """
     try:
-        sdk.files.add(path, name)
+        expanded = os.path.expanduser(path)
+        filename = os.path.basename(expanded)
+        praetorian = False
+
+        if name:
+            dest_path = name
+        elif sdk.is_praetorian_user():
+            if is_public:
+                dest_path = f'home/shared-with/{filename}'
+            else:
+                dest_path = f'home/internal/{filename}'
+                praetorian = True
+        else:
+            dest_path = f'home/shared-by/{filename}'
+
+        sdk.files.add(expanded, dest_path, praetorian=praetorian)
+        size = os.path.getsize(expanded)
+        click.echo(f'Uploaded {expanded} -> {dest_path} ({size} bytes)')
     except Exception as e:
         error(f'Unable to upload file {path}. Error: {e}')
 

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -222,21 +222,22 @@ class Chariot:
         process_failure(resp)
         return resp.json()
 
-    def upload(self, local_filepath: str, chariot_filepath: str = None) -> dict:
+    def upload(self, local_filepath: str, chariot_filepath: str = None, praetorian: bool = False) -> dict:
         if not chariot_filepath:
             chariot_filepath = local_filepath
         with open(local_filepath, 'rb') as content:
-            resp = self._upload(chariot_filepath, content)
+            resp = self._upload(chariot_filepath, content, praetorian=praetorian)
         return resp
 
-    def _upload(self, chariot_filepath: str, content: str) -> dict:
-        # Encrypted files have _encrypted/ prefix in the path. Encrypted files do not use presigned URLs.
-        # Instead, they use the /encrypted-file endpoint that directly gets and puts content.
+    def _upload(self, chariot_filepath: str, content: str, praetorian: bool = False) -> dict:
         if is_encrypted_partition(chariot_filepath):
             return self.chariot_request('PUT', self.url('/encrypted-file'), params=dict(name=chariot_filepath), data=content)
 
-        # Regular files use presigned URLs
-        presigned_url = self.chariot_request('PUT', self.url('/file'), params=dict(name=chariot_filepath))
+        params = dict(name=chariot_filepath)
+        if praetorian:
+            params['praetorian'] = 'true'
+
+        presigned_url = self.chariot_request('PUT', self.url('/file'), params=params)
         process_failure(presigned_url)
         resp = requests.put(presigned_url.json()['url'], data=content, timeout=DEFAULT_HTTP_TIMEOUT)
         process_failure(resp)
@@ -288,7 +289,7 @@ class Chariot:
         return self.keychain.base_url() + path
 
     def is_praetorian_user(self) -> bool:
-        return self.keychain.username().endswith('@praetorian.com')
+        return (self.keychain.username() or self.keychain.account or '').endswith('@praetorian.com')
 
     def start_mcp_server(self, allowable_tools=None):
         """ Start MCP server exposing SDK methods as tools

--- a/praetorian_cli/sdk/entities/files.py
+++ b/praetorian_cli/sdk/entities/files.py
@@ -8,7 +8,7 @@ class Files:
     def __init__(self, api):
         self.api = api
 
-    def add(self, local_filepath, chariot_filepath=None):
+    def add(self, local_filepath, chariot_filepath=None, praetorian=False):
         """
         Upload a file to Chariot storage.
 
@@ -16,10 +16,12 @@ class Files:
         :type local_filepath: str
         :param chariot_filepath: Optional destination path in Chariot storage. If None, uses the local filename
         :type chariot_filepath: str or None
+        :param praetorian: If True, upload to the scoped partition (requires praetorian user)
+        :type praetorian: bool
         :return: The uploaded file entity
         :rtype: dict
         """
-        return self.api.upload(local_filepath, chariot_filepath)
+        return self.api.upload(local_filepath, chariot_filepath, praetorian=praetorian)
 
     def save(self, chariot_filepath, download_directory=os.getcwd()):
         """


### PR DESCRIPTION
## Summary
  - Fix `guard add file` to match Guard UI upload conventions so files appear in the platform
  - Auto-compute destination path based on user type (customer vs praetorian) and visibility
  - Thread `praetorian` query param to backend for scoped partition uploads (`file.go:56-62`)
  - Fix `is_praetorian_user()` crash when `keychain.username()` returns None (API key auth)
  - Add `--public` flag for praetorian users to share files with customers
  - Print verbose output (destination path + size) on successful upload