### PR TITLE
feat: Constantine, OSINT, remediation, and enrichment admin CLI

### DIFF
--- a/praetorian_cli/handlers/constantine.py
+++ b/praetorian_cli/handlers/constantine.py
@@ -1,0 +1,79 @@
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group()
+def constantine():
+    """ Constantine exploit, patch, and validation pipelines """
+    pass
+
+
+@constantine.command()
+@cli_handler
+@click.option('--risk-keys', required=True, help='Comma-separated risk keys to exploit')
+def exploit(sdk, risk_keys):
+    """ Trigger exploit-only Constantine runs for risks
+
+    \b
+    Example usages:
+        guard constantine exploit --risk-keys "#risk#example.com#CVE-2024-1234"
+        guard constantine exploit --risk-keys "key1,key2,key3"
+    """
+    keys = [k.strip() for k in risk_keys.split(',')]
+    print_json(sdk.constantine.exploit(keys))
+
+
+@constantine.command()
+@cli_handler
+@click.option('--risk-keys', required=True, help='Comma-separated risk keys to patch')
+def patch(sdk, risk_keys):
+    """ Trigger patch-only Constantine runs for risks
+
+    \b
+    Example usages:
+        guard constantine patch --risk-keys "#risk#example.com#CVE-2024-1234"
+    """
+    keys = [k.strip() for k in risk_keys.split(',')]
+    print_json(sdk.constantine.patch(keys))
+
+
+@constantine.command('patch-and-pr')
+@cli_handler
+@click.option('--risk-key', required=True, help='Single risk key to patch and create a PR for')
+def patch_and_pr(sdk, risk_key):
+    """ Patch a risk and create a GitHub pull request
+
+    \b
+    Example usages:
+        guard constantine patch-and-pr --risk-key "#risk#example.com#CVE-2024-1234"
+    """
+    print_json(sdk.constantine.patch_and_pr(risk_key))
+
+
+@constantine.command()
+@cli_handler
+@click.option('--risk-keys', required=True, help='Comma-separated risk keys to validate')
+def validate(sdk, risk_keys):
+    """ Validate previous exploit results for risks
+
+    \b
+    Example usages:
+        guard constantine validate --risk-keys "#risk#example.com#CVE-2024-1234"
+    """
+    keys = [k.strip() for k in risk_keys.split(',')]
+    print_json(sdk.constantine.validate(keys))
+
+
+@constantine.command()
+@cli_handler
+def manifest(sdk):
+    """ Get the Constantine pipeline manifest (presets and modules)
+
+    \b
+    Example usages:
+        guard constantine manifest
+    """
+    print_json(sdk.constantine.manifest())

--- a/praetorian_cli/handlers/constantine.py
+++ b/praetorian_cli/handlers/constantine.py
@@ -11,6 +11,11 @@ def constantine():
     pass
 
 
+def _parse_risk_keys(risk_keys_str):
+    """Parse comma-separated risk keys into a list."""
+    return [k.strip() for k in risk_keys_str.split(',') if k.strip()]
+
+
 @constantine.command()
 @cli_handler
 @click.option('--risk-keys', required=True, help='Comma-separated risk keys to exploit')
@@ -22,7 +27,7 @@ def exploit(sdk, risk_keys):
         guard constantine exploit --risk-keys "#risk#example.com#CVE-2024-1234"
         guard constantine exploit --risk-keys "key1,key2,key3"
     """
-    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
+    keys = _parse_risk_keys(risk_keys)
     print_json(sdk.constantine.exploit(keys))
 
 
@@ -36,7 +41,7 @@ def patch(sdk, risk_keys):
     Example usages:
         guard constantine patch --risk-keys "#risk#example.com#CVE-2024-1234"
     """
-    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
+    keys = _parse_risk_keys(risk_keys)
     print_json(sdk.constantine.patch(keys))
 
 
@@ -63,7 +68,7 @@ def validate(sdk, risk_keys):
     Example usages:
         guard constantine validate --risk-keys "#risk#example.com#CVE-2024-1234"
     """
-    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
+    keys = _parse_risk_keys(risk_keys)
     print_json(sdk.constantine.validate(keys))
 
 

--- a/praetorian_cli/handlers/constantine.py
+++ b/praetorian_cli/handlers/constantine.py
@@ -22,7 +22,7 @@ def exploit(sdk, risk_keys):
         guard constantine exploit --risk-keys "#risk#example.com#CVE-2024-1234"
         guard constantine exploit --risk-keys "key1,key2,key3"
     """
-    keys = [k.strip() for k in risk_keys.split(',')]
+    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
     print_json(sdk.constantine.exploit(keys))
 
 
