### PR TITLE
feat: add hunt management commands [10T-680]

### DIFF
--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -14,8 +14,8 @@ def hunt():
 @hunt.command()
 @cli_handler
 @click.option('-p', '--prompt', required=True, help='The hunt objective / central mandate')
-@click.option('-e', '--expires', type=int, default=72, show_default=True,
-              help='Hours until the hunt expires (max 72)')
+@click.option('-e', '--expires', type=click.IntRange(1, 72), default=72, show_default=True,
+              help='Hours until the hunt expires (1-72)')
 @click.option('-a', '--agent', type=click.Choice(['hannibal', 'hannibal-cloud', 'hannibal-webapp', 'hannibal-llm']),
               default='hannibal', show_default=True, help='Agent type')
 @click.option('-s', '--scope', multiple=True, help='Target asset keys to restrict the hunt (repeatable)')

--- a/praetorian_cli/handlers/hunt.py
+++ b/praetorian_cli/handlers/hunt.py
@@ -1,0 +1,156 @@
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json, render_list_results, pagination_size
+
+
+@chariot.group()
+def hunt():
+    """Manage Hannibal hunts — launch, monitor, and control automated vulnerability discovery."""
+    pass
+
+
+@hunt.command()
+@cli_handler
+@click.option('-p', '--prompt', required=True, help='The hunt objective / central mandate')
+@click.option('-e', '--expires', type=int, default=72, show_default=True,
+              help='Hours until the hunt expires (max 72)')
+@click.option('-a', '--agent', type=click.Choice(['hannibal', 'hannibal-cloud', 'hannibal-webapp', 'hannibal-llm']),
+              default='hannibal', show_default=True, help='Agent type')
+@click.option('-s', '--scope', multiple=True, help='Target asset keys to restrict the hunt (repeatable)')
+@click.option('--scope-level', type=click.Choice(['normal', 'strict']), default='normal', show_default=True)
+@click.option('--aggressiveness', type=click.Choice(['cautious', 'balanced', 'aggressive']),
+              default='balanced', show_default=True)
+def launch(sdk, prompt, expires, agent, scope, scope_level, aggressiveness):
+    """Launch a new hunt against the current account.
+
+    Example usages:
+        guard hunt launch --prompt "Find XSS vulnerabilities in web applications"
+        guard hunt launch --prompt "Test API endpoints" --agent hannibal-webapp --expires 24
+        guard hunt launch --prompt "Cloud misconfigs" --agent hannibal-cloud --scope "#asset#example.com#1.2.3.4"
+    """
+    result = sdk.hunts.create(
+        prompt=prompt,
+        expires_hours=expires,
+        agent=agent,
+        scope=list(scope) if scope else None,
+        scope_level=scope_level,
+        aggressiveness=aggressiveness,
+    )
+    print_json(result)
+
+
+@hunt.command('list')
+@cli_handler
+@click.option('-s', '--status', type=click.Choice(['active', 'paused', 'completed', 'stopped', 'expired', 'errored']),
+              default=None, help='Filter by hunt status')
+@click.option('-d', '--details', is_flag=True, default=False, help='Show detailed information')
+@click.option('-p', '--page', type=click.Choice(['first', 'all']), default='first', show_default=True)
+def list_hunts(sdk, status, details, page):
+    """List hunts for the current account.
+
+    Example usages:
+        guard hunt list
+        guard hunt list --status active --details
+        guard hunt list --page all
+    """
+    render_list_results(sdk.hunts.list(status=status, pages=pagination_size(page)), details)
+
+
+@hunt.command()
+@cli_handler
+@click.argument('uuid')
+def status(sdk, uuid):
+    """Show detailed status of a hunt.
+
+    Argument:
+        UUID: the hunt's UUID
+
+    Example usage:
+        guard hunt status a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    """
+    result = sdk.hunts.get(uuid)
+    if not result:
+        click.secho(f'Hunt {uuid} not found.', fg='red', err=True)
+        return
+    fields = {
+        'uuid': result.get('uuid', result.get('key', '').replace('#hunt#', '')),
+        'status': result.get('status'),
+        'agent': result.get('agent'),
+        'prompt': result.get('prompt', '')[:120],
+        'iterations': result.get('iterationCount', 0),
+        'findings': result.get('findingsCount', 0),
+        'created': result.get('created'),
+        'expires': result.get('expiresAt'),
+        'lastError': result.get('lastError', ''),
+    }
+    print_json(fields)
+
+
+@hunt.command()
+@cli_handler
+@click.argument('uuid')
+def stop(sdk, uuid):
+    """Stop a running hunt permanently.
+
+    Argument:
+        UUID: the hunt's UUID
+
+    Example usage:
+        guard hunt stop a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    """
+    result = sdk.hunts.stop(uuid)
+    click.echo(f'Hunt {uuid} stopped.')
+    print_json(result)
+
+
+@hunt.command()
+@cli_handler
+@click.argument('uuid')
+def pause(sdk, uuid):
+    """Pause an active hunt.
+
+    Argument:
+        UUID: the hunt's UUID
+
+    Example usage:
+        guard hunt pause a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    """
+    result = sdk.hunts.pause(uuid)
+    click.echo(f'Hunt {uuid} paused.')
+    print_json(result)
+
+
+@hunt.command()
+@cli_handler
+@click.argument('uuid')
+def resume(sdk, uuid):
+    """Resume a paused hunt.
+
+    Argument:
+        UUID: the hunt's UUID
+
+    Example usage:
+        guard hunt resume a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    """
+    result = sdk.hunts.resume(uuid)
+    click.echo(f'Hunt {uuid} resumed.')
+    print_json(result)
+
+
+@hunt.command('delete')
+@cli_handler
+@click.argument('uuid')
+@click.confirmation_option(prompt='This will delete the hunt and its artifacts. Findings are preserved. Continue?')
+def delete_hunt(sdk, uuid):
+    """Delete a hunt. Findings are preserved.
+
+    Argument:
+        UUID: the hunt's UUID
+
+    Example usage:
+        guard hunt delete a1b2c3d4-e5f6-7890-abcd-ef1234567890
+    """
+    sdk.hunts.delete(uuid)
+    click.echo(f'Hunt {uuid} deleted.')

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -11,6 +11,7 @@ import praetorian_cli.handlers.engagement
 import praetorian_cli.handlers.find
 import praetorian_cli.handlers.export
 import praetorian_cli.handlers.get
