### PR TITLE
Add top-level retest command (shorthand for running priscus against a risk)

### DIFF
--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -124,6 +124,37 @@ def run():
     pass
 
 
+@chariot.command('retest')
+@cli_handler
+@click.argument('risk')
+@click.option('--wait', is_flag=True, default=False, help='Wait for job completion and show results')
+def retest(sdk, risk, wait):
+    """ Queue a remediation retest for a risk
+
+    Runs the priscus remediation retesting agent against the given risk.
+    Shorthand for "guard run tool priscus <risk_key> --remote".
+
+    \b
+    RISK can be a full Guard risk key (#risk#example.com#cve-2024-1234)
+    or a friendly name that resolves to a single risk.
+
+    \b
+    Example usages:
+        guard retest "#risk#example.com#cve-2024-1234"
+        guard retest cve-2024-1234 --wait
+    """
+    risk_key, warning = resolve_target(sdk, risk, 'risk')
+    if not risk_key:
+        error(warning)
+    if warning:
+        click.echo(warning, err=True)
+    if not risk_key.startswith('#risk#'):
+        error(f'"{risk}" resolved to {risk_key}, which is not a risk. Retest requires a risk key (#risk#...).')
+
+    cap = resolve_capability(sdk, 'priscus') or TOOL_ALIASES['priscus']
+    _run_direct(sdk, cap, risk_key, '', [], wait)
+
+
 @run.command(
     'tool',
     context_settings={'ignore_unknown_options': True, 'allow_extra_args': True},

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -67,10 +67,19 @@ def resolve_capability(sdk, name):
     return None
 
 
-def resolve_target(sdk, target_input, expected_type):
+def _ambiguity_warning(target_input, expected_type, results):
+    """Build the failure message for an input that matches multiple entities."""
+    keys = '\n'.join(r['key'] for r in results)
+    return (f'"{target_input}" matches multiple {expected_type} entities:\n{keys}\n'
+            f'Pass a full #{expected_type}#... key to disambiguate.')
+
+
+def resolve_target(sdk, target_input, expected_type, require_unique=False):
     """Resolve a friendly target (domain, IP, URL) to a Guard entity key.
 
     Uses sdk.search.fulltext() for resolution. Returns (key, warning) tuple.
+    When require_unique is True, an input matching multiple entities returns
+    (None, warning) instead of picking the first match.
     """
     if target_input.startswith('#'):
         return target_input, None
@@ -79,11 +88,13 @@ def resolve_target(sdk, target_input, expected_type):
     try:
         results, _ = sdk.search.fulltext(target_input, kind=expected_type, limit=10)
         if results:
-            # Exact match on dns/name
-            for r in results:
-                if r.get('dns', '') == target_input or r.get('name', '') == target_input:
-                    return r['key'], None
-            return results[0]['key'], None
+            # Exact match on dns/name, falling back to all results
+            exact = [r for r in results
+                     if r.get('dns', '') == target_input or r.get('name', '') == target_input]
+            candidates = exact or results
+            if require_unique and len(candidates) > 1:
+                return None, _ambiguity_warning(target_input, expected_type, candidates)
+            return candidates[0]['key'], None
     except Exception:
         pass
 
@@ -97,6 +108,8 @@ def resolve_target(sdk, target_input, expected_type):
     try:
         results, _ = sdk.search.by_key_prefix(f'#{vtype}#{target_input}', pages=1)
         if results:
+            if require_unique and len(results) > 1:
+                return None, _ambiguity_warning(target_input, expected_type, results)
             return results[0]['key'], None
     except Exception:
         pass
@@ -106,6 +119,8 @@ def resolve_target(sdk, target_input, expected_type):
         try:
             results, _ = sdk.search.by_term(f'{field}:{target_input}', expected_type, pages=1)
             if results:
+                if require_unique and len(results) > 1:
+                    return None, _ambiguity_warning(target_input, expected_type, results)
                 return results[0]['key'], None
         except Exception:
             pass
@@ -143,11 +158,9 @@ def retest(sdk, risk, wait):
         guard retest "#risk#example.com#cve-2024-1234"
         guard retest cve-2024-1234 --wait
     """
-    risk_key, warning = resolve_target(sdk, risk, 'risk')
+    risk_key, warning = resolve_target(sdk, risk, 'risk', require_unique=True)
     if not risk_key:
         error(warning)
-    if warning:
-        click.echo(warning, err=True)
     if not risk_key.startswith('#risk#'):
         error(f'"{risk}" resolved to {risk_key}, which is not a risk. Retest requires a risk key (#risk#...).')
 

--- a/praetorian_cli/handlers/run.py
+++ b/praetorian_cli/handlers/run.py
@@ -67,9 +67,12 @@ def resolve_capability(sdk, name):
     return None
 
 
-def _ambiguity_warning(target_input, expected_type, results):
+def _ambiguity_warning(target_input, expected_type, results, max_shown=10):
     """Build the failure message for an input that matches multiple entities."""
-    keys = '\n'.join(r['key'] for r in results)
+    shown = results[:max_shown]
+    keys = '\n'.join(r['key'] for r in shown)
+    if len(results) > len(shown):
+        keys += f'\n...and {len(results) - len(shown)} more'
     return (f'"{target_input}" matches multiple {expected_type} entities:\n{keys}\n'
             f'Pass a full #{expected_type}#... key to disambiguate.')
 

--- a/praetorian_cli/sdk/test/test_run_cli.py
+++ b/praetorian_cli/sdk/test/test_run_cli.py
@@ -177,6 +177,33 @@ def test_retest_non_risk_resolution_errors(runner, fake_sdk):
     fake_sdk.jobs.add.assert_not_called()
 
 
+def test_retest_ambiguity_warning_truncates_long_candidate_lists(runner, fake_sdk):
+    """A large ambiguous match set shows the first 10 keys plus a count, not all of them."""
+    results = [{'key': f'#risk#host{i}.example.com#cve-2024-1234', 'name': 'cve-2024-1234'}
+               for i in range(12)]
+    fake_sdk.search.fulltext.return_value = (results, None)
+    result = _invoke(runner, fake_sdk, ['retest', 'cve-2024-1234'])
+    assert result.exit_code != 0
+    assert results[9]['key'] in result.output
+    assert results[10]['key'] not in result.output
+    assert '...and 2 more' in result.output
+    fake_sdk.jobs.add.assert_not_called()
+
+
+def test_retest_ambiguous_prefix_fallback_errors(runner, fake_sdk):
+    """The by_key_prefix fallback path also refuses ambiguous matches."""
+    other_key = '#risk#other.example.com#cve-2024-1234'
+    fake_sdk.search.fulltext.return_value = ([], None)
+    fake_sdk.search.by_key_prefix.return_value = (
+        [{'key': RISK_KEY}, {'key': other_key}], None)
+    result = _invoke(runner, fake_sdk, ['retest', 'cve-2024-1234'])
+    assert result.exit_code != 0
+    assert 'multiple' in result.output.lower()
+    assert RISK_KEY in result.output
+    assert other_key in result.output
+    fake_sdk.jobs.add.assert_not_called()
+
+
 def test_retest_unresolvable_name_errors(runner, fake_sdk):
     """Name matching nothing anywhere (fulltext + fallbacks) fails cleanly."""
     fake_sdk.search.fulltext.return_value = ([], None)

--- a/praetorian_cli/sdk/test/test_run_cli.py
+++ b/praetorian_cli/sdk/test/test_run_cli.py
@@ -126,3 +126,64 @@ def test_remote_and_ask_conflict(runner, fake_sdk):
     assert result.exit_code != 0
     assert '--remote' in result.output
     assert '--ask' in result.output
+
+
+# --- guard retest ---
+
+RISK_KEY = '#risk#example.com#cve-2024-1234'
+
+
+def test_retest_full_risk_key_queues_priscus_job(runner, fake_sdk):
+    """A full #risk# key passes straight through to the job system, no search."""
+    result = _invoke(runner, fake_sdk, ['retest', RISK_KEY])
+    assert result.exit_code == 0
+    fake_sdk.jobs.add.assert_called_once_with(RISK_KEY, ['priscus'], None, None)
+    fake_sdk.search.fulltext.assert_not_called()
+    assert RISK_KEY in result.output
+
+
+def test_retest_friendly_name_resolves_unique_risk(runner, fake_sdk):
+    """A friendly name matching exactly one risk queues the job against its key."""
+    fake_sdk.search.fulltext.return_value = (
+        [{'key': RISK_KEY, 'name': 'cve-2024-1234'}], None)
+    result = _invoke(runner, fake_sdk, ['retest', 'cve-2024-1234'])
+    assert result.exit_code == 0
+    fake_sdk.jobs.add.assert_called_once_with(RISK_KEY, ['priscus'], None, None)
+
+
+def test_retest_ambiguous_friendly_name_errors_and_lists_keys(runner, fake_sdk):
+    """A name matching multiple risks fails instead of silently picking one."""
+    other_key = '#risk#other.example.com#cve-2024-1234'
+    fake_sdk.search.fulltext.return_value = (
+        [{'key': RISK_KEY, 'name': 'cve-2024-1234'},
+         {'key': other_key, 'name': 'cve-2024-1234'}], None)
+    result = _invoke(runner, fake_sdk, ['retest', 'cve-2024-1234'])
+    assert result.exit_code != 0
+    assert 'multiple' in result.output.lower()
+    assert RISK_KEY in result.output
+    assert other_key in result.output
+    fake_sdk.jobs.add.assert_not_called()
+
+
+def test_retest_non_risk_resolution_errors(runner, fake_sdk):
+    """Input resolving to an asset key is rejected — retest needs a risk."""
+    asset_key = '#asset#example.com#example.com'
+    fake_sdk.search.fulltext.return_value = (
+        [{'key': asset_key, 'name': 'example.com'}], None)
+    result = _invoke(runner, fake_sdk, ['retest', 'example.com'])
+    assert result.exit_code != 0
+    assert 'not a risk' in result.output
+    assert asset_key in result.output
+    fake_sdk.jobs.add.assert_not_called()
+
+
+def test_retest_unresolvable_name_errors(runner, fake_sdk):
+    """Name matching nothing anywhere (fulltext + fallbacks) fails cleanly."""
+    fake_sdk.search.fulltext.return_value = ([], None)
+    fake_sdk.search.by_key_prefix.return_value = ([], None)
+    fake_sdk.search.by_term.return_value = ([], None)
+    result = _invoke(runner, fake_sdk, ['retest', 'no-such-risk'])
+    assert result.exit_code != 0
+    assert 'Could not resolve' in result.output
+    assert 'no-such-risk' in result.output
+    fake_sdk.jobs.add.assert_not_called()


### PR DESCRIPTION
## Summary
Adds `guard retest <risk>` as a first-class command so users no longer need to know about the priscus agent to queue a remediation retest. Prompted by a customer question in Slack asking whether retest is available via the API/CLI.

- `guard retest "#risk#example.com#cve-2024-1234"` queues the priscus remediation retesting agent against the risk
- Accepts either a full Guard risk key or a friendly name (resolved via existing target resolution); rejects targets that resolve to non-risk entities
- `--wait` polls for job completion and prints findings, same as `guard run tool`
- Resolves the priscus capability from the backend, falling back to the built-in alias if the lookup fails

## Testing
- `guard retest --help` renders correctly
- Mocked-SDK invocation queues `sdk.jobs.add(risk_key, ['priscus'], None, None)` as expected
- Non-risk resolution (asset key) exits with a clear error