### PR TITLE
feat: publish to PyPI from GitHub Actions via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,126 @@
+name: Publish to PyPI
+
+# Manually publish the current praetorian-cli version (from setup.cfg) to PyPI
+# using PyPI Trusted Publishing (OIDC) -- no API token is stored anywhere.
+#
+# To release:
+#   1. Merge the version bump (setup.cfg + CHANGELOG.md) to main.
+#   2. Actions tab -> "Publish to PyPI" -> "Run workflow" (from main).
+#
+# One-time setup required before the first run (see the PR description / docs):
+#   - PyPI:   add a Trusted Publisher for this repo, workflow "publish-pypi.yml",
+#             environment "pypi".
+#   - GitHub: create an Environment named "pypi" (optionally with required
+#             reviewers to add a manual approval gate).
+
+on:
+  workflow_dispatch:
+
+# Least privilege by default; jobs opt into more where needed.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+
+      - name: Resolve version and guard against duplicate
+        id: version
+        run: |
+          VERSION=$(grep -E '^version' setup.cfg | head -1 | sed 's/.*=[[:space:]]*//')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from setup.cfg"
+            exit 1
+          fi
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if curl -sf "https://pypi.org/pypi/praetorian-cli/$VERSION/json" >/dev/null; then
+            echo "::error::praetorian-cli $VERSION is already on PyPI. Bump the version in setup.cfg first."
+            exit 1
+          fi
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check artifacts
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The "pypi" environment must exist in repo Settings -> Environments and be
+    # named in the PyPI Trusted Publisher config. Add required reviewers here for
+    # a manual approval gate before anything is pushed to PyPI.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/praetorian-cli/${{ needs.build.outputs.version }}/
+    permissions:
+      id-token: write   # REQUIRED for Trusted Publishing (OIDC). No token needed.
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+
+  tag:
+    name: Tag release
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # to push the vX.Y.Z tag
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists on origin; skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION (published to PyPI)"
+          git push origin "v$VERSION"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     - [SDK](#sdk)
     - [Developing external scripts](#developing-external-scripts)
     - [Contributing](#contributing)
+    - [Releasing](#releasing)
     - [Support](#support)
     - [License](#license)
 - [Backwards Compatibility](#backwards-compatibility)
@@ -354,6 +355,12 @@ repository and following the
 to create pull requests.
 
 By contributing, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Releasing
+
+Maintainers publish new versions to PyPI from GitHub Actions using PyPI Trusted
+Publishing — no API tokens required. See
+[the documentation on publishing](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/publishing.md).
 
 ## Support
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,82 @@
+# Publishing to PyPI
+
+The CLI is published to [PyPI](https://pypi.org/project/praetorian-cli/) from GitHub
+Actions using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+(OpenID Connect). No API token is stored anywhere — PyPI trusts this repository
+directly, and each run gets a short-lived credential.
+
+The workflow lives at
+[`.github/workflows/publish-pypi.yml`](../.github/workflows/publish-pypi.yml) and is
+triggered manually.
+
+## Cutting a release
+
+1. **Bump the version.** Update `version` in [`setup.cfg`](../setup.cfg) and add an entry
+   to [`CHANGELOG.md`](../CHANGELOG.md). Open a PR and merge it to `main`.
+2. **Run the workflow.** Go to the **Actions** tab → **Publish to PyPI** → **Run
+   workflow**, and run it from `main`.
+3. **Approve** the deployment if the `pypi` environment has required reviewers
+   (see below).
+
+The workflow then:
+
+- reads the version from `setup.cfg`;
+- fails fast if that version is already on PyPI (bump it first);
+- builds the sdist and wheel and runs `twine check`;
+- publishes to PyPI via OIDC; and
+- creates and pushes a `vX.Y.Z` git tag.
+
+That's the whole release process — there is no local script to run and no credentials
+to manage on your machine.
+
+## One-time setup
+
+These steps only need to be done once (they are already in place for the live project;
+this section documents them for reference and for standing up the flow elsewhere).
+
+### 1. Trusted Publisher on PyPI
+
+As a maintainer of the project, go to
+**[Manage project → Settings → Publishing](https://pypi.org/manage/project/praetorian-cli/settings/publishing/)**
+and add a new GitHub publisher with these exact values:
+
+| Field           | Value              |
+| --------------- | ------------------ |
+| Owner           | `praetorian-inc`   |
+| Repository name | `praetorian-cli`   |
+| Workflow name   | `publish-pypi.yml` |
+| Environment name| `pypi`             |
+
+No token is generated — this is the only credential configuration needed.
+
+### 2. `pypi` environment on GitHub
+
+In the repository, go to **Settings → Environments → New environment** and create one
+named **`pypi`** (it must match the environment name above).
+
+This is also where you add a **manual approval gate**: under **Required reviewers**, add
+the people allowed to approve a publish. When set, every run pauses for approval before
+the `publish` job pushes anything to PyPI.
+
+## How it works
+
+The workflow uses three jobs:
+
+| Job       | Permission        | Purpose                                                        |
+| --------- | ----------------- | ------------------------------------------------------------- |
+| `build`   | `contents: read`  | Resolve/guard the version, build the sdist + wheel, `twine check`. |
+| `publish` | `id-token: write` | Publish to PyPI via Trusted Publishing (OIDC). No token used.  |
+| `tag`     | `contents: write` | Push the `vX.Y.Z` release tag after a successful publish.      |
+
+All actions are pinned to commit SHAs, and each job runs with
+[Harden-Runner](https://github.com/step-security/harden-runner) in audit mode, matching
+the repository's supply-chain security posture.
+
+## Notes
+
+- The **Run workflow** button only appears once the workflow file is present on the
+  default branch (`main`).
+- The version guard means re-running the workflow without bumping the version is a safe
+  no-op — it fails before uploading rather than producing a confusing PyPI error.
+- Publishing no longer requires a PyPI API token or a `~/.pypirc` file on any developer
+  machine.


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow to publish `praetorian-cli` to PyPI using **PyPI Trusted Publishing (OIDC)** — no API token stored anywhere. This replaces the manual local publish script (`chariot-devops/deploy-scripts/cli/publish-praetorian-cli.sh`).

## Changes

- **`.github/workflows/publish-pypi.yml`** — manually-triggered (`workflow_dispatch`) release workflow:
  - `build` — resolves the version from `setup.cfg`, **fails fast if that version is already on PyPI**, builds the sdist + wheel, runs `twine check`.
  - `publish` — publishes via Trusted Publishing (`id-token: write`, `pypi` environment).
  - `tag` — pushes a `vX.Y.Z` git tag after a successful publish.
  - All actions SHA-pinned; Harden-Runner (audit) on every job, matching the repo's supply-chain posture.
- **`docs/publishing.md`** — release process + one-time setup reference.
- **`README.md`** — links the new publishing docs from the Developers section.

## ⚠️ Required one-time setup before the first run

These are browser-only and must be done by a PyPI maintainer / repo admin:

1. **PyPI Trusted Publisher** (Manage project → Settings → Publishing):
   | Field | Value |
   |-------|-------|
   | Owner | `praetorian-inc` |
   | Repository name | `praetorian-cli` |
   | Workflow name | `publish-pypi.yml` |
   | Environment name | `pypi` |
2. **GitHub environment** named `pypi` (Settings → Environments), optionally with required reviewers for a manual approval gate.

Note: the **Run workflow** button only appears once this workflow is on `main`.

## Follow-ups (separate)

- Revoke the existing PyPI API token once this flow is confirmed working.
- Retire `publish-praetorian-cli.sh` in the `chariot-devops` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)