@@ -36,7 +36,7 @@ def patch(sdk, risk_keys):
     Example usages:
         guard constantine patch --risk-keys "#risk#example.com#CVE-2024-1234"
     """
-    keys = [k.strip() for k in risk_keys.split(',')]
+    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
     print_json(sdk.constantine.patch(keys))
 
 
@@ -63,7 +63,7 @@ def validate(sdk, risk_keys):
     Example usages:
         guard constantine validate --risk-keys "#risk#example.com#CVE-2024-1234"
     """
-    keys = [k.strip() for k in risk_keys.split(',')]
+    keys = [k.strip() for k in risk_keys.split(',') if k.strip()]
     print_json(sdk.constantine.validate(keys))
 
 

--- a/praetorian_cli/handlers/enrichment_admin.py
+++ b/praetorian_cli/handlers/enrichment_admin.py
@@ -1,0 +1,136 @@
+import sys
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group('enrichment')
+def enrichment_group():
+    """ Enrichment plugin administration """
+    pass
+
+
+@enrichment_group.command('status')
+@cli_handler
+def enrichment_status(sdk):
+    """ Get global enrichment status
+
+    \b
+    Example usages:
+        guard enrichment status
+    """
+    print_json(sdk.enrichment_admin.status())
+
+
+@enrichment_group.command('enabled')
+@cli_handler
+def enrichment_enabled(sdk):
+    """ Get bulk enabled state for all enrichment plugins
+
+    \b
+    Example usages:
+        guard enrichment enabled
+    """
+    print_json(sdk.enrichment_admin.enabled())
+
+
+@enrichment_group.command('global-enabled')
+@cli_handler
+def enrichment_global_enabled(sdk):
+    """ Get global enrichment enabled state
+
+    \b
+    Example usages:
+        guard enrichment global-enabled
+    """
+    print_json(sdk.enrichment_admin.global_enabled())
+
+
+@enrichment_group.command('set-global-enabled')
+@cli_handler
+@click.option('--enabled/--disabled', required=True, help='Enable or disable global enrichment')
+def set_global_enabled(sdk, enabled):
+    """ Enable or disable global enrichment
+
+    \b
+    Example usages:
+        guard enrichment set-global-enabled --enabled
+        guard enrichment set-global-enabled --disabled
+    """
+    print_json(sdk.enrichment_admin.set_global_enabled(enabled))
+
+
+@enrichment_group.command('credits')
+@cli_handler
+def enrichment_credits(sdk):
+    """ Get bulk credit information for all enrichment plugins
+
+    \b
+    Example usages:
+        guard enrichment credits
+    """
+    print_json(sdk.enrichment_admin.credits())
+
+
+@enrichment_group.command('plugin-status')
+@cli_handler
+@click.argument('plugin')
+def plugin_status(sdk, plugin):
+    """ Get status for a specific enrichment plugin
+
+    \b
+    Example usages:
+        guard enrichment plugin-status shodan
+    """
+    print_json(sdk.enrichment_admin.plugin_status(plugin))
+
+
+@enrichment_group.command('plugin-credits')
+@cli_handler
+@click.argument('plugin')
+def plugin_credits(sdk, plugin):
+    """ Get credit information for a specific enrichment plugin
+
+    \b
+    Example usages:
+        guard enrichment plugin-credits shodan
+    """
+    print_json(sdk.enrichment_admin.plugin_credits(plugin))
+
+
+@enrichment_group.command('set-enabled')
+@cli_handler
+@click.argument('plugin')
+@click.option('--enabled/--disabled', required=True, help='Enable or disable the plugin')
+def set_enabled(sdk, plugin, enabled):
+    """ Enable or disable a specific enrichment plugin
+
+    \b
+    Example usages:
+        guard enrichment set-enabled shodan --enabled
+        guard enrichment set-enabled shodan --disabled
+    """
+    print_json(sdk.enrichment_admin.set_plugin_enabled(plugin, enabled))
+
+
+@enrichment_group.command('set-key')
+@cli_handler
+@click.argument('plugin')
+def set_key(sdk, plugin):
+    """ Set the API key for an enrichment plugin
+
+    \b
+    Reads the key from stdin to avoid exposing secrets in process arguments.
+
+    \b
+    Example usages:
+        echo "sk-abc123" | guard enrichment set-key shodan
+        guard enrichment set-key shodan < keyfile.txt
+    """
+    key = sys.stdin.read().strip()
+    if not key:
+        raise click.UsageError('No key provided on stdin. Pipe your key: echo "KEY" | guard enrichment set-key PLUGIN')
+    print_json(sdk.enrichment_admin.set_plugin_key(plugin, key))

