### PR TITLE
feat: add tenant-integration and global credential resolution methods [ENG-6538]

### DIFF
--- a/praetorian_cli/handlers/get.py
+++ b/praetorian_cli/handlers/get.py
@@ -264,12 +264,14 @@ def configuration(chariot, key):
 @click.option('--type', default='default', help='The type of credential (e.g., aws, gcp, azure, static, ssh_key, json)')
 @click.option('--format', default='token', help='The format of the credential response')
 @click.option('--resolution',
-              type=click.Choice(['by-target', 'from-parent'], case_sensitive=False),
+              type=click.Choice(['by-target', 'from-parent', 'tenant-integration', 'global'], case_sensitive=False),
               default='by-target',
               show_default=True,
               help='How the broker should locate the credential. '
                    'by-target: use the supplied CREDENTIAL_ID as-is. '
-                   'from-parent: walk DISCOVERED ancestors of --resource-key to find one with a matching credential.')
+                   'from-parent: walk DISCOVERED ancestors of --resource-key to find one with a matching credential. '
+                   'tenant-integration: resolve from the tenant\'s integration account for this credential type. '
+                   'global: resolve a platform-wide credential by type.')
 @click.option('--resource-key', default=None,
               help='Asset/resource key to scope the lookup. Required when --resolution=from-parent.')
 @click.option('--parameters', nargs=2, multiple=True, help='Additional parameters, as --parameters key value')
@@ -281,13 +283,15 @@ def credential(chariot, credential_id, category, type, format, resolution, resou
     \b
     Argument:
         - CREDENTIAL_ID: the ID of the credential to retrieve. Required for
-          --resolution=by-target; optional for from-parent.
+          --resolution=by-target; optional for other resolution methods.
 
     \b
     Example usages:
         - guard get credential aws-prod --category integration --type aws --format json
         - guard get credential ssh-key-1 --category cloud --type ssh_key --format pem
         - guard get credential --resolution from-parent --resource-key '#asset#example.com#1.2.3.4' --type aws
+        - guard get credential --resolution tenant-integration --type github
+        - guard get credential --resolution global --type shodan
     """
     if resolution == 'by-target' and not credential_id:
         error('CREDENTIAL_ID is required when --resolution=by-target.')

--- a/praetorian_cli/sdk/entities/credentials.py
+++ b/praetorian_cli/sdk/entities/credentials.py
@@ -94,8 +94,10 @@ class Credentials:
         :param format: The format of the credential response ('token', 'file', 'env')
         :type format: str or list
         :param resolution: How the broker should locate the credential. One of
-            'by-target' (use credential_id as-is; default) or 'from-parent'
-            (walk DISCOVERED ancestors of resource_key).
+            'by-target' (use credential_id as-is; default), 'from-parent'
+            (walk DISCOVERED ancestors of resource_key), 'tenant-integration'
+            (resolve from the tenant's integration account for this type), or
+            'global' (resolve a platform-wide credential by type).
         :type resolution: str
         :param resource_key: Asset/resource key the credential is scoped to.
             Required when resolution='from-parent'.

--- a/praetorian_cli/sdk/test/test_credentials.py
+++ b/praetorian_cli/sdk/test/test_credentials.py
@@ -130,6 +130,58 @@ class TestCredentialsGet:
         })
 
 
+    def test_get_with_tenant_integration_sends_no_credential_id(self):
+        """tenant-integration: broker resolves the credential from the tenant's
+        integration account for the requested type. No CredentialID or
+        ResourceKey required from the caller."""
+        api = MagicMock()
+        api.post.return_value = {'credentialValue': {'github': 'ghs_xxx'}}
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='',
+            category='env-integration',
+            type='github',
+            format=['token'],
+            resolution='tenant-integration',
+        )
+
+        api.post.assert_called_once_with('broker', {
+            'Operation': 'get',
+            'CredentialID': '',
+            'Category': 'env-integration',
+            'Type': 'github',
+            'Format': ['token'],
+            'Resolution': 'tenant-integration',
+            'Parameters': {},
+        })
+
+    def test_get_with_global_sends_no_credential_id(self):
+        """global: broker synthesizes CredentialID from Type. No caller-supplied
+        fields required."""
+        api = MagicMock()
+        api.post.return_value = {'credentialValue': {'shodan': 'key123'}}
+        creds = Credentials(api=api)
+
+        creds.get(
+            credential_id='',
+            category='env-integration',
+            type='shodan',
+            format=['token'],
+            resolution='global',
+        )
+
+        api.post.assert_called_once_with('broker', {
+            'Operation': 'get',
+            'CredentialID': '',
+            'Category': 'env-integration',
+            'Type': 'shodan',
+            'Format': ['token'],
+            'Resolution': 'global',
+            'Parameters': {},
+        })
+
+
 class TestCredentialsDelete:
     def test_delete_builds_broker_request(self):
         api = MagicMock()
@@ -397,6 +449,30 @@ class TestGetCredentialCLI:
         assert result.exit_code != 0
         assert 'CREDENTIAL_ID' in result.output
         fake_sdk.credentials.get.assert_not_called()
+
+    def test_tenant_integration_does_not_require_credential_id(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'tenant-integration',
+            '--type', 'github',
+        ])
+        assert result.exit_code == 0, result.output
+        fake_sdk.credentials.get.assert_called_once_with(
+            '', 'env-integration', 'github', ['token'],
+            resolution='tenant-integration', resource_key=None,
+        )
+
+    def test_global_does_not_require_credential_id(self, runner, fake_sdk):
+        result = _invoke(runner, fake_sdk, [
+            'get', 'credential',
+            '--resolution', 'global',
+            '--type', 'shodan',
+        ])
+        assert result.exit_code == 0, result.output
+        fake_sdk.credentials.get.assert_called_once_with(
+            '', 'env-integration', 'shodan', ['token'],
+            resolution='global', resource_key=None,
+        )
 
     def test_invalid_resolution_value_is_rejected(self, runner, fake_sdk):
         result = _invoke(runner, fake_sdk, [


### PR DESCRIPTION
## Summary
- Add `tenant-integration` and `global` to the `--resolution` Click choice list for `guard get credential`
- Update help text, examples, and SDK docstring

## Context

The broker Lambda supports four resolution methods (`by-target`, `from-parent`, `tenant-integration`, `global`) but the CLI only exposed the first two. This blocked engineers from retrieving GitHub App tokens for source code access on Engineer VMs — the GitHub App credential lives on the tenant's integration account row, requiring `tenant-integration` resolution.

No SDK logic changes needed — `credentials.get()` already passes `resolution` through to the broker.

### Backend dependency

The broker's `tenant-integration` case landed in guard#7712 (merged 2026-08-17, deployed to UAT). This CLI change is safe to ship independently.

## Test plan
- [x] Existing `TestGetCredentialCLI` tests pass (23/23)
- [ ] E2E: `guard get credential --resolution tenant-integration --type github` returns a minted token (once backend deploys to prod)

https://linear.app/praetorianlabs/issue/ENG-6538
https://claude.ai/code/session_01VSQR9wgeomYy6oRrQFaLfs