### PR TITLE
fix: add pull-requests write permission to claude-code workflow [ENG-6662]

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   claude-code-action:
     uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@3fb9ffbace86c9e93a7b92170241dd54b5031608  # v2.11.3


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read, pull-requests: write` to `.github/workflows/claude-code.yml`
- The reusable workflow's nested jobs (`preflight`, `claude-code-action`) require `pull-requests: write` to post comments and suggestions on PRs
- Without an explicit permissions block, the caller inherited the repo default which didn't grant it, causing the workflow to be invalid

## Test plan
- [ ] Verify the workflow file passes GitHub Actions validation (no annotation errors)
- [ ] Confirm the Claude PR assistant can post comments on a test PR

https://claude.ai/code/session_01WrAyyehX9M8WnfjxznUBwt