--- a/praetorian_cli/handlers/enrichment_admin.py
+++ b/praetorian_cli/handlers/enrichment_admin.py
@@ -4,7 +4,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import error, print_json
 
 
 @chariot.group('enrichment')
@@ -130,7 +130,9 @@ def set_key(sdk, plugin):
         echo "sk-abc123" | guard enrichment set-key shodan
         guard enrichment set-key shodan < keyfile.txt
     """
+    if sys.stdin.isatty():
+        error('Pipe the key via stdin (e.g., echo "key" | guard enrichment set-key <plugin>)')
     key = sys.stdin.read().strip()
     if not key:
-        raise click.UsageError('No key provided on stdin. Pipe your key: echo "KEY" | guard enrichment set-key PLUGIN')
+        error('No key provided on stdin. Pipe your key: echo "KEY" | guard enrichment set-key PLUGIN')
     print_json(sdk.enrichment_admin.set_plugin_key(plugin, key))

--- a/praetorian_cli/handlers/osint.py
+++ b/praetorian_cli/handlers/osint.py
@@ -1,0 +1,65 @@
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group()
+def osint():
+    """ OSINT repository and technology operations """
+    pass
+
+
+@osint.command('guess-repo')
+@cli_handler
+@click.option('--cpe', default=None, help='CPE string (e.g., cpe:2.3:a:apache:httpd)')
+@click.option('--technology-name', default=None, help='Technology name to look up')
+def guess_repo(sdk, cpe, technology_name):
+    """ Identify the source code repository for a technology via LLM
+
+    \b
+    At least one of --cpe or --technology-name is required.
+
+    \b
+    Example usages:
+        guard osint guess-repo --cpe "cpe:2.3:a:apache:httpd"
+        guard osint guess-repo --technology-name "OpenSSL"
+    """
+    if not cpe and not technology_name:
+        raise click.UsageError('At least one of --cpe or --technology-name is required')
+    print_json(sdk.osint.guess_repo(cpe=cpe, technology_name=technology_name))
+
+
+@osint.command()
+@cli_handler
+@click.option('--repo-url', required=True, help='Public repository URL')
+@click.option('--technology-key', default=None, help='Technology key to link')
+@click.option('--goal', default=None, help='Scan goal description')
+@click.option('--pipeline', default=None, help='Constantine pipeline name')
+@click.option('--scan-mode', default=None, type=click.Choice(['auto', 'full', 'diff']),
+              help='Scan mode')
+def submit(sdk, repo_url, technology_key, goal, pipeline, scan_mode):
+    """ Submit a repository for Constantine OSINT scanning
+
+    \b
+    Example usages:
+        guard osint submit --repo-url "https://github.com/org/repo"
+        guard osint submit --repo-url "https://github.com/org/repo" --pipeline premium-legacy
+    """
+    print_json(sdk.osint.submit(
+        repo_url, technology_key=technology_key, goal=goal,
+        pipeline=pipeline, scan_mode=scan_mode))
+
+
+@osint.command('create-technology')
+@cli_handler
+@click.option('--cpe', required=True, help='CPE string for the technology')
+def create_technology(sdk, cpe):
+    """ Create a new technology in the OSINT partition from a CPE string
+
+    \b
+    Example usages:
+        guard osint create-technology --cpe "cpe:2.3:a:apache:httpd:2.4.58"
+    """
+    print_json(sdk.osint.create_technology(cpe))

--- a/praetorian_cli/handlers/osint.py
+++ b/praetorian_cli/handlers/osint.py
@@ -2,7 +2,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import error, print_json
 
 
 @chariot.group()
@@ -27,7 +27,7 @@ def guess_repo(sdk, cpe, technology_name):
         guard osint guess-repo --technology-name "OpenSSL"
     """
     if not cpe and not technology_name:
-        raise click.UsageError('At least one of --cpe or --technology-name is required')
+        error('At least one of --cpe or --technology-name is required')
     print_json(sdk.osint.guess_repo(cpe=cpe, technology_name=technology_name))
 
 