+import praetorian_cli.handlers.hunt
 import praetorian_cli.handlers.run
 import praetorian_cli.handlers.imports
 import praetorian_cli.handlers.link

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -12,6 +12,7 @@ from praetorian_cli.sdk.entities.conversations import Conversations
 from praetorian_cli.sdk.entities.credentials import Credentials
 from praetorian_cli.sdk.entities.definitions import Definitions
 from praetorian_cli.sdk.entities.files import Files
+from praetorian_cli.sdk.entities.hunts import Hunts
 from praetorian_cli.sdk.entities.integrations import Integrations
 from praetorian_cli.sdk.entities.jobs import Jobs
 from praetorian_cli.sdk.entities.keys import Keys
@@ -45,6 +46,7 @@ class Chariot:
         self.integrations = Integrations(self)
         self.jobs = Jobs(self)
         self.files = Files(self)
+        self.hunts = Hunts(self)
         self.definitions = Definitions(self)
         self.attributes = Attributes(self)
         self.search = Search(self)

--- a/praetorian_cli/sdk/entities/hunts.py
+++ b/praetorian_cli/sdk/entities/hunts.py
@@ -1,6 +1,11 @@
 from datetime import datetime, timezone, timedelta
 
 
+def _strip_hunt_prefix(uuid):
+    """Strip #hunt# prefix if present, returning the bare UUID."""
+    return uuid.replace('#hunt#', '') if uuid.startswith('#hunt#') else uuid
+
+
 class Hunts:
     """Hunt management methods, accessed via sdk.hunts."""
 
@@ -13,15 +18,17 @@ class Hunts:
         """Create and launch a new hunt.
 
         :param prompt: The hunt objective
-        :param expires_hours: Hours until expiry (max 72)
+        :param expires_hours: Hours until expiry (1-72)
         :param agent: hannibal, hannibal-cloud, hannibal-webapp, hannibal-llm
         :param scope: Optional list of target asset keys
         :param scope_level: normal or strict
         :param aggressiveness: cautious, balanced, or aggressive
         :return: The created hunt object
         """
