### PR TITLE
avoid customer users being treated as praetorian

### DIFF
--- a/praetorian_cli/handlers/add.py
+++ b/praetorian_cli/handlers/add.py
@@ -88,6 +88,10 @@ def file(sdk, path, name, is_public):
         praetorian = False
 
         if name:
+            # if name is provided, use it as the destination path regardless of whether
+            # the path follows the Guard file system filepath conventions. If it does not
+            # follow the conventions, it will still be uploaded but it will not be
+            # displayed in the Guard app UI.
             dest_path = name
         elif sdk.is_praetorian_user():
             if is_public:

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -289,7 +289,7 @@ class Chariot:
         return self.keychain.base_url() + path
 
     def is_praetorian_user(self) -> bool:
-        return (self.keychain.username() or self.keychain.account or '').endswith('@praetorian.com')
+        return (self.keychain.username() or '').endswith('@praetorian.com')
 
     def start_mcp_server(self, allowable_tools=None):
         """ Start MCP server exposing SDK methods as tools


### PR DESCRIPTION
## Summary (required)

- `keychain.account` holds tenant email addresses, such as chariot+fox@praetorian.com. So, the original logic would return `True` for someone from Fox operating on the tenant.
- This change stops that problem. However, it also means that from the CLI, all Praetorian users will not be regarded as Praetorian, since we all are using API key after username-password login is removed for us.
- I don't have a better solution at this point.
- 
## JIRA (required)

- Add reference to the JIRA ticket. It helps connect JIRA with this PR.