--- a/praetorian_cli/handlers/remediation.py
+++ b/praetorian_cli/handlers/remediation.py
@@ -1,0 +1,62 @@
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group()
+def remediation():
+    """ Remediation patch selection and PR creation """
+    pass
+
+
+@remediation.command('select')
+@cli_handler
+@click.option('--risk-key', required=True, help='Risk key to remediate')
+@click.option('--finding-id', required=True, help='Finding ID within the risk')
+@click.option('--option-id', required=True, help='Patch option ID to select')
+@click.option('--strategy', default=None, help='Remediation strategy')
+def select_patch(sdk, risk_key, finding_id, option_id, strategy):
+    """ Save a patch selection for a risk finding
+
+    \b
+    Example usages:
+        guard remediation select --risk-key "#risk#example.com#CVE-2024-1234" \\
+            --finding-id "f1" --option-id "opt1"
+        guard remediation select --risk-key "..." --finding-id "f1" \\
+            --option-id "opt1" --strategy "minimal"
+    """
+    print_json(sdk.remediation.select_patch(
+        risk_key, finding_id, option_id, strategy=strategy))
+
+
+@remediation.command('clear')
+@cli_handler
+@click.option('--risk-key', required=True, help='Risk key')
+@click.option('--finding-id', required=True, help='Finding ID to clear patch selection for')
+def clear_patch(sdk, risk_key, finding_id):
+    """ Clear a patch selection for a risk finding
+
+    \b
+    Example usages:
+        guard remediation clear --risk-key "#risk#example.com#CVE-2024-1234" --finding-id "f1"
+    """
+    print_json(sdk.remediation.clear_patch(risk_key, finding_id))
+
+
+@remediation.command('create-pr')
+@cli_handler
+@click.option('--risk-key', required=True, help='Risk key with a selected patch')
+@click.option('--finding-id', required=True, help='Finding ID to create PR for')
+def create_pr(sdk, risk_key, finding_id):
+    """ Create a GitHub PR from a selected patch option
+
+    \b
+    Requires a patch to be selected first via 'guard remediation select'.
+
+    \b
+    Example usages:
+        guard remediation create-pr --risk-key "#risk#example.com#CVE-2024-1234" --finding-id "f1"
+    """
+    print_json(sdk.remediation.create_pr(risk_key, finding_id))

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -11,8 +11,10 @@ import praetorian_cli.handlers.add
 import praetorian_cli.handlers.aegis
 import praetorian_cli.handlers.agent
 import praetorian_cli.handlers.bulk
+import praetorian_cli.handlers.constantine  # noqa: F401
 import praetorian_cli.handlers.critfinder
 import praetorian_cli.handlers.delete
+import praetorian_cli.handlers.enrichment_admin  # noqa: F401
 import praetorian_cli.handlers.enrich
 import praetorian_cli.handlers.engagement
 import praetorian_cli.handlers.find
@@ -27,6 +29,8 @@ import praetorian_cli.handlers.list
 import praetorian_cli.handlers.purge
 import praetorian_cli.handlers.query
 import praetorian_cli.handlers.tenant
+import praetorian_cli.handlers.osint  # noqa: F401
+import praetorian_cli.handlers.remediation  # noqa: F401
 import praetorian_cli.handlers.report
 import praetorian_cli.handlers.script
 import praetorian_cli.handlers.search

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -9,14 +9,18 @@ from praetorian_cli.sdk.entities.attributes import Attributes
 from praetorian_cli.sdk.entities.capabilities import Capabilities
 from praetorian_cli.sdk.entities.configurations import Configurations
 from praetorian_cli.sdk.entities.conversations import Conversations
+from praetorian_cli.sdk.entities.constantine import Constantine
 from praetorian_cli.sdk.entities.credentials import Credentials
 from praetorian_cli.sdk.entities.definitions import Definitions
+from praetorian_cli.sdk.entities.enrichment import Enrichment as EnrichmentAdmin
 from praetorian_cli.sdk.entities.files import Files
 from praetorian_cli.sdk.entities.hunts import Hunts
 from praetorian_cli.sdk.entities.integrations import Integrations
 from praetorian_cli.sdk.entities.jobs import Jobs
 from praetorian_cli.sdk.entities.keys import Keys
+from praetorian_cli.sdk.entities.osint import OSINT
 from praetorian_cli.sdk.entities.preseeds import Preseeds
+from praetorian_cli.sdk.entities.remediation import Remediation
 from praetorian_cli.sdk.entities.reports import Reports
 from praetorian_cli.sdk.entities.risks import Risks
 from praetorian_cli.sdk.entities.scanners import Scanners
@@ -56,7 +60,11 @@ class Chariot:
         self.ad = AD(self)
         self.aegis = Aegis(self)
         self.agents = Agents(self)
+        self.constantine = Constantine(self)
         self.conversations = Conversations(self)
+        self.enrichment_admin = EnrichmentAdmin(self)
+        self.osint = OSINT(self)
+        self.remediation = Remediation(self)
         self.settings = Settings(self)
         self.configurations = Configurations(self)
         self.keys = Keys(self)