-        hours = min(expires_hours, 72)
-        expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+        if expires_hours < 1 or expires_hours > 72:
+            raise ValueError(f'expires_hours must be between 1 and 72, got {expires_hours}')
+
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=expires_hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
 
         body = {
             'prompt': prompt,
@@ -61,7 +68,7 @@ class Hunts:
         :param uuid: Hunt UUID (with or without #hunt# prefix)
         :return: Hunt dict or None
         """
-        key = f'#hunt#{uuid}' if not uuid.startswith('#hunt#') else uuid
+        key = f'#hunt#{_strip_hunt_prefix(uuid)}'
         return self.api.search.by_exact_key(key)
 
     def stop(self, uuid):
@@ -79,12 +86,14 @@ class Hunts:
     def delete(self, uuid):
         """Delete a hunt and its artifacts. Findings are preserved."""
         from praetorian_cli.sdk.chariot import process_failure
-        resp = self.api.chariot_request('DELETE', self.api.url(f'/hunt/{uuid}'))
+        bare = _strip_hunt_prefix(uuid)
+        resp = self.api.chariot_request('DELETE', self.api.url(f'/hunt/{bare}'))
         process_failure(resp)
         return resp.json()
 
     def _update_status(self, uuid, status):
         from praetorian_cli.sdk.chariot import process_failure
-        resp = self.api.chariot_request('PUT', self.api.url(f'/hunt/{uuid}'), json={'status': status})
+        bare = _strip_hunt_prefix(uuid)
+        resp = self.api.chariot_request('PUT', self.api.url(f'/hunt/{bare}'), json={'status': status})
         process_failure(resp)
         return resp.json()

--- a/praetorian_cli/sdk/entities/hunts.py
+++ b/praetorian_cli/sdk/entities/hunts.py
@@ -42,17 +42,18 @@ class Hunts:
         return self.api.post('hunt', body)
 
     def list(self, status=None, pages=1):
-        """List hunts for the current account via graph search.
+        """List hunts for the current account.
+
+        Hunts are graph-only (Neo4j), queried via the search endpoint.
 
         :param status: Optional status filter (active, paused, completed, stopped, expired, errored)
         :param pages: Number of pages to fetch
         :return: Tuple of (list of hunts, offset)
         """
-        result = self.api.my({'key': '#hunt#'}, pages=pages)
-        data = result.get('data', [])
+        data, offset = self.api.search.by_key_prefix('#hunt#', pages=pages)
         if status:
             data = [h for h in data if h.get('status') == status]
-        return data, result.get('offset')
+        return data, offset
 
     def get(self, uuid):
         """Get a single hunt by UUID.
@@ -61,9 +62,7 @@ class Hunts:
         :return: Hunt dict or None
         """
         key = f'#hunt#{uuid}' if not uuid.startswith('#hunt#') else uuid
-        result = self.api.my({'key': key})
-        data = result.get('data', [])
-        return data[0] if data else None
+        return self.api.search.by_exact_key(key)
 
     def stop(self, uuid):
         """Stop a running hunt permanently."""

--- a/praetorian_cli/sdk/entities/hunts.py
+++ b/praetorian_cli/sdk/entities/hunts.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone, timedelta
+
+
+class Hunts:
+    """Hunt management methods, accessed via sdk.hunts."""
+
+    def __init__(self, api):
+        self.api = api
+
+    def create(self, prompt, expires_hours=72, agent='hannibal', scope=None,
+               scope_level='normal', aggressiveness='balanced',
+               finish_criteria='', user_guardrails='', allowed_tools=None):
+        """Create and launch a new hunt.
+
+        :param prompt: The hunt objective
+        :param expires_hours: Hours until expiry (max 72)
+        :param agent: hannibal, hannibal-cloud, hannibal-webapp, hannibal-llm
+        :param scope: Optional list of target asset keys
+        :param scope_level: normal or strict
+        :param aggressiveness: cautious, balanced, or aggressive
+        :return: The created hunt object
+        """
+        hours = min(expires_hours, 72)
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        body = {
+            'prompt': prompt,
+            'expiresAt': expires_at,
+            'agent': agent,
+            'scopeLevel': scope_level,
+            'aggressiveness': aggressiveness,
+        }
+        if scope:
+            body['scope'] = scope
+        if finish_criteria:
+            body['finishCriteria'] = finish_criteria
+        if user_guardrails:
+            body['userGuardrails'] = user_guardrails
+        if allowed_tools:
+            body['allowedTools'] = allowed_tools
+
+        return self.api.post('hunt', body)
+
+    def list(self, status=None, pages=1):
+        """List hunts for the current account via graph search.
+
+        :param status: Optional status filter (active, paused, completed, stopped, expired, errored)
+        :param pages: Number of pages to fetch
+        :return: Tuple of (list of hunts, offset)
+        """
+        result = self.api.my({'key': '#hunt#'}, pages=pages)
+        data = result.get('data', [])
+        if status:
+            data = [h for h in data if h.get('status') == status]
+        return data, result.get('offset')
+
+    def get(self, uuid):
+        """Get a single hunt by UUID.
+
+        :param uuid: Hunt UUID (with or without #hunt# prefix)
+        :return: Hunt dict or None
+        """
+        key = f'#hunt#{uuid}' if not uuid.startswith('#hunt#') else uuid
+        result = self.api.my({'key': key})
+        data = result.get('data', [])
+        return data[0] if data else None
+
+    def stop(self, uuid):
+        """Stop a running hunt permanently."""
+        return self._update_status(uuid, 'stopped')
+
+    def pause(self, uuid):
+        """Pause an active hunt."""
+        return self._update_status(uuid, 'paused')
+
+    def resume(self, uuid):
+        """Resume a paused hunt."""
+        return self._update_status(uuid, 'active')
+
+    def delete(self, uuid):
+        """Delete a hunt and its artifacts. Findings are preserved."""
+        from praetorian_cli.sdk.chariot import process_failure
+        resp = self.api.chariot_request('DELETE', self.api.url(f'/hunt/{uuid}'))
+        process_failure(resp)
+        return resp.json()
+
+    def _update_status(self, uuid, status):
+        from praetorian_cli.sdk.chariot import process_failure
+        resp = self.api.chariot_request('PUT', self.api.url(f'/hunt/{uuid}'), json={'status': status})
+        process_failure(resp)
+        return resp.json()


### PR DESCRIPTION
## Summary

- Adds `guard hunt` command group for managing Hannibal hunts via the CLI
- Enables automated BB campaign orchestration — launch hunts across tenants, monitor progress, and stop stalled hunts without the UI
- New SDK entity (`sdk/entities/hunts.py`) wrapping the `/hunt` API endpoints
- New CLI handler (`handlers/hunt.py`) with 7 subcommands

## Commands

| Command | What it does | API |
|---------|-------------|-----|
| `guard hunt launch --prompt "..." [--agent hannibal] [--expires 72]` | Create and start a new hunt | `POST /hunt` |
| `guard hunt list [--status active] [--details]` | List hunts with optional status filter | `GET /my?key=#hunt#` |
| `guard hunt status <uuid>` | Show iterations, findings, errors | `GET /my?key=#hunt#<uuid>` |
| `guard hunt stop <uuid>` | Stop permanently | `PUT /hunt/{uuid}` |
| `guard hunt pause <uuid>` | Pause | `PUT /hunt/{uuid}` |
| `guard hunt resume <uuid>` | Resume | `PUT /hunt/{uuid}` |
| `guard hunt delete <uuid>` | Delete (findings preserved) | `DELETE /hunt/{uuid}` |

## BB Campaign Use Cases

```bash
# Launch a hunt on a BB tenant
guard --account 'guard+peloton-5xl@praetorian.com' hunt launch \
  --prompt "Find web application vulnerabilities" \
  --agent hannibal-webapp --expires 48

# Check active hunts across BB tenants
for tenant in guard+peloton-5xl guard+costco-0z2 guard+bookingcom-lwy; do
  echo "=== $tenant ==="
  guard --account "${tenant}@praetorian.com" hunt list --status active --details
done

# Monitor a specific hunt's progress
guard hunt status a1b2c3d4-e5f6-7890-abcd-ef1234567890

# Stop a stalled hunt
guard hunt stop a1b2c3d4-e5f6-7890-abcd-ef1234567890
```

## Test plan

- [x] Import verification: all 7 commands register under `chariot.commands['hunt']`
- [x] SDK entity follows existing pattern (Assets, Risks, etc.)
- [x] CLI handler follows existing Click conventions (`@cli_handler`, `@click.option`)
- [x] Integration test: `guard hunt list` against a real account
- [x] Integration test: `guard hunt launch` + `guard hunt status` + `guard hunt stop` lifecycle

Closes 10T-680