### PR TITLE
Use system CA store for CLI TLS

### DIFF
--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -1,3 +1,8 @@
+import truststore
+
+# Configure TLS before importing HTTP clients so they use the OS trust store.
+truststore.inject_into_ssl()
+
 import click
 
 import praetorian_cli.handlers.access

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     click >= 8.1.7
     boto3 >= 1.34.0
     requests >= 2.31.0
+    truststore >= 0.10.0
     pytest >= 8.0.2
     mcp >= 1.12.2
     anyio >= 3.0.0


### PR DESCRIPTION
## Summary (required)

Use the platform CA store for CLI TLS verification via `truststore`, allowing certificates trusted by the OS (including Proxyman and enterprise CAs) without disabling verification. Requests continues to honor `REQUESTS_CA_BUNDLE` for explicit CA bundles.

## JIRA (required)

- N/A

## Testing

- `pytest -q praetorian_cli/sdk/test -m "not coherence" --ignore=praetorian_cli/sdk/test/test_z_cli.py` (370 passed)
- Verified `guard list accounts` succeeds through Proxyman without `REQUESTS_CA_BUNDLE`
- Verified `REQUESTS_CA_BUNDLE` remains honored