--- a/praetorian_cli/sdk/entities/constantine.py
+++ b/praetorian_cli/sdk/entities/constantine.py
@@ -1,0 +1,19 @@
+class Constantine:
+
+    def __init__(self, api):
+        self.api = api
+
+    def exploit(self, risk_keys):
+        return self.api.post('constantine/exploit', {'risk_keys': risk_keys})
+
+    def patch(self, risk_keys):
+        return self.api.post('constantine/patch', {'risk_keys': risk_keys})
+
+    def patch_and_pr(self, risk_key):
+        return self.api.post('constantine/patch-and-pr', {'risk_key': risk_key})
+
+    def validate(self, risk_keys):
+        return self.api.post('constantine/validate', {'risk_keys': risk_keys})
+
+    def manifest(self):
+        return self.api.get('constantine/manifest')

--- a/praetorian_cli/sdk/entities/enrichment.py
+++ b/praetorian_cli/sdk/entities/enrichment.py
@@ -1,0 +1,37 @@
+class Enrichment:
+
+    def __init__(self, api):
+        self.api = api
+
+    def status(self):
+        return self.api.get('enrichment')
+
+    def enabled(self):
+        return self.api.get('enrichment/enabled')
+
+    def set_enabled(self, plugins):
+        return self.api.put('enrichment/enabled', plugins)
+
+    def global_enabled(self):
+        return self.api.get('enrichment/global/enabled')
+
+    def set_global_enabled(self, enabled):
+        return self.api.put('enrichment/global/enabled', {'enabled': enabled})
+
+    def credits(self):
+        return self.api.get('enrichment/credits')
+
+    def plugin_status(self, plugin):
+        return self.api.get(f'enrichment/{plugin}')
+
+    def plugin_credits(self, plugin):
+        return self.api.get(f'enrichment/{plugin}/credits')
+
+    def plugin_enabled(self, plugin):
+        return self.api.get(f'enrichment/{plugin}/enabled')
+
+    def set_plugin_enabled(self, plugin, enabled):
+        return self.api.put(f'enrichment/{plugin}/enabled', {'enabled': enabled})
+
+    def set_plugin_key(self, plugin, key):
+        return self.api.put(f'enrichment/{plugin}/key', {'key': key})

--- a/praetorian_cli/sdk/entities/enrichment.py
+++ b/praetorian_cli/sdk/entities/enrichment.py
@@ -9,6 +9,7 @@ class Enrichment:
     def enabled(self):
         return self.api.get('enrichment/enabled')
 
+    # SDK-only method available for programmatic use; no corresponding CLI command exists.
     def set_enabled(self, plugins):
         return self.api.put('enrichment/enabled', plugins)
 
@@ -27,6 +28,7 @@ class Enrichment:
     def plugin_credits(self, plugin):
         return self.api.get(f'enrichment/{plugin}/credits')
 
+    # SDK-only method available for programmatic use; no corresponding CLI command exists.
     def plugin_enabled(self, plugin):
         return self.api.get(f'enrichment/{plugin}/enabled')
 

--- a/praetorian_cli/sdk/entities/osint.py
+++ b/praetorian_cli/sdk/entities/osint.py
@@ -1,0 +1,27 @@
+class OSINT:
+
+    def __init__(self, api):
+        self.api = api
+
+    def guess_repo(self, cpe=None, technology_name=None):
+        body = {}
+        if cpe:
+            body['cpe'] = cpe
+        if technology_name:
+            body['technology_name'] = technology_name
+        return self.api.post('osint/guess-repo', body)
+
+    def submit(self, repo_url, technology_key=None, goal=None, pipeline=None, scan_mode=None):
+        body = {'repo_url': repo_url}
+        if technology_key:
+            body['technology_key'] = technology_key
+        if goal:
+            body['goal'] = goal
+        if pipeline:
+            body['pipeline'] = pipeline
+        if scan_mode:
+            body['scan_mode'] = scan_mode
+        return self.api.post('osint/submit', body)
+
+    def create_technology(self, cpe):
+        return self.api.post('osint/create-technology', {'cpe': cpe})

--- a/praetorian_cli/sdk/entities/remediation.py
+++ b/praetorian_cli/sdk/entities/remediation.py
@@ -1,0 +1,16 @@
+class Remediation:
+
+    def __init__(self, api):
+        self.api = api
+
+    def select_patch(self, risk_key, finding_id, option_id, strategy=None):
+        body = {'risk_key': risk_key, 'finding_id': finding_id, 'option_id': option_id}
+        if strategy:
+            body['strategy'] = strategy
+        return self.api.put('remediation', body)
+
+    def clear_patch(self, risk_key, finding_id):
+        return self.api.delete('remediation', {'risk_key': risk_key, 'finding_id': finding_id}, {})
+
+    def create_pr(self, risk_key, finding_id):
+        return self.api.post('remediation/pr', {'risk_key': risk_key, 'finding_id': finding_id})

--- a/praetorian_cli/sdk/test/test_constantine_cli.py
+++ b/praetorian_cli/sdk/test/test_constantine_cli.py
@@ -1,0 +1,192 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.constantine  # noqa: F401
+import praetorian_cli.handlers.osint  # noqa: F401
+import praetorian_cli.handlers.remediation  # noqa: F401
+from praetorian_cli.handlers.chariot import chariot
+
+
+def _invoke(*args):
+    runner = CliRunner()
+    mock_sdk = MagicMock()
+    mock_sdk.constantine.exploit.return_value = {'status': 'ok'}
+    mock_sdk.constantine.patch.return_value = {'status': 'ok'}
+    mock_sdk.constantine.patch_and_pr.return_value = {'status': 'ok'}
+    mock_sdk.constantine.validate.return_value = {'status': 'ok'}
+    mock_sdk.constantine.manifest.return_value = {'presets': []}
+    mock_sdk.osint.guess_repo.return_value = {'repo': 'https://github.com/org/repo'}
+    mock_sdk.osint.submit.return_value = {'status': 'ok'}
+    mock_sdk.osint.create_technology.return_value = {'status': 'ok'}
+    mock_sdk.remediation.select_patch.return_value = {'status': 'ok'}
+    mock_sdk.remediation.clear_patch.return_value = {'status': 'ok'}
+    mock_sdk.remediation.create_pr.return_value = {'status': 'ok'}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=mock_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        result = runner.invoke(
+            chariot, list(args),
+            obj={'keychain': MagicMock(), 'proxy': ''},
+        )
+    return result, mock_sdk
+
+
+# --- Constantine commands ---
+
+def test_constantine_exploit():
+    result, sdk = _invoke('constantine', 'exploit', '--risk-keys', 'key1,key2')
+    assert result.exit_code == 0
+    sdk.constantine.exploit.assert_called_once_with(['key1', 'key2'])
+
+
+def test_constantine_exploit_single_key():
+    result, sdk = _invoke('constantine', 'exploit', '--risk-keys', '#risk#example.com#CVE-1')
+    assert result.exit_code == 0
+    sdk.constantine.exploit.assert_called_once_with(['#risk#example.com#CVE-1'])
+
+
+def test_constantine_exploit_missing_keys():
+    result, _ = _invoke('constantine', 'exploit')
+    assert result.exit_code != 0
+
+
+def test_constantine_patch():
+    result, sdk = _invoke('constantine', 'patch', '--risk-keys', 'key1,key2')
+    assert result.exit_code == 0
+    sdk.constantine.patch.assert_called_once_with(['key1', 'key2'])
+
+
+def test_constantine_patch_missing_keys():
+    result, _ = _invoke('constantine', 'patch')
+    assert result.exit_code != 0
+
+
+def test_constantine_patch_and_pr():
+    result, sdk = _invoke('constantine', 'patch-and-pr', '--risk-key', '#risk#ex#CVE-1')
+    assert result.exit_code == 0
+    sdk.constantine.patch_and_pr.assert_called_once_with('#risk#ex#CVE-1')
+
+
+def test_constantine_patch_and_pr_missing_key():
+    result, _ = _invoke('constantine', 'patch-and-pr')
+    assert result.exit_code != 0
+
+
+def test_constantine_validate():
+    result, sdk = _invoke('constantine', 'validate', '--risk-keys', 'k1,k2,k3')
+    assert result.exit_code == 0
+    sdk.constantine.validate.assert_called_once_with(['k1', 'k2', 'k3'])
+
+
+def test_constantine_manifest():
+    result, sdk = _invoke('constantine', 'manifest')
+    assert result.exit_code == 0
+    sdk.constantine.manifest.assert_called_once()
+
+
+# --- OSINT commands ---
+
+def test_osint_guess_repo_with_cpe():
+    result, sdk = _invoke('osint', 'guess-repo', '--cpe', 'cpe:2.3:a:apache:httpd')
+    assert result.exit_code == 0
+    sdk.osint.guess_repo.assert_called_once_with(cpe='cpe:2.3:a:apache:httpd', technology_name=None)
+
+
+def test_osint_guess_repo_with_name():
+    result, sdk = _invoke('osint', 'guess-repo', '--technology-name', 'OpenSSL')
+    assert result.exit_code == 0
+    sdk.osint.guess_repo.assert_called_once_with(cpe=None, technology_name='OpenSSL')
+
+
+def test_osint_guess_repo_no_args():
+    result, _ = _invoke('osint', 'guess-repo')
+    assert 'ERROR' in result.output
+
+
+def test_osint_submit():
+    result, sdk = _invoke('osint', 'submit', '--repo-url', 'https://github.com/org/repo')
+    assert result.exit_code == 0
+    sdk.osint.submit.assert_called_once_with(
+        'https://github.com/org/repo',
+        technology_key=None, goal=None, pipeline=None, scan_mode=None)
+
+
+def test_osint_submit_with_options():
+    result, sdk = _invoke(
+        'osint', 'submit',
+        '--repo-url', 'https://github.com/org/repo',
+        '--pipeline', 'premium-legacy',
+        '--scan-mode', 'full')
+    assert result.exit_code == 0
+    sdk.osint.submit.assert_called_once_with(
+        'https://github.com/org/repo',
+        technology_key=None, goal=None, pipeline='premium-legacy', scan_mode='full')
+
+
+def test_osint_submit_missing_url():
+    result, _ = _invoke('osint', 'submit')
+    assert result.exit_code != 0
+
+
+def test_osint_submit_invalid_scan_mode():
+    result, _ = _invoke('osint', 'submit', '--repo-url', 'https://x.com/r', '--scan-mode', 'bad')
+    assert result.exit_code != 0
+
+
+def test_osint_create_technology():
+    result, sdk = _invoke('osint', 'create-technology', '--cpe', 'cpe:2.3:a:openssl:openssl:3.0.0')
+    assert result.exit_code == 0
+    sdk.osint.create_technology.assert_called_once_with('cpe:2.3:a:openssl:openssl:3.0.0')
+
+
+def test_osint_create_technology_missing_cpe():
+    result, _ = _invoke('osint', 'create-technology')
+    assert result.exit_code != 0
+
+
+# --- Remediation commands ---
+
+def test_remediation_select():
+    result, sdk = _invoke(
+        'remediation', 'select',
+        '--risk-key', 'rk1', '--finding-id', 'f1', '--option-id', 'opt1')
+    assert result.exit_code == 0
+    sdk.remediation.select_patch.assert_called_once_with('rk1', 'f1', 'opt1', strategy=None)
+
+
+def test_remediation_select_with_strategy():
+    result, sdk = _invoke(
+        'remediation', 'select',
+        '--risk-key', 'rk1', '--finding-id', 'f1', '--option-id', 'opt1',
+        '--strategy', 'minimal')
+    assert result.exit_code == 0
+    sdk.remediation.select_patch.assert_called_once_with('rk1', 'f1', 'opt1', strategy='minimal')
+
+
+def test_remediation_select_missing_required():
+    result, _ = _invoke('remediation', 'select', '--risk-key', 'rk1')
+    assert result.exit_code != 0
+
+
+def test_remediation_clear():
+    result, sdk = _invoke(
+        'remediation', 'clear', '--risk-key', 'rk1', '--finding-id', 'f1')
+    assert result.exit_code == 0
+    sdk.remediation.clear_patch.assert_called_once_with('rk1', 'f1')
+
+
+def test_remediation_clear_missing_required():
+    result, _ = _invoke('remediation', 'clear', '--risk-key', 'rk1')
+    assert result.exit_code != 0
+
+
+def test_remediation_create_pr():
+    result, sdk = _invoke(
+        'remediation', 'create-pr', '--risk-key', 'rk1', '--finding-id', 'f1')
+    assert result.exit_code == 0
+    sdk.remediation.create_pr.assert_called_once_with('rk1', 'f1')
+
+
+def test_remediation_create_pr_missing_required():
+    result, _ = _invoke('remediation', 'create-pr', '--risk-key', 'rk1')
+    assert result.exit_code != 0

--- a/praetorian_cli/sdk/test/test_enrichment_cli.py
+++ b/praetorian_cli/sdk/test/test_enrichment_cli.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.enrichment_admin  # noqa: F401
+from praetorian_cli.handlers.chariot import chariot
+
+
+def _invoke(*args, stdin=None):
+    runner = CliRunner()
+    mock_sdk = MagicMock()
+    mock_sdk.enrichment_admin.status.return_value = {'enabled': True}
+    mock_sdk.enrichment_admin.enabled.return_value = {'plugins': []}
+    mock_sdk.enrichment_admin.global_enabled.return_value = {'enabled': True}
+    mock_sdk.enrichment_admin.set_global_enabled.return_value = {'status': 'ok'}
+    mock_sdk.enrichment_admin.credits.return_value = {'credits': 100}
+    mock_sdk.enrichment_admin.plugin_status.return_value = {'status': 'active'}
+    mock_sdk.enrichment_admin.plugin_credits.return_value = {'credits': 50}
+    mock_sdk.enrichment_admin.set_plugin_enabled.return_value = {'status': 'ok'}
+    mock_sdk.enrichment_admin.set_plugin_key.return_value = {'status': 'ok'}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=mock_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        result = runner.invoke(
+            chariot, list(args),
+            obj={'keychain': MagicMock(), 'proxy': ''},
+            input=stdin,
+        )
+    return result, mock_sdk
+
+
+def test_enrichment_status():
+    result, sdk = _invoke('enrichment', 'status')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.status.assert_called_once()
+
+
+def test_enrichment_enabled():
+    result, sdk = _invoke('enrichment', 'enabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.enabled.assert_called_once()
+
+
+def test_enrichment_global_enabled():
+    result, sdk = _invoke('enrichment', 'global-enabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.global_enabled.assert_called_once()
+
+
+def test_set_global_enabled_on():
+    result, sdk = _invoke('enrichment', 'set-global-enabled', '--enabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.set_global_enabled.assert_called_once_with(True)
+
+
+def test_set_global_enabled_off():
+    result, sdk = _invoke('enrichment', 'set-global-enabled', '--disabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.set_global_enabled.assert_called_once_with(False)
+
+
+def test_enrichment_credits():
+    result, sdk = _invoke('enrichment', 'credits')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.credits.assert_called_once()
+
+
+def test_plugin_status():
+    result, sdk = _invoke('enrichment', 'plugin-status', 'shodan')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.plugin_status.assert_called_once_with('shodan')
+
+
+def test_plugin_credits():
+    result, sdk = _invoke('enrichment', 'plugin-credits', 'shodan')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.plugin_credits.assert_called_once_with('shodan')
+
+
+def test_set_enabled_on():
+    result, sdk = _invoke('enrichment', 'set-enabled', 'shodan', '--enabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.set_plugin_enabled.assert_called_once_with('shodan', True)
+
+
+def test_set_enabled_off():
+    result, sdk = _invoke('enrichment', 'set-enabled', 'shodan', '--disabled')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.set_plugin_enabled.assert_called_once_with('shodan', False)
+
+
+def test_set_key_from_stdin():
+    result, sdk = _invoke('enrichment', 'set-key', 'shodan', stdin='sk-test-key-123\n')
+    assert result.exit_code == 0
+    sdk.enrichment_admin.set_plugin_key.assert_called_once_with('shodan', 'sk-test-key-123')
+
+
+def test_set_key_empty_stdin():
+    result, _ = _invoke('enrichment', 'set-key', 'shodan', stdin='\n')
+    assert 'ERROR' in result.output
+
+
+def test_plugin_status_missing_plugin():
+    result, _ = _invoke('enrichment', 'plugin-status')
+    assert result.exit_code != 0


### PR DESCRIPTION
> **PR Stack (3/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> **3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)** (this PR)
> 4. #268 Knossos, Aegis management (st7-st9)
> 5. #269 Red Team CLI (st5)
> 6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> 8. #272 share, leaderboard, misc, multipart (st18-st21)
> 9. #244 skills, risk-status, conversation UX
> 10. #243 Hannibal hunt CLI + TUI
> 11. #228 Marcus terminal hardening
> 12. #226 module management system


## Summary
- **Constantine pipeline** (`guard constantine exploit|patch|patch-and-pr|validate|manifest`) — trigger exploit-only, patch-only, or patch+PR runs against risk keys, validate previous results, and view the manifest
- **OSINT operations** (`guard osint guess-repo|submit|create-technology`) — identify repos from CPE/technology name, submit repos for scanning, create technologies from CPEs
- **Remediation** (`guard remediation select|clear|create-pr`) — select/clear patch options and create GitHub PRs from selected patches
- **Enrichment admin** (`guard enrichment status|enabled|global-enabled|set-global-enabled|credits|plugin-status|plugin-credits|set-enabled|set-key`) — full enrichment plugin lifecycle management with secure key input via stdin

Each command has a corresponding SDK entity wired into `Chariot`. 38 unit tests.

Covers [ENG-6613](https://linear.app/praetorianlabs/issue/ENG-6613) (ST-6) and [ENG-6615](https://linear.app/praetorianlabs/issue/ENG-6615) (ST-8).

## Test plan
- [x] 38 CLI unit tests pass (`pytest test_constantine_cli.py test_enrichment_cli.py`)
- [x] Argument validation (missing required options, invalid scan-mode choices)
- [x] Enrichment `set-key` reads from stdin, rejects empty input
- [x] Comma-separated risk-key splitting in Constantine commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)