### PR TITLE
feat: Red Team CLI — deployment, campaigns, domains, evilginx, payload

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   claude-code-action:
     uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@3fb9ffbace86c9e93a7b92170241dd54b5031608  # v2.11.3

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -23,6 +23,6 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      model: "gpt-5.5"
+      model: "gpt-5.6-sol"
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Developers](#developers)
     - [SDK](#sdk)
     - [Developing external scripts](#developing-external-scripts)
+    - [Running the test suite](#running-the-test-suite)
     - [Contributing](#contributing)
     - [Support](#support)
     - [License](#license)
@@ -344,6 +345,49 @@ guard --account guard+example@praetorian.com script --help
 
 For developing scripts, you can refer to
 this [readme file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/script-development.md).
+
+
+## Running the test suite
+
+`guard test` runs the integration suites that ship with the package. **Some of
+those suites create, modify and delete real entities in whatever account the
+selected profile points at**, so the command is gated.
+
+Suites are selected with `-s`/`--suite`:
+
+| Suite | What it runs | Touches a live account? |
+| --- | --- | --- |
+| `safe` *(default)* | Local, offline unit tests | No |
+| `coherence` | End-to-end entity lifecycle tests | **Yes — creates and deletes assets, risks, settings, configurations** |
+| `cli` | CLI-level integration tests | **Yes — mutating** |
+| `tui` | Terminal UI tests | No |
+
+A bare `guard test` runs the `safe` suite only. It executes with a temporary
+`HOME` and with credential environment variables stripped, so it cannot reach
+your real credentials.
+
+The mutating suites additionally require:
+
+1. **An explicit profile and account.** Both must be given and non-empty —
+   `guard --profile <profile> --account <account> test --suite coherence`.
+   There is no fallback: an unset or blank value is an error, so the suite can
+   never quietly run against a default profile.
+2. **Interactive confirmation.** The command prints the suite, profile, account,
+   and whether the suite is live and mutating, then asks you to confirm.
+   Declining — or a non-interactive invocation, which cannot confirm — exits
+   non-zero without running any test.
+
+```zsh
+# Safe by default — no account is touched.
+guard test
+
+# Mutating suite: target must be explicit, and you must confirm.
+guard --profile "United States" --account guard+scratch@praetorian.com \
+    test --suite coherence
+```
+
+Never point a mutating suite at a production account. Use a dedicated scratch
+account whose contents you are willing to lose.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -172,15 +172,18 @@ deliberately quiet and infrequent:
   plain file that belongs to you and is no larger than 64 KiB. Anything else at
   that path is ignored as though it were absent, so the next invocation refreshes
   and replaces it rather than trusting what it found. Commands that start at the
-  same instant are excluded by a marker file created beside that record, so eight
-  concurrent invocations perform one refresh rather than eight — including when
-  the request fails instantly, since the attempt is recorded before it is made.
-  A process killed mid-refresh leaves the marker behind, which defers the next
-  refresh that is actually due rather than permitting an extra one — by up to a
-  minute, or up to two if the clock steps backwards in between, since a marker
-  counts as held while its age is within a minute in *either* direction. A
-  relative `XDG_CACHE_HOME` is
-  ignored in favour of `~/.cache`, as the base-directory spec requires —
+  same instant are *not* excluded from one another: each reads the same stale
+  record before any of them writes, so eight simultaneous invocations may each
+  refresh once. That is an accepted tradeoff rather than an oversight — all
+  eight then write the record, so the following 24 hours are quiet; the gates
+  below already skip non-interactive and CI sessions, which leaves simultaneous
+  *interactive* invocations rare; and a duplicate refresh costs one CDN-backed
+  GET. An exclusion held by path was measured to be worse than none: a claim
+  that cannot identify its own holder unlinks a live peer's claim and so defeats
+  the very limit it was added to guarantee. Each write is an atomic
+  same-directory rename, so a reader always sees one writer's whole record,
+  never a torn one. A relative `XDG_CACHE_HOME` is ignored in favour of
+  `~/.cache`, as the base-directory spec requires —
   honouring it would put a separate cache in every working directory and so
   defeat the limit outright. If the cache directory cannot be written at all (a
   read-only home, one owned by another user, or one reached through a symlink),

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [Signing up](#signing-up)
     - [Authentication](#authentication)
 - [Using the CLI](#using-the-cli)
+    - [Update checks](#update-checks)
 - [Operators](#operators)
     - [Interactive Console](#interactive-console)
     - [Install local security tools (optional)](#install-local-security-tools-optional)
@@ -150,6 +151,72 @@ To get detailed information about a specific asset, run:
 ```zsh
 guard --account guard+example@praetorian.com get asset <ASSET_KEY>
 ```
+
+## Update checks
+
+After a command finishes, the CLI may check PyPI for a newer release of
+`praetorian-cli` and print a three-line upgrade advisory to stderr. The check is
+deliberately quiet and infrequent:
+
+- **At most once every 24 hours.** Every attempt is recorded at
+  `${XDG_CACHE_HOME:-~/.cache}/praetorian-cli/update-check.json` *before* the
+  request is made, so a refresh that fails — offline, DNS, timeout, a malformed
+  response — is rate-limited exactly like one that succeeds, and keeps
+  advertising the last version it did learn. Between refreshes the check reads
+  that file and makes no network request at all — as long as the record is a
+  plain file that belongs to you and is no larger than 64 KiB. Anything else at
+  that path is ignored as though it were absent, so the next invocation refreshes
+  and replaces it rather than trusting what it found. Commands that start at the
+  same instant are excluded by a marker file created beside that record, so eight
+  concurrent invocations perform one refresh rather than eight — including when
+  the request fails instantly, since the attempt is recorded before it is made.
+  A process killed mid-refresh leaves the marker behind, which defers the next
+  refresh that is actually due rather than permitting an extra one — by up to a
+  minute, or up to two if the clock steps backwards in between, since a marker
+  counts as held while its age is within a minute in *either* direction. A
+  relative `XDG_CACHE_HOME` is
+  ignored in favour of `~/.cache`, as the base-directory spec requires —
+  honouring it would put a separate cache in every working directory and so
+  defeat the limit outright. If the cache directory cannot be written at all (a
+  read-only home, one owned by another user, or one reached through a symlink),
+  the check does not run: a probe whose rate we cannot limit is one we do not
+  send.
+- **Only when a human is watching.** It is skipped unless **both** stdout and
+  stderr are a terminal, and skipped when `CI` or `GITHUB_ACTIONS` is set or
+  `TERM=dumb`. Piping either stream — `guard list assets | jq` — turns it off.
+  A script you launch by hand from your own terminal inherits your terminal, so
+  treat the opt-out below, not this gate, as the way to guarantee silence.
+- **Never in place of your command's work.** A command that raises skips the
+  check, and a group that is only delegating to a subcommand leaves the check to
+  the subcommand that does the work. A command that reports an error but still
+  exits `0` is the one case where an advisory can follow a visible error.
+- **Not on the path you run day to day.** The daily refresh passes a 2-second
+  timeout to `requests`, which bounds how long the server may go without
+  sending data — not total wall-clock, so DNS, TLS, redirects and a slow trickle
+  are outside it. Ordinary failures are swallowed and cannot change your exit
+  code; `Ctrl-C` and process-control exceptions raised during the check still
+  propagate, by design, so that interrupting the CLI always works.
+
+### Disabling it
+
+```zsh
+export PRAETORIAN_CLI_DISABLE_UPDATE_CHECK=1
+```
+
+`1`, `true`, `yes` or `on` (any case). Nothing is read or written — no request,
+no cache file.
+
+### Privacy
+
+A refresh is an unauthenticated `GET` to `https://pypi.org/pypi/praetorian-cli/json`.
+It sends no account, profile, command, or argument — only what any HTTPS request
+inherently reveals to the server: your IP address and the fact that some
+`praetorian-cli` install asked for the package index at that moment. Because
+every attempt is recorded before it is made and concurrent attempts are
+excluded, that happens at most once per day per user account on the machine —
+several users each get their own cache — so your per-command usage cadence is
+not exposed. If contacting
+pypi.org at all is unacceptable in your environment, set the variable above.
 
 # Operators
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ export PRAETORIAN_CLI_API_KEY_ID=your-api-key-id-here
 export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-here
 ```
 
+The backend API URL and the Cognito emulator endpoint (`aws_endpoint_url`)
+must be HTTPS; the CLI refuses to send credentials over plaintext HTTP. For local development against a loopback endpoint (`localhost`,
+`127.0.0.1`, `::1`), set `PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1`.
+
 For more advanced configuration options or managing access in SSO organizations see
 [the documentation on configuration](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/configure.md).
 

--- a/README.md
+++ b/README.md
@@ -379,8 +379,11 @@ guard engagement create-vault --client acme --sow SOW-1234 --sku WAPT --github-u
 The `red-team` family drives Praetorian's phishing and red-team infrastructure: the deployment lifecycle,
 phishing campaigns, parked domains and their DNS, Mailgun mail delivery, Evilginx phishing proxies, and
 payload generation. Like `engagement` and `configuration`, these commands are limited to Praetorian
-engineers — the check is enforced in the SDK as well as the CLI, so the same restriction applies to
-scripts and to the MCP server.
+engineers. The check now runs at the SDK layer as well as the CLI, so the same restriction applies to
+scripts and to the MCP server rather than to interactive use alone. Note what that check is: it
+compares the email address in the local keychain against a Praetorian suffix, so it is a client-side
+operator guardrail against reaching for the wrong tool — not a trust boundary. Anyone able to edit
+their own keychain can pass it. Authorization for these operations has to be enforced server-side.
 
 Every `red_team_*` MCP tool is classified sensitive, so none of them is exposed to an MCP client unless
 an allow entry names it exactly (see [SDK](#sdk)).
@@ -434,11 +437,14 @@ guard red-team phishkit-nodes --status all
 
 Two conventions run through the family:
 
-- **JSON bodies come from a file or stdin.** Commands that take a JSON document accept `-f/--file PATH`.
-  When `--file` is omitted, stdin is read automatically (matching the SDK test patterns). `--file -`
-  makes the stdin source explicit. Prefer the file form on `deployment apply`: stdin is also the
-  confirmation channel, so a piped payload leaves the prompt with nothing to read and the command
-  aborts unless `--yes` is given.
+- **JSON bodies come from stdin or a file.** Commands that take a JSON document read stdin when
+  `--file` is omitted; `-f/--file PATH` reads a file instead, and `--file -` names stdin explicitly.
+  `deployment apply` is the one body-reading command that also prompts, so there stdin carries both
+  the confirmation answer and the payload: either pass `--file` and answer the prompt interactively,
+  pass `--yes` to skip it, or prefix the piped payload with `y` on its own line. A bare piped JSON
+  body aborts — the prompt consumes the body's first line, rejects it as invalid input, and hits
+  end-of-input. That is a safe default rather than a bypass: no valid JSON document can begin with a
+  line that is exactly `y` or `yes`, so a payload can never answer its own prompt.
 - **Secrets stay off the command line.** Evilginx phishlet parameters (OAuth client IDs and secrets,
   session tokens) and payload template variables can be passed inline with `--params` / `--variables`,
   but an inline value is visible in process listings and shell history. Use `--params-file` /

--- a/README.md
+++ b/README.md
@@ -434,8 +434,9 @@ guard red-team phishkit-nodes --status all
 
 Two conventions run through the family:
 
-- **JSON bodies come from a file.** Commands that take a JSON document accept `-f/--file PATH`, and
-  `--file -` reads stdin as before. Prefer the file form on `deployment apply`: stdin is also the
+- **JSON bodies come from a file or stdin.** Commands that take a JSON document accept `-f/--file PATH`.
+  When `--file` is omitted, stdin is read automatically (matching the SDK test patterns). `--file -`
+  makes the stdin source explicit. Prefer the file form on `deployment apply`: stdin is also the
   confirmation channel, so a piped payload leaves the prompt with nothing to read and the command
   aborts unless `--yes` is given.
 - **Secrets stay off the command line.** Evilginx phishlet parameters (OAuth client IDs and secrets,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
     - [Install local security tools (optional)](#install-local-security-tools-optional)
     - [Marcus Aurelius AI](#marcus-aurelius-ai)
     - [Security Tools](#security-tools)
+    - [Red Team](#red-team)
 - [Developers](#developers)
     - [SDK](#sdk)
     - [Developing external scripts](#developing-external-scripts)
@@ -372,6 +373,79 @@ guard engagement list
 guard engagement create-customer --email ops@acme.com --name "ACME Corp"
 guard engagement create-vault --client acme --sow SOW-1234 --sku WAPT --github-user jdoe
 ```
+
+## Red Team
+
+The `red-team` family drives Praetorian's phishing and red-team infrastructure: the deployment lifecycle,
+phishing campaigns, parked domains and their DNS, Mailgun mail delivery, Evilginx phishing proxies, and
+payload generation. Like `engagement` and `configuration`, these commands are limited to Praetorian
+engineers — the check is enforced in the SDK as well as the CLI, so the same restriction applies to
+scripts and to the MCP server.
+
+Every `red_team_*` MCP tool is classified sensitive, so none of them is exposed to an MCP client unless
+an allow entry names it exactly (see [SDK](#sdk)).
+
+```zsh
+# Deployment lifecycle
+guard red-team deployment launch
+guard red-team deployment details
+guard red-team deployment history
+guard red-team deployment last-inputs
+guard red-team deployment node-schema --tag v1.2.3
+guard red-team deployment tags
+guard red-team deployment collaborators --collaborators user1@co.com,user2@co.com
+guard red-team deployment plan --file builder.json
+guard red-team deployment apply --file builder.json          # prompts; --yes skips
+guard red-team deployment delete --force                     # prompts; --yes skips
+
+# Campaigns
+guard red-team campaign create --file campaign.json
+guard red-team campaign targets --id camp-1 --file targets.json
+guard red-team campaign authorize --id camp-1                # prompts: sends live phishing email
+guard red-team campaign funnel --id camp-1
+guard red-team campaign activity --id camp-1 --limit 100
+guard red-team campaign delete --key "#campaign#camp-1"      # prompts; --yes skips
+
+# Domain parking, DNS, and Mailgun
+guard red-team domain update --file domain.json
+guard red-team domain dns-list --domain evil.com
+guard red-team domain dns-create --domain evil.com --type A --name www --content 1.2.3.4
+guard red-team domain dns-update --domain evil.com --record-id abc123 --type A --name www --content 1.2.3.4
+guard red-team domain dns-delete --domain evil.com --record-id abc123   # prompts; --yes skips
+guard red-team domain mailgun-status --domain evil.com
+guard red-team domain mailgun-provision --domain evil.com
+guard red-team domain mailgun-domain-delete --domain evil.com          # prompts; --yes skips
+guard red-team domain mailgun-user --username noreply --domain evil.com
+guard red-team domain mailgun-user-delete --username noreply --domain evil.com  # prompts; --yes skips
+
+# Evilginx
+guard red-team evilginx phishlets --node node-ref-1
+guard red-team evilginx phishlet-params --node node-ref-1 --name o365
+guard red-team evilginx configure --node node-ref-1 --domain evil.com --phishlet o365 \
+    --params-file phishlet-params.json
+guard red-team evilginx lures --node node-ref-1
+guard red-team evilginx create-lure --node node-ref-1 --path /login
+guard red-team evilginx status --node node-ref-1
+
+# Payloads and phishkit nodes
+guard red-team payload-generate --shellcode beacon.bin --variables-file payload-vars.json
+guard red-team phishkit-nodes --status all
+```
+
+Two conventions run through the family:
+
+- **JSON bodies come from a file.** Commands that take a JSON document accept `-f/--file PATH`, and
+  `--file -` reads stdin as before. Prefer the file form on `deployment apply`: stdin is also the
+  confirmation channel, so a piped payload leaves the prompt with nothing to read and the command
+  aborts unless `--yes` is given.
+- **Secrets stay off the command line.** Evilginx phishlet parameters (OAuth client IDs and secrets,
+  session tokens) and payload template variables can be passed inline with `--params` / `--variables`,
+  but an inline value is visible in process listings and shell history. Use `--params-file` /
+  `--variables-file` for anything sensitive; supplying both forms of the same value is an error.
+
+Every destructive command — deployment delete, terraform apply, campaign delete, DNS record delete,
+Mailgun domain and user delete — prompts for confirmation, and `campaign authorize` prompts because it
+starts delivering live phishing email to real recipients. Pass `--yes` to skip a prompt in automation.
 
 # Developers
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -52,6 +52,16 @@ export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-secret-here
 
 Environment variables take precedence over keychain file settings.
 
+The backend URL (the `api` field, or `PRAETORIAN_CLI_API`) and the Cognito
+emulator endpoint (the `aws_endpoint_url` field) must be HTTPS URLs; the CLI
+refuses to send credentials over plaintext HTTP. The one exception is a
+loopback endpoint (`localhost`, `127.0.0.1`, `::1`) for local development, which
+requires an explicit opt-in:
+
+```bash
+export PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1
+```
+
 ## Multiple profiles
 
 Similar to the pattern used in AWS CLI configuration files, the keychain file is

--- a/praetorian_cli/handlers/agent.py
+++ b/praetorian_cli/handlers/agent.py
@@ -7,6 +7,11 @@ from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
 from praetorian_cli.handlers.utils import error
 
+# Default MCP tool allow profile: read-only query/list/get tools. Sensitive
+# tools (see praetorian_cli.sdk.mcp_server.SENSITIVE_TOOL_PATTERNS) are never
+# matched by these wildcards — they require an exact-name -a entry.
+DEFAULT_MCP_TOOLS = ['search_by_query', '*_list', '*_get']
+
 
 @chariot.group()
 def agent():
@@ -38,19 +43,28 @@ def mcp():
 
 @mcp.command()
 @cli_handler
-@click.option('--allowed', '-a', type=str, multiple=True, default=['search_by_query', '*_list', '*_get'])
+@click.option('--allowed', '-a', type=str, multiple=True, default=DEFAULT_MCP_TOOLS)
 def start(sdk, allowed):
     """ Starts the Guard MCP server
+
+    The default profile exposes read-only query/list/get tools. Tools that
+    return or manage secrets (accounts_*, credentials_*, integrations_*,
+    keys_*, webhook_*) are never matched by wildcard patterns — the default
+    profile included — and are only exposed by passing the exact tool name
+    with -a (e.g. -a credentials_get). Opting in accounts_assume_role is
+    higher-consequence than a read tool: it switches the session's tenant for
+    all subsequent tool calls.
 
     \b
     Example usages:
         - guard agent mcp start
         - guard agent mcp start -a search_by_term -a risk_add
         - guard agent mcp start -a search_* -a risk_add
+        - guard agent mcp start -a credentials_get # exact name required for sensitive tools
 
     \b
     Claude code configuration/usage:
-        - claude mcp add chariot -- guard agent mcp start # read-only
+        - claude mcp add chariot -- guard agent mcp start # default read-only, non-sensitive tools
         - claude mcp add chariot -- guard agent mcp start -a search_by_query -a risk_add -a asset_add # select write tools
         - claude "show me my chariot assets from the example.com domain"
         - claude "show me my chariot assets with port 22 open"
@@ -61,10 +75,14 @@ def start(sdk, allowed):
     sdk.agents.start_mcp_server(allowed)
 
 @mcp.command()
-@click.option('--allowed', '-a', type=str, multiple=True, default=['search_by_query', '*_list', '*_get'])
+@click.option('--allowed', '-a', type=str, multiple=True, default=DEFAULT_MCP_TOOLS)
 @cli_handler
 def tools(sdk, allowed):
     """ Lists available mcp tools
+
+    Sensitive tools (accounts_*, credentials_*, integrations_*, keys_*,
+    webhook_*) never match wildcard patterns and appear only when named
+    exactly with -a.
 
     \b
     Example usages:

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -9,7 +9,9 @@ def chariot(click_context):
     if isinstance(click_context.obj, TestTarget):
         return
 
-    # import done here to avoid circular import errors in praetorian_cli/handlers/cli_decorators.py
+    # Deferred import: keeps the cost of importing the whole SDK off the
+    # module-import path, so `guard --help` and unrelated commands do not pay
+    # for it. ENG-6585 owns making this lazy loading systematic.
     from praetorian_cli.sdk.chariot import Chariot
 
     """ Command group for interacting with the Guard product """

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -4,6 +4,11 @@ import click
 @click.group()
 @click.pass_context
 def chariot(click_context):
+    from praetorian_cli.handlers.test import TestTarget
+
+    if isinstance(click_context.obj, TestTarget):
+        return
+
     # import done here to avoid circular import errors in praetorian_cli/handlers/cli_decorators.py
     from praetorian_cli.sdk.chariot import Chariot
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,10 +1,19 @@
+import errno
+import json
+import os
+import stat
+import sys
+import tempfile
+import threading
+import time
 from concurrent.futures import CancelledError
 from functools import wraps
 from importlib.metadata import version
+from pathlib import Path
 
 import click
 import requests
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from praetorian_cli.handlers.utils import error
 
@@ -58,26 +67,558 @@ def handle_error(func):
     return wrapper
 
 
+# POLICY: the update advisory is best-effort. It is skipped when the session is
+# not interactive, when the opt-out env var is set, and when a group callback is
+# merely delegating to a subcommand; it carries no command context (no argv,
+# profile, account, or custom headers), bounds its network refresh to
+# `UPDATE_CHECK_DEADLINE_SECONDS` of wall clock, and fails open -- no ordinary
+# failure of it changes a command outcome. The cache is private where the
+# platform enforces POSIX modes: 0700 directory, 0600 file, atomic
+# same-directory replace.
+#
+# POLICY: the throttle record orders SEQUENTIAL invocations only. N truly
+# simultaneous ones all read the stale record before any of them writes, so each
+# may probe once -- an accepted tradeoff: all of them then write the record, so
+# the next TTL is quiet, and the gates above already exclude non-interactive and
+# CI sessions, which leaves simultaneous interactive invocations rare. Do NOT
+# reintroduce a claim held BY PATH to close it: a claim that cannot identify its
+# own holder unlinks a live peer's claim and defeats the rate limit it was built
+# to guarantee (measured), and a duplicate refresh costs one CDN-backed GET
+# against an already-atomic record write.
+#
+# WHERE TO CHANGE: cadence, opt-out, endpoint, per-socket timeout, total
+# wall-clock deadline, and the sizes a record and a response body may reach
+# before they are refused are the constants below; the advisory itself is
+# `_check_for_update`.
+UPDATE_CHECK_CACHE_MAX_BYTES = 64 * 1024
+UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
+UPDATE_CHECK_DEADLINE_SECONDS = 3
+UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
+UPDATE_CHECK_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
+UPDATE_CHECK_NON_INTERACTIVE_ENV = ("CI", "GITHUB_ACTIONS")
+UPDATE_CHECK_RESPONSE_MAX_BYTES = 1024 * 1024
+UPDATE_CHECK_TIMEOUT_SECONDS = 2
+UPDATE_CHECK_URL = "https://pypi.org/pypi/praetorian-cli/json"
+
+
+def _session_is_interactive():
+    """True only when a human is plausibly watching this invocation.
+
+    BOTH streams must be a terminal. An stderr-only gate does not hold: in
+    `guard list assets | jq` only stdout is redirected, so stderr stays a tty
+    and the advisory still fires -- the piped, scripted, high-volume case whose
+    cadence this is supposed to stop leaking. `CI`/`GITHUB_ACTIONS`/`TERM=dumb`
+    cover the runners that allocate a pty anyway.
+    """
+    try:
+        if not (sys.stdout.isatty() and sys.stderr.isatty()):
+            return False
+    except Exception:
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return not any(os.environ.get(name) for name in UPDATE_CHECK_NON_INTERACTIVE_ENV)
+
+
+def _update_check_disabled():
+    """Accept any conventional truthy value, not only `1`.
+
+    This is a privacy opt-out: a user who exports `=true` and still gets network
+    requests has been silently overruled by a parsing detail.
+    """
+    return os.environ.get(UPDATE_CHECK_DISABLE_ENV, "").strip().lower() in UPDATE_CHECK_DISABLE_VALUES
+
+
+def _delegating_to_subcommand():
+    """True when this callback is a group about to invoke a subcommand.
+
+    Click runs a group callback BEFORE its subcommand (measured), so an advisory
+    printed here precedes the work the user asked for, and still prints when that
+    subcommand goes on to fail. The leaf command runs its own check, so skipping
+    here loses nothing -- and it needs no hand-maintained command list.
+    """
+    ctx = click.get_current_context(silent=True)
+    return ctx is not None and ctx.invoked_subcommand is not None
+
+
+def _update_check_cache_path():
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    # POLICY: a relative `XDG_CACHE_HOME` is ignored, as the XDG base-directory
+    # spec requires. Honouring one resolves the cache against the current working
+    # directory, so every invocation from a different directory sees a cold cache
+    # and re-probes. An empty value is falsy and already falls back here.
+    if cache_home and not Path(cache_home).is_absolute():
+        cache_home = None
+    base = Path(cache_home) if cache_home else Path.home() / ".cache"
+    return base / "praetorian-cli" / "update-check.json"
+
+
+def _path_is_owned_by_effective_user(path):
+    """True when `path` belongs to us -- and on platforms that have no uids.
+
+    POLICY: `os.geteuid` is POSIX-only, so its absence must read as "owned"
+    rather than take the advisory down; an unguarded POSIX-only call has done
+    the latter here once already.
+    """
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return True
+    return path.stat().st_uid == geteuid()
+
+
+def _parse_version(raw):
+    """A `Version`, or None when the value is absent or unparseable.
+
+    Returning None rather than raising is what keeps a malformed PyPI payload
+    from killing the advisory through the fail-open arm (measured: an
+    unparseable release key took the advisory from 0 to 1). It does not shorten
+    a blackout: a fresh entry short-circuits the refresh whether or not its
+    version parsed, and such an entry stays silent until its TTL expires -- at
+    which point it does recover.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
+
+
+def _read_update_check_cache(cache_path):
+    """`(checked_at, latest_version_or_None)`, or None when there is no usable record.
+
+    A record with a null or unparseable version is still returned: it throttles.
+
+    POLICY: the record is opened by DESCRIPTOR and validated before a byte of it
+    is read. Nothing has vetted this path yet -- on a cold cache this is the
+    first thing in the module to touch it -- and a plain `open` here trusts
+    whatever is sitting at the path: it blocks in the kernel forever on a planted
+    FIFO, raising no `OSError` for either fail-open arm to catch, and hands
+    `json.load` an unbounded read of a device or an oversized file. `O_NONBLOCK`
+    refuses the FIFO, `O_NOFOLLOW` the symlink, `S_ISREG` a device reached any
+    other way, the size cap the oversized regular file, and the uid check a
+    record planted by another user. Every refusal is raised as an `OSError`, so
+    the arm below already reads it as "no usable record".
+
+    POLICY: the `fstat` size check is the cheap first line of defence, not the
+    enforcement -- it describes the file as of the stat, and the read that
+    follows is a separate syscall on the same descriptor. So the read is bounded
+    too: at most `UPDATE_CHECK_CACHE_MAX_BYTES + 1` bytes, and one byte over the
+    ceiling is refused as `EFBIG` for the arm below (measured: an unbounded
+    `json.load` on a descriptor whose file grew after the stat yielded 8 MiB
+    against a 64 KiB cap).
+
+    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_CACHE_MAX_BYTES`, and it counts
+    BYTES -- the descriptor is read in binary and `json.loads` decodes UTF-8
+    itself, so a multi-byte record cannot spend more than the ceiling. On Windows
+    both `os.open` flags degrade to 0 and `O_BINARY` stays unset, which is
+    JSON-insensitive (the writer emits no newlines); the type, size, and
+    ownership checks still hold there.
+    """
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        fd = os.open(cache_path, flags)
+        # `os.fdopen` owns the descriptor only once it returns; until then this is
+        # the only reference to it, so every exit but success closes it here.
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise OSError(errno.EINVAL, "cache record is not a regular file")
+            if info.st_size > UPDATE_CHECK_CACHE_MAX_BYTES:
+                raise OSError(errno.EFBIG, "cache record is too large")
+            geteuid = getattr(os, "geteuid", None)
+            if geteuid is not None and info.st_uid != geteuid():
+                raise OSError(errno.EPERM, "cache record is not owned by us")
+            cache_file = os.fdopen(fd, "rb")
+        except BaseException:
+            os.close(fd)
+            raise
+        with cache_file:
+            record = cache_file.read(UPDATE_CHECK_CACHE_MAX_BYTES + 1)
+        if len(record) > UPDATE_CHECK_CACHE_MAX_BYTES:
+            raise OSError(errno.EFBIG, "cache record is too large")
+        cache = json.loads(record)
+        checked_at = cache["checked_at"]
+        if isinstance(checked_at, bool) or not isinstance(checked_at, (int, float)):
+            return None
+        return checked_at, _parse_version(cache.get("latest_version"))
+    except (KeyError, OSError, TypeError, ValueError):
+        return None
+
+
+def _update_check_cache_is_fresh(cached, now):
+    """True when `cached` is a usable record still inside the TTL.
+
+    POLICY: a `checked_at` in the future is stale, not fresh, so a bad clock
+    cannot pin a stale answer forever.
+    """
+    return cached is not None and 0 <= now - cached[0] < UPDATE_CHECK_CACHE_TTL_SECONDS
+
+
+def _cache_dir_descriptor_supported():
+    """True when the leaf directory can be validated and re-moded through one descriptor.
+
+    POLICY: `O_NOFOLLOW` and `os.fchmod` are POSIX-only, and an unguarded
+    POSIX-only call has taken this advisory down once already, so their absence
+    selects the path-based arm instead of raising. `O_DIRECTORY` is POSIX-only
+    too but needs no guard of its own: the explicit `S_ISDIR` check is what the
+    decision rests on, on every platform.
+    """
+    return hasattr(os, "O_NOFOLLOW") and hasattr(os, "fchmod")
+
+
+def _open_update_check_cache_dir(cache_path):
+    """An open descriptor on the leaf cache directory, locked to 0700, or None.
+
+    POLICY: validate and re-mode ONE inode -- the one this descriptor addresses.
+    A path-based `is_symlink()` check followed by a path-based `chmod` resolves
+    the leaf twice, and swapping it for a symlink in between aims the 0700 repair
+    at a directory that is none of our business; `os.fstat` and `os.fchmod` cannot
+    be redirected that way. `O_NOFOLLOW` covers the FINAL component only, which is
+    exactly the leaf-only scope this module holds to: a symlinked `~/.cache`
+    ANCESTOR is a legitimate, common dotfile setup and keeps working. A directory
+    we do not own is refused rather than repaired.
+
+    WHERE TO CHANGE: the descriptor is the caller's to close, and a caller that
+    goes on to write inside the directory addresses its files with `dir_fd=`
+    rather than resolving the path a second time. Any `OSError` means None.
+    """
+    parent = cache_path.parent
+    try:
+        try:
+            parent.mkdir(parents=True, mode=0o700)
+        except FileExistsError:
+            pass
+        fd = os.open(parent, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return None
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISDIR(info.st_mode):
+            raise OSError(errno.ENOTDIR, "cache directory is not a directory")
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is not None and info.st_uid != geteuid():
+            raise OSError(errno.EPERM, "cache directory is not owned by us")
+        # mkdir's mode is masked by umask; the fchmod is what guarantees the mode.
+        os.fchmod(fd, 0o700)
+    except OSError:
+        os.close(fd)
+        return None
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _prepare_update_check_cache_dir(cache_path):
+    """Create the cache directory and lock it to 0700. True only when writing there is safe.
+
+    POLICY: the LEAF directory only -- the `praetorian-cli` directory this
+    creates. A symlinked `~/.cache` is a legitimate, common dotfile setup and
+    must keep working, so do NOT widen this to ancestors. Following a symlinked
+    leaf would chmod and write inside whatever directory someone else pointed it
+    at, and a path we did not create is only ours to repair when it is a
+    directory we own.
+
+    WHERE TO CHANGE: this runs before the throttle record is written (the record
+    needs a directory to be created in) and again inside
+    `_write_update_check_cache`, which validates on its own terms rather than
+    trusting its caller -- and which keeps the descriptor this discards. The
+    path-based arm below is the fallback for platforms that cannot close the
+    two-resolution window at all.
+    """
+    try:
+        if _cache_dir_descriptor_supported():
+            dir_fd = _open_update_check_cache_dir(cache_path)
+            if dir_fd is None:
+                return False
+            os.close(dir_fd)
+            return True
+        parent = cache_path.parent
+        if parent.is_symlink():
+            return False
+        try:
+            parent.mkdir(parents=True, mode=0o700)
+            created = True
+        except FileExistsError:
+            created = False
+        if not created and not (parent.is_dir() and _path_is_owned_by_effective_user(parent)):
+            return False
+        # mkdir's mode is masked by umask; the chmod is what guarantees the mode.
+        parent.chmod(0o700)
+        return True
+    except CancelledError:
+        raise
+    except Exception:
+        return False
+
+
+def _write_update_check_record_at(dir_fd, name, payload):
+    """Atomically write `payload` to `name` inside the directory `dir_fd` addresses.
+
+    POLICY: every step names the validated directory by descriptor, never by
+    path, so the destination cannot be swapped between the check and the write.
+    `os.rename` and not `os.replace`: measured, `os.replace` is absent from
+    `os.supports_dir_fd` on platforms where `os.open` and `os.rename` are
+    present, and a same-directory rename overwrites atomically either way.
+    `tempfile.mkstemp` has no `dir_fd`, so the temporary is created here --
+    `O_EXCL` against a random name, 0600 from the start as `mkstemp` does it,
+    and `os.fchmod` to hold that mode under any umask.
+    """
+    temp_name = f"{name}.{os.urandom(8).hex()}.tmp"
+    fd = os.open(temp_name, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600, dir_fd=dir_fd)
+    try:
+        # `os.fdopen` takes ownership of the descriptor only once it returns, so a
+        # failure inside it leaves the descriptor with no owner at all; the
+        # `finally` below reclaims the temporary's PATH, never a DESCRIPTOR.
+        # `BaseException`, because a KeyboardInterrupt landing here leaks
+        # identically.
+        try:
+            temp_file = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with temp_file:
+            os.fchmod(temp_file.fileno(), 0o600)
+            json.dump(payload, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.rename(temp_name, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    finally:
+        try:
+            os.unlink(temp_name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            pass
+
+
+def _write_update_check_record_by_path(cache_path, payload):
+    """Atomically write `payload` to `cache_path`, resolving it by path.
+
+    The fallback for platforms with no directory descriptor. `mkstemp` creates
+    the file 0600 regardless of umask (measured at `umask 0000`), which is why no
+    `os.fchmod` follows it: `os.fchmod` is POSIX-only, and on Windows its
+    AttributeError was swallowed by the fail-open arm -- taking the whole
+    advisory down with it, every run.
+    """
+    # Same directory as the destination, so `os.replace` is an atomic rename.
+    fd, temp_name = tempfile.mkstemp(dir=cache_path.parent)
+    temp_path = Path(temp_name)
+    try:
+        # As above: `os.fdopen` owns the descriptor only once it returns, and the
+        # `finally` reclaims the path rather than the descriptor.
+        try:
+            temp_file = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with temp_file:
+            json.dump(payload, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, cache_path)
+        cache_path.chmod(0o600)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _write_update_check_cache(cache_path, checked_at, latest_version):
+    """Record an attempt. True on success, False when this environment cannot.
+
+    The contract, spelled out because this one write is load-bearing for three
+    unrelated properties:
+
+    * It VALIDATES THE DESTINATION before touching it, whatever its caller
+      already did -- and on the descriptor arm it writes THROUGH the descriptor
+      it validated, so the directory it vetted is the directory it writes in.
+    * It lets NOTHING ESCAPE. No descriptor and no temporary file survives any
+      failure path, including a failure raised between the temporary's creation
+      and the `os.fdopen` that takes ownership of its descriptor.
+    * It is NO PART of any exclusion between concurrent refreshes -- there is
+      none, by policy (see the module POLICY block). Simultaneous invocations
+      each reach this function and each write; the write is an atomic
+      same-directory rename, so the record a reader sees is always one writer's
+      whole record.
+    * `False` means "this environment cannot be throttled, so do not probe".
+      Returns rather than raises: the caller treats a failed write as a
+      control-flow signal (stay off the network), not as an error to swallow.
+    """
+    try:
+        payload = {
+            "checked_at": checked_at,
+            "latest_version": None if latest_version is None else str(latest_version),
+        }
+        if _cache_dir_descriptor_supported():
+            dir_fd = _open_update_check_cache_dir(cache_path)
+            if dir_fd is None:
+                return False
+            try:
+                _write_update_check_record_at(dir_fd, cache_path.name, payload)
+            finally:
+                os.close(dir_fd)
+            return True
+        if not _prepare_update_check_cache_dir(cache_path):
+            return False
+        _write_update_check_record_by_path(cache_path, payload)
+        return True
+    except CancelledError:
+        raise
+    except Exception:
+        return False
+
+
+def _fetch_latest_version():
+    """PyPI's own latest STABLE release, or None when the payload is unusable.
+
+    `info.version` rather than `max(Version(r) for r in releases)`: the max over
+    release keys ranks prereleases above stable ones (2.0.0rc1 over 1.0.0), and a
+    single unparseable key raises `InvalidVersion` into the fail-open arm.
+
+    POLICY: the GET asks for no compression and the body is bounded by the RAW
+    bytes read off the socket, so raw and decoded are the same bytes. The cap has
+    to hold on EVERY urllib3 the `requests` pin permits, and only the raw read is
+    bounded on all of them: `decode_content=True` bounds DECODED bytes on urllib3
+    >= 2, but on 1.26.x it reads that many ENCODED bytes and then decompresses
+    without any bound -- a wire-bytes cap, which a gzip bomb walks straight
+    through (measured, 55 KiB of wire peaking 131x past this 1 MiB ceiling). A
+    server that ignores the header and compresses anyway is still capped at the
+    raw read, and `json.loads` then raises on the compressed bytes into the
+    fail-open arm -- no advisory, which is the intended outcome, so a
+    `Content-Encoding` check would add a branch and change no behaviour.
+    `Content-Length` cannot stand in for the cap either: measured, this endpoint
+    answers `Content-Length: 28568` for a body of 117712 bytes when it gzips, and
+    a header describes what a server claims it will send, not what arrives.
+
+    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_RESPONSE_MAX_BYTES`, it counts
+    RAW bytes, and the oversize arm must return BEFORE parsing. The real payload
+    is 115 KiB across 64 releases (~1.8 KiB per release), so the 1 MiB ceiling
+    keeps ~8.9x of headroom that grows with the release count. `json.loads` takes
+    the undecoded `bytes` and detects UTF-8 itself, so no decoding step belongs
+    here. The response is closed on every path: `stream=True` holds the
+    connection open until it is.
+    """
+    response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS, stream=True,
+                            headers={"Accept-Encoding": "identity"})
+    with response:
+        response.raise_for_status()
+        body = response.raw.read(UPDATE_CHECK_RESPONSE_MAX_BYTES + 1, decode_content=False)
+    if len(body) > UPDATE_CHECK_RESPONSE_MAX_BYTES:
+        return None
+    return _parse_version(json.loads(body)["info"]["version"])
+
+
+def _fetch_latest_version_within_deadline():
+    """`_fetch_latest_version`'s answer, or None when it does not land in time.
+
+    POLICY: the refresh gets a hard WALL-CLOCK bound. `requests`' `timeout`
+    bounds each individual socket operation and never the total -- measured, a
+    `timeout=2` GET against a server dribbling one header byte every 1.5s
+    returned after 64.7 seconds, and the real CLI sat alive 10.1s past its own
+    last line of output. So the fetch runs on a thread and a thread still alive
+    after the join is ABANDONED, its result discarded. `daemon=True` is
+    load-bearing: the interpreter must not wait for an abandoned fetch at exit.
+    For the same reason this is a bare thread and NOT a
+    `concurrent.futures.ThreadPoolExecutor`, whose `atexit` handler joins its
+    workers and would reinstate exactly the wait this removes.
+
+    WHERE TO CHANGE: the bound is `UPDATE_CHECK_DEADLINE_SECONDS`; the per-socket
+    `UPDATE_CHECK_TIMEOUT_SECONDS` still applies inside the thread and still
+    helps the common case -- this is the outer guarantee, not its replacement.
+    """
+    fetched = [None]
+
+    def fetch():
+        # Nothing may escape a thread nobody is waiting for any more: an
+        # exception here would reach the interpreter's excepthook and print over
+        # the command's own output.
+        try:
+            fetched[0] = _fetch_latest_version()
+        except BaseException:
+            pass
+
+    thread = threading.Thread(target=fetch, daemon=True)
+    thread.start()
+    thread.join(UPDATE_CHECK_DEADLINE_SECONDS)
+    return None if thread.is_alive() else fetched[0]
+
+
+def _check_for_update():
+    try:
+        if _update_check_disabled():
+            return
+        if not _session_is_interactive():
+            return
+        if _delegating_to_subcommand():
+            return
+        now = time.time()
+        cache_path = _update_check_cache_path()
+        cached = _read_update_check_cache(cache_path)
+        latest = cached[1] if cached is not None else None
+        if not _update_check_cache_is_fresh(cached, now):
+            # The record below is written IN the cache directory, so the directory
+            # has to exist and be trustworthy first. Failing to prepare it is the
+            # same signal a failed record write is: an environment whose probe
+            # rate we cannot limit is one we must not probe.
+            if not _prepare_update_check_cache_dir(cache_path):
+                return
+            # Record the attempt BEFORE making it, so EVERY way a refresh can
+            # fail is throttled by the same record -- network and HTTP errors, an
+            # unparseable payload, a body over the size ceiling, a fetch
+            # abandoned at the deadline, and the environments where the cache
+            # cannot be written at all (a read-only filesystem, a cache directory
+            # owned by another user). A file-based cache written only on success
+            # cannot throttle the case where the file cannot be written, which is
+            # how this reached pypi.org on every single invocation. The previous
+            # known version rides along, so a failed refresh keeps advertising
+            # what we already knew.
+            if not _write_update_check_cache(cache_path, now, latest):
+                return
+            try:
+                fetched = _fetch_latest_version_within_deadline()
+            except CancelledError:
+                raise
+            except Exception:
+                fetched = None
+            if fetched is not None:
+                latest = fetched
+                _write_update_check_cache(cache_path, now, latest)
+        if latest is None:
+            return
+        local = Version(version('praetorian-cli'))
+        if latest > local:
+            click.echo(f'A new version of praetorian-cli is available: {latest}', err=True)
+            click.echo(f'You are currently running {local}.', err=True)
+            click.echo('To upgrade, run "pip install --upgrade praetorian-cli".', err=True)
+    except CancelledError:
+        raise
+    # `Exception`, not a bare `except`: KeyboardInterrupt and SystemExit derive
+    # from BaseException, so they keep propagating instead of being swallowed.
+    except Exception:
+        pass
+
+
 def upgrade_check(func):
+    # POLICY: the advisory is an epilogue to work whose output has ALREADY been
+    # produced, and this decorator composes OUTERMOST -- outside `handle_error`
+    # -- so anything escaping here becomes the command's exit status. A Ctrl-C
+    # during the advisory therefore must not turn a completed command into
+    # `Aborted!` and exit 1: a non-zero exit for work that already succeeded
+    # invites an unsafe retry of a mutating command (measured: 968 rows
+    # delivered, then exit 1).
+    #
+    # WHERE TO CHANGE: `CancelledError` is deliberately NOT caught here, and the
+    # asymmetry with `KeyboardInterrupt` is not an oversight -- a cancelled async
+    # task must still observe its cancellation, so it keeps propagating exactly
+    # as `_check_for_update`'s own `except CancelledError: raise` arm sends it.
     @wraps(func)
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
         try:
-            response = requests.get('https://pypi.org/pypi/praetorian-cli/json', timeout=3)
-            pypi = sorted([Version(v) for v in list(response.json()['releases'].keys())])[-1]
-            local = Version(version('praetorian-cli'))
-            if pypi > local:
-                click.echo(f'A new version of praetorian-cli is available: {pypi}', err=True)
-                click.echo(f'You are currently running {local}.', err=True)
-                click.echo('To upgrade, run "pip install --upgrade praetorian-cli".', err=True)
-        except:
-            # Silently fail if we can't check for updates
-            # This preserves the main functionality even if update checks fail
+            _check_for_update()
+        except KeyboardInterrupt:
             pass
         return result
 
     return wrapper
-
 
 def cli_handler(func):
     func = click.pass_obj(func)

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,4 +1,4 @@
-import traceback
+from concurrent.futures import CancelledError
 from functools import wraps
 from importlib.metadata import version
 
@@ -6,8 +6,34 @@ import click
 import requests
 from packaging.version import Version
 
-from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.utils import error
+
+
+DEBUG_HINT = "(re-run with --debug for the full traceback)"
+
+
+def _debug_enabled(ctx):
+    return bool(ctx.find_root().params.get("debug", False))
+
+
+# POLICY: every command routes through this boundary, which surfaces the
+# exception's own message -- no sanitizing, summarizing, or redacting. The one
+# normalization is outer whitespace: it is trimmed so the appended hint lands on
+# the line immediately after the message (and so a whitespace-only message
+# counts as blank). The SDK raises bare `Exception`/`ValueError` as its normal
+# error-reporting mechanism (`process_failure` in praetorian_cli/sdk/chariot.py,
+# praetorian_cli/sdk/entities/*.py), so that message IS the user-facing text.
+#
+# WHERE TO CHANGE: classification is ENG-6570, redaction is ENG-6781 -- neither
+# here. Nor is this the only egress path: praetorian_cli/sdk/mcp_server.py
+# returns `str(e)` to its caller, and the SDK is a public library surface.
+def _error_message(exc):
+    """Surface the exception's own message, plus the `--debug` hint.
+
+    Falls back to the exception's type name when its message is blank.
+    """
+    message = str(exc).strip() or type(exc).__name__
+    return f"{message}\n{DEBUG_HINT}"
 
 
 def handle_error(func):
@@ -22,6 +48,12 @@ def handle_error(func):
             error(str(e), quit=False)
             if chariot.is_debug:
                 click.echo(traceback.format_exc())
+        except click.ClickException:
+        except click.exceptions.Exit:
+        except CancelledError:
+        except Exception as exc:
+            if _debug_enabled(ctx):
+            raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -51,17 +51,17 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except click.ClickException:
+            raise
         except click.Abort:
             raise
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
-        except click.ClickException:
         except click.exceptions.Exit:
+            raise
         except CancelledError:
+            raise
         except Exception as exc:
             if _debug_enabled(ctx):
+                raise
             raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper

--- a/praetorian_cli/handlers/configure.py
+++ b/praetorian_cli/handlers/configure.py
@@ -1,5 +1,5 @@
 import click
-from praetorian_cli.sdk.keychain import Keychain, DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_PROFILE
+from praetorian_cli.sdk.keychain import Keychain, DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_KEYCHAIN_FILEPATH, DEFAULT_PROFILE
 
 
 @click.command()
@@ -25,3 +25,5 @@ def configure(click_context):
         api_key_id=api_key_id,
         api_key_secret=api_key_secret
     )
+
+    click.echo(f'\nKeychain data written to {DEFAULT_KEYCHAIN_FILEPATH}')

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -5,14 +5,19 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import error, print_json
 
 
 def _read_json_body():
+    if sys.stdin.isatty():
+        error('Pipe JSON input via stdin (e.g., echo \'{"key":"val"}\' | guard red-team ...)')
     data = sys.stdin.read().strip()
     if not data:
         raise click.UsageError('No JSON body provided on stdin')
-    return json.loads(data)
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
 
 
 @chariot.group('red-team')
@@ -466,7 +471,10 @@ def configure(sdk, node, domain, phishlet, params, unauth_url):
         guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365
         guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365 --params '{"client_id":"abc"}'
     """
-    phishlet_params = json.loads(params) if params else None
+    try:
+        phishlet_params = json.loads(params) if params else None
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
     print_json(sdk.red_team.evilginx_configure(
         node, domain, phishlet,
         phishlet_params=phishlet_params, unauth_url=unauth_url))
@@ -503,7 +511,10 @@ def payload_generate(sdk, shellcode, variables):
         guard red-team payload-generate --shellcode beacon.bin
         guard red-team payload-generate --shellcode beacon.bin --variables '{"dll_filename":"update.dll"}'
     """
-    vars_dict = json.loads(variables) if variables else None
+    try:
+        vars_dict = json.loads(variables) if variables else None
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
     print_json(sdk.red_team.payload_generate(shellcode, variables=vars_dict))
 
 

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -1,0 +1,523 @@
+import json
+import sys
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
+from praetorian_cli.handlers.utils import print_json
+
+
+def _read_json_body():
+    data = sys.stdin.read().strip()
+    if not data:
+        raise click.UsageError('No JSON body provided on stdin')
+    return json.loads(data)
+
+
+@chariot.group('red-team')
+def red_team():
+    """ Red Team operations """
+    pass
+
+
+# ===================== Deployment =====================
+
+@red_team.group()
+def deployment():
+    """ Red Team deployment lifecycle """
+    pass
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+@click.option('--id', 'desired_id', default=None, help='Desired deployment ID')
+def launch(sdk, desired_id):
+    """ Launch a new Red Team deployment
+
+    \b
+    Example usages:
+        guard red-team deployment launch
+        guard red-team deployment launch --id my-deploy
+    """
+    print_json(sdk.red_team.deployment_launch(desired_id=desired_id))
+
+
+@deployment.command('delete')
+@cli_handler
+@praetorian_only
+@click.option('--force', is_flag=True, default=False, help='Force deletion')
+@click.confirmation_option(prompt='Delete the Red Team deployment?')
+def deploy_delete(sdk, force):
+    """ Delete the Red Team deployment
+
+    \b
+    Prompts for confirmation.
+
+    \b
+    Example usages:
+        guard red-team deployment delete
+        guard red-team deployment delete --force
+    """
+    print_json(sdk.red_team.deployment_delete(force=force))
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+def details(sdk):
+    """ Get current deployment details
+
+    \b
+    Example usages:
+        guard red-team deployment details
+    """
+    print_json(sdk.red_team.deployment_details())
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+def history(sdk):
+    """ Get deployment history
+
+    \b
+    Example usages:
+        guard red-team deployment history
+    """
+    print_json(sdk.red_team.deployment_history())
+
+
+@deployment.command('last-inputs')
+@cli_handler
+@praetorian_only
+def last_inputs(sdk):
+    """ Get the last submitted builder configuration
+
+    \b
+    Example usages:
+        guard red-team deployment last-inputs
+    """
+    print_json(sdk.red_team.deployment_last_inputs())
+
+
+@deployment.command('node-schema')
+@cli_handler
+@praetorian_only
+@click.option('--tag', default=None, help='Infrastructure version tag')
+def node_schema(sdk, tag):
+    """ Get the node catalog schema for infrastructure
+
+    \b
+    Example usages:
+        guard red-team deployment node-schema
+        guard red-team deployment node-schema --tag v1.2.3
+    """
+    print_json(sdk.red_team.deployment_node_schema(tag=tag))
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+@click.option('--tag', default=None, help='Infrastructure version tag')
+@click.option('--sha', default=None, help='Git commit SHA')
+def plan(sdk, tag, sha):
+    """ Run terraform plan from a builder state JSON on stdin
+
+    \b
+    Example usages:
+        cat builder.json | guard red-team deployment plan
+    """
+    print_json(sdk.red_team.deployment_terraform(
+        'plan', _read_json_body(), tag=tag, sha=sha))
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+@click.option('--tag', default=None, help='Infrastructure version tag')
+@click.option('--sha', default=None, help='Git commit SHA')
+@click.confirmation_option(prompt='Apply the Terraform deployment?')
+def apply(sdk, tag, sha):
+    """ Run terraform apply from a builder state JSON on stdin
+
+    \b
+    Prompts for confirmation.
+
+    \b
+    Example usages:
+        cat builder.json | guard red-team deployment apply
+    """
+    print_json(sdk.red_team.deployment_terraform(
+        'apply', _read_json_body(), tag=tag, sha=sha))
+
+
+@deployment.command()
+@cli_handler
+@praetorian_only
+@click.option('--collaborators', required=True,
+              help='Comma-separated list of collaborator emails')
+def collaborators(sdk, collaborators):
+    """ Update deployment collaborators
+
+    \b
+    Example usages:
+        guard red-team deployment collaborators --collaborators user1@co.com,user2@co.com
+    """
+    collabs = [c.strip() for c in collaborators.split(',')]
+    print_json(sdk.red_team.deployment_collaborators(collabs))
+
+
+# ===================== Campaigns =====================
+
+@red_team.group()
+def campaign():
+    """ Red Team phishing campaigns """
+    pass
+
+
+@campaign.command()
+@cli_handler
+@praetorian_only
+def create(sdk):
+    """ Create or update a campaign from JSON on stdin
+
+    \b
+    Example usages:
+        cat campaign.json | guard red-team campaign create
+    """
+    print_json(sdk.red_team.campaign_create(_read_json_body()))
+
+
+@campaign.command('delete')
+@cli_handler
+@praetorian_only
+@click.option('--key', required=True, help='Campaign key')
+def campaign_delete(sdk, key):
+    """ Delete a campaign
+
+    \b
+    Example usages:
+        guard red-team campaign delete --key "#campaign#my-campaign"
+    """
+    print_json(sdk.red_team.campaign_delete(key))
+
+
+@campaign.command()
+@cli_handler
+@praetorian_only
+@click.option('--id', 'campaign_id', required=True, help='Campaign ID')
+@click.option('--segment', default=None, help='Target segment name')
+def targets(sdk, campaign_id, segment):
+    """ Set campaign targets from JSON on stdin
+
+    \b
+    Replaces the full target roster.
+
+    \b
+    Example usages:
+        cat targets.json | guard red-team campaign targets --id camp-1
+    """
+    body = _read_json_body()
+    target_list = body.get('targets', body) if isinstance(body, dict) else body
+    print_json(sdk.red_team.campaign_targets(
+        campaign_id, target_list, segment=segment))
+
+
+@campaign.command()
+@cli_handler
+@praetorian_only
+@click.option('--id', 'campaign_id', required=True, help='Campaign ID')
+def authorize(sdk, campaign_id):
+    """ Authorize a campaign to go live
+
+    \b
+    Example usages:
+        guard red-team campaign authorize --id camp-1
+    """
+    print_json(sdk.red_team.campaign_authorize(campaign_id))
+
+
+@campaign.command()
+@cli_handler
+@praetorian_only
+@click.option('--id', 'campaign_id', required=True, help='Campaign ID')
+def funnel(sdk, campaign_id):
+    """ Get campaign funnel metrics
+
+    \b
+    Example usages:
+        guard red-team campaign funnel --id camp-1
+    """
+    print_json(sdk.red_team.campaign_funnel(campaign_id))
+
+
+@campaign.command()
+@cli_handler
+@praetorian_only
+@click.option('--id', 'campaign_id', required=True, help='Campaign ID')
+@click.option('--limit', type=int, default=None, help='Max events (default 50)')
+def activity(sdk, campaign_id, limit):
+    """ Get campaign activity events
+
+    \b
+    Example usages:
+        guard red-team campaign activity --id camp-1
+        guard red-team campaign activity --id camp-1 --limit 100
+    """
+    print_json(sdk.red_team.campaign_activity(campaign_id, limit=limit))
+
+
+# ===================== Domain parking =====================
+
+@red_team.group()
+def domain():
+    """ Red Team domain parking and DNS """
+    pass
+
+
+@domain.command()
+@cli_handler
+@praetorian_only
+def update(sdk):
+    """ Update a parked domain from JSON on stdin
+
+    \b
+    Example usages:
+        echo '{"domain":"evil.com","status":"in-use"}' | guard red-team domain update
+    """
+    print_json(sdk.red_team.domain_update(_read_json_body()))
+
+
+@domain.command('dns-list')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+def dns_list(sdk, domain):
+    """ List DNS records for a parked domain
+
+    \b
+    Example usages:
+        guard red-team domain dns-list --domain evil.com
+    """
+    print_json(sdk.red_team.dns_list(domain))
+
+
+@domain.command('dns-create')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+@click.option('--type', 'record_type', required=True,
+              type=click.Choice(['A', 'CNAME', 'MX', 'TXT']),
+              help='Record type')
+@click.option('--name', required=True, help='Record name')
+@click.option('--content', required=True, help='Record value')
+@click.option('--ttl', type=int, default=1, help='TTL in seconds (1=auto)')
+def dns_create(sdk, domain, record_type, name, content, ttl):
+    """ Create a DNS record for a parked domain
+
+    \b
+    Example usages:
+        guard red-team domain dns-create --domain evil.com --type A --name www --content 1.2.3.4
+    """
+    print_json(sdk.red_team.dns_create(domain, record_type, name, content, ttl))
+
+
+@domain.command('dns-delete')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+@click.option('--record-id', required=True, help='DNS record ID')
+def dns_delete(sdk, domain, record_id):
+    """ Delete a DNS record
+
+    \b
+    Example usages:
+        guard red-team domain dns-delete --domain evil.com --record-id abc123
+    """
+    print_json(sdk.red_team.dns_delete(domain, record_id))
+
+
+@domain.command('mailgun-status')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+def mailgun_status(sdk, domain):
+    """ Get Mailgun domain status
+
+    \b
+    Example usages:
+        guard red-team domain mailgun-status --domain evil.com
+    """
+    print_json(sdk.red_team.mailgun_domain_status(domain))
+
+
+@domain.command('mailgun-provision')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain to provision')
+def mailgun_provision(sdk, domain):
+    """ Provision a Mailgun domain
+
+    \b
+    Example usages:
+        guard red-team domain mailgun-provision --domain evil.com
+    """
+    print_json(sdk.red_team.mailgun_domain_provision(domain))
+
+
+@domain.command('mailgun-user')
+@cli_handler
+@praetorian_only
+@click.option('--username', required=True, help='SMTP username')
+@click.option('--domain', required=True, help='Domain name')
+def mailgun_user(sdk, username, domain):
+    """ Create a Mailgun SMTP user
+
+    \b
+    Example usages:
+        guard red-team domain mailgun-user --username noreply --domain evil.com
+    """
+    print_json(sdk.red_team.mailgun_user_create(username, domain))
+
+
+# ===================== Evilginx =====================
+
+@red_team.group()
+def evilginx():
+    """ Evilginx phishing infrastructure """
+    pass
+
+
+@evilginx.command()
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+def phishlets(sdk, node):
+    """ List available Evilginx phishlets
+
+    \b
+    Example usages:
+        guard red-team evilginx phishlets --node node-ref-1
+    """
+    print_json(sdk.red_team.evilginx_phishlets(node))
+
+
+@evilginx.command('phishlet-params')
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+@click.option('--name', required=True, help='Phishlet name')
+def phishlet_params(sdk, node, name):
+    """ Get parameters for a specific phishlet
+
+    \b
+    Example usages:
+        guard red-team evilginx phishlet-params --node node-ref-1 --name o365
+    """
+    print_json(sdk.red_team.evilginx_phishlet_params(node, name))
+
+
+@evilginx.command()
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+def lures(sdk, node):
+    """ List Evilginx lures
+
+    \b
+    Example usages:
+        guard red-team evilginx lures --node node-ref-1
+    """
+    print_json(sdk.red_team.evilginx_lures(node))
+
+
+@evilginx.command('create-lure')
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+@click.option('--path', required=True, help='Lure URL path')
+def create_lure(sdk, node, path):
+    """ Create an Evilginx lure
+
+    \b
+    Example usages:
+        guard red-team evilginx create-lure --node node-ref-1 --path /login
+    """
+    print_json(sdk.red_team.evilginx_create_lure(node, path))
+
+
+@evilginx.command()
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+@click.option('--domain', required=True, help='Domain to configure')
+@click.option('--phishlet', required=True, help='Phishlet name')
+@click.option('--params', default=None,
+              help='JSON string of phishlet parameters')
+@click.option('--unauth-url', default=None,
+              help='URL for unauthenticated visitors')
+def configure(sdk, node, domain, phishlet, params, unauth_url):
+    """ Configure Evilginx on a phishkit node
+
+    \b
+    Example usages:
+        guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365
+        guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365 --params '{"client_id":"abc"}'
+    """
+    phishlet_params = json.loads(params) if params else None
+    print_json(sdk.red_team.evilginx_configure(
+        node, domain, phishlet,
+        phishlet_params=phishlet_params, unauth_url=unauth_url))
+
+
+@evilginx.command()
+@cli_handler
+@praetorian_only
+@click.option('--node', required=True, help='Phishkit node reference')
+def status(sdk, node):
+    """ Get Evilginx configuration status
+
+    \b
+    Example usages:
+        guard red-team evilginx status --node node-ref-1
+    """
+    print_json(sdk.red_team.evilginx_status(node))
+
+
+# ===================== Payload & phishkit =====================
+
+@red_team.command('payload-generate')
+@cli_handler
+@praetorian_only
+@click.option('--shellcode', required=True,
+              help='S3 filename of shellcode to embed')
+@click.option('--variables', default=None,
+              help='JSON string of template variables')
+def payload_generate(sdk, shellcode, variables):
+    """ Generate a payload from shellcode
+
+    \b
+    Example usages:
+        guard red-team payload-generate --shellcode beacon.bin
+        guard red-team payload-generate --shellcode beacon.bin --variables '{"dll_filename":"update.dll"}'
+    """
+    vars_dict = json.loads(variables) if variables else None
+    print_json(sdk.red_team.payload_generate(shellcode, variables=vars_dict))
+
+
+@red_team.command('phishkit-nodes')
+@cli_handler
+@praetorian_only
+@click.option('--status', default=None,
+              help='Filter by status (e.g. "running", "all")')
+def phishkit_nodes(sdk, status):
+    """ List phishkit nodes
+
+    \b
+    Example usages:
+        guard red-team phishkit-nodes
+        guard red-team phishkit-nodes --status all
+    """
+    print_json(sdk.red_team.phishkit_nodes(status=status))

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -5,17 +5,55 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import error, print_json
+from praetorian_cli.handlers.utils import print_json
+
+# POLICY: stdin cannot be both the JSON payload channel and Click's confirmation
+# channel. Every command that takes a JSON body therefore accepts `-f/--file`,
+# and `-f -` selects the original stdin behavior explicitly. A destructive
+# command reads its payload from a file so that @click.confirmation_option can
+# still reach the controlling terminal to prompt.
+JSON_FILE_HELP = 'Read the JSON body from PATH ("-" reads stdin)'
 
 
-def _read_json_body():
-    if sys.stdin.isatty():
-        raise click.UsageError('Pipe JSON input via stdin')
-    data = sys.stdin.read().strip()
+def _load_json_body(path=None):
+    """Load a JSON request body from `path`, or from stdin when `path` is None or '-'."""
+    if path in (None, '-'):
+        if sys.stdin.isatty():
+            raise click.UsageError('Pipe JSON input via stdin, or pass --file PATH')
+        data = sys.stdin.read().strip()
+        source = 'stdin'
+    else:
+        try:
+            with open(path) as f:
+                data = f.read().strip()
+        except OSError as e:
+            raise click.UsageError(f'Cannot read JSON body from {path}: {e.strerror}')
+        source = path
+
     if not data:
-        raise click.UsageError('No JSON body provided on stdin')
+        raise click.UsageError(f'No JSON body provided on {source}')
     try:
         return json.loads(data)
+    except json.JSONDecodeError:
+        raise click.UsageError('Invalid JSON input')
+
+
+def _json_option(inline_value, inline_flag, file_path, file_flag):
+    """Resolve a JSON value supplied either inline on argv or from a file.
+
+    The two forms are mutually exclusive: an inline string is visible in process
+    listings and shell history, so a caller who has moved a value into a file is
+    not silently given the argv one back.
+    """
+    if inline_value and file_path:
+        raise click.UsageError(
+            f'{inline_flag} and {file_flag} are mutually exclusive; pass only one')
+    if file_path:
+        return _load_json_body(file_path)
+    if not inline_value:
+        return None
+    try:
+        return json.loads(inline_value)
     except json.JSONDecodeError:
         raise click.UsageError('Invalid JSON input')
 
@@ -127,15 +165,21 @@ def node_schema(sdk, tag):
 @praetorian_only
 @click.option('--tag', default=None, help='Infrastructure version tag')
 @click.option('--sha', default=None, help='Git commit SHA')
-def plan(sdk, tag, sha):
-    """ Run terraform plan from a builder state JSON on stdin
+@click.option('--file', '-f', 'body_file', default=None, help=JSON_FILE_HELP)
+def plan(sdk, tag, sha, body_file):
+    """ Run terraform plan from a builder state JSON
+
+    \b
+    The builder state is read from --file, or from stdin when --file is omitted
+    or given as "-".
 
     \b
     Example usages:
         cat builder.json | guard red-team deployment plan
+        guard red-team deployment plan --file builder.json
     """
     print_json(sdk.red_team.deployment_terraform(
-        'plan', _read_json_body(), tag=tag, sha=sha))
+        'plan', _load_json_body(body_file), tag=tag, sha=sha))
 
 
 @deployment.command()
@@ -143,22 +187,25 @@ def plan(sdk, tag, sha):
 @praetorian_only
 @click.option('--tag', default=None, help='Infrastructure version tag')
 @click.option('--sha', default=None, help='Git commit SHA')
-@click.option('--yes', '-y', is_flag=True, default=False, help='Skip confirmation prompt')
-def apply(sdk, tag, sha, yes):
-    """ Run terraform apply from a builder state JSON on stdin
+@click.option('--file', '-f', 'body_file', default=None, help=JSON_FILE_HELP)
+@click.confirmation_option(prompt='Apply the Terraform deployment?')
+def apply(sdk, tag, sha, body_file):
+    """ Run terraform apply from a builder state JSON
 
     \b
-    Prompts for confirmation (unless stdin is piped or --yes is given).
+    Prompts for confirmation; --yes skips the prompt. The builder state is read
+    from --file, or from stdin when --file is omitted or given as "-". Pass the
+    builder state with --file to leave stdin free for the confirmation prompt --
+    when the payload is piped in instead, the prompt has no input to read and
+    the command aborts unless --yes is given.
 
     \b
     Example usages:
-        cat builder.json | guard red-team deployment apply
+        guard red-team deployment apply --file builder.json
+        cat builder.json | guard red-team deployment apply --yes
     """
-    body = _read_json_body()
-    if not yes and sys.stdin.isatty():
-        click.confirm('Apply the Terraform deployment?', abort=True)
     print_json(sdk.red_team.deployment_terraform(
-        'apply', body, tag=tag, sha=sha))
+        'apply', _load_json_body(body_file), tag=tag, sha=sha))
 
 
 @deployment.command()
@@ -201,22 +248,32 @@ def campaign():
 @campaign.command()
 @cli_handler
 @praetorian_only
-def create(sdk):
-    """ Create or update a campaign from JSON on stdin
+@click.option('--file', '-f', 'body_file', default=None, help=JSON_FILE_HELP)
+def create(sdk, body_file):
+    """ Create or update a campaign from JSON
+
+    \b
+    The campaign document is read from --file, or from stdin when --file is
+    omitted or given as "-".
 
     \b
     Example usages:
         cat campaign.json | guard red-team campaign create
+        guard red-team campaign create --file campaign.json
     """
-    print_json(sdk.red_team.campaign_create(_read_json_body()))
+    print_json(sdk.red_team.campaign_create(_load_json_body(body_file)))
 
 
 @campaign.command('delete')
 @cli_handler
 @praetorian_only
 @click.option('--key', required=True, help='Campaign key')
+@click.confirmation_option(prompt='Delete this campaign?')
 def campaign_delete(sdk, key):
     """ Delete a campaign
+
+    \b
+    Prompts for confirmation.
 
     \b
     Example usages:
@@ -230,25 +287,30 @@ def campaign_delete(sdk, key):
 @praetorian_only
 @click.option('--id', 'campaign_id', required=True, help='Campaign ID')
 @click.option('--segment', default=None, help='Target segment name')
-def targets(sdk, campaign_id, segment):
-    """ Set campaign targets from JSON on stdin
+@click.option('--file', '-f', 'body_file', default=None, help=JSON_FILE_HELP)
+def targets(sdk, campaign_id, segment, body_file):
+    """ Set campaign targets from JSON
 
     \b
-    Replaces the full target roster.
+    Replaces the full target roster. The roster is read from --file, or from
+    stdin when --file is omitted or given as "-".
 
     \b
     Example usages:
         cat targets.json | guard red-team campaign targets --id camp-1
+        guard red-team campaign targets --id camp-1 --file targets.json
     """
-    body = _read_json_body()
+    body = _load_json_body(body_file)
     if isinstance(body, dict):
         target_list = body.get('targets')
         if target_list is None:
-            error("Expected JSON with 'targets' key or a JSON array of targets")
+            raise click.UsageError(
+                "Expected JSON with 'targets' key or a JSON array of targets")
     elif isinstance(body, list):
         target_list = body
     else:
-        error('Expected JSON array or object with \'targets\' key')
+        raise click.UsageError(
+            'Expected JSON array or object with \'targets\' key')
     print_json(sdk.red_team.campaign_targets(
         campaign_id, target_list, segment=segment))
 
@@ -257,8 +319,15 @@ def targets(sdk, campaign_id, segment):
 @cli_handler
 @praetorian_only
 @click.option('--id', 'campaign_id', required=True, help='Campaign ID')
+@click.confirmation_option(
+    prompt='Authorize this campaign to go live? '
+           'This sends live phishing email to real recipients.')
 def authorize(sdk, campaign_id):
     """ Authorize a campaign to go live
+
+    \b
+    Prompts for confirmation. Once authorized, the campaign sends live phishing
+    email to every recipient on its target roster.
 
     \b
     Example usages:
@@ -285,7 +354,8 @@ def funnel(sdk, campaign_id):
 @cli_handler
 @praetorian_only
 @click.option('--id', 'campaign_id', required=True, help='Campaign ID')
-@click.option('--limit', type=int, default=None, help='Max events (default 50)')
+@click.option('--limit', type=int, default=None,
+              help='Maximum number of events to return')
 def activity(sdk, campaign_id, limit):
     """ Get campaign activity events
 
@@ -308,14 +378,20 @@ def domain():
 @domain.command()
 @cli_handler
 @praetorian_only
-def update(sdk):
-    """ Update a parked domain from JSON on stdin
+@click.option('--file', '-f', 'body_file', default=None, help=JSON_FILE_HELP)
+def update(sdk, body_file):
+    """ Update a parked domain from JSON
+
+    \b
+    The domain document is read from --file, or from stdin when --file is
+    omitted or given as "-".
 
     \b
     Example usages:
         echo '{"domain":"evil.com","status":"in-use"}' | guard red-team domain update
+        guard red-team domain update --file domain.json
     """
-    print_json(sdk.red_team.domain_update(_read_json_body()))
+    print_json(sdk.red_team.domain_update(_load_json_body(body_file)))
 
 
 @domain.command('dns-list')
@@ -378,8 +454,12 @@ def dns_update(sdk, domain, record_id, record_type, name, content, ttl):
 @praetorian_only
 @click.option('--domain', required=True, help='Domain name')
 @click.option('--record-id', required=True, help='DNS record ID')
+@click.confirmation_option(prompt='Delete this DNS record?')
 def dns_delete(sdk, domain, record_id):
     """ Delete a DNS record
+
+    \b
+    Prompts for confirmation.
 
     \b
     Example usages:
@@ -541,21 +621,30 @@ def create_lure(sdk, node, path):
 @click.option('--domain', required=True, help='Domain to configure')
 @click.option('--phishlet', required=True, help='Phishlet name')
 @click.option('--params', default=None,
-              help='JSON string of phishlet parameters')
+              help='JSON string of phishlet parameters. Values passed inline are '
+                   'visible in process listings and shell history; use '
+                   '--params-file for anything sensitive')
+@click.option('--params-file', default=None,
+              help='Read the phishlet parameters JSON from PATH ("-" reads stdin). '
+                   'Use this for OAuth client IDs/secrets, session tokens, and '
+                   'other sensitive values')
 @click.option('--unauth-url', default=None,
               help='URL for unauthenticated visitors')
-def configure(sdk, node, domain, phishlet, params, unauth_url):
+def configure(sdk, node, domain, phishlet, params, params_file, unauth_url):
     """ Configure Evilginx on a phishkit node
+
+    \b
+    Phishlet parameters carry secret material (OAuth client IDs and secrets,
+    session tokens). Pass them with --params-file: a value given inline with
+    --params is visible in process listings and shell history.
 
     \b
     Example usages:
         guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365
-        guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365 --params '{"client_id":"abc"}'
+        guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365 --params '{"landing_path":"/login"}'
+        guard red-team evilginx configure --node n1 --domain evil.com --phishlet o365 --params-file phishlet-params.json
     """
-    try:
-        phishlet_params = json.loads(params) if params else None
-    except json.JSONDecodeError:
-        raise click.UsageError('Invalid JSON input')
+    phishlet_params = _json_option(params, '--params', params_file, '--params-file')
     print_json(sdk.red_team.evilginx_configure(
         node, domain, phishlet,
         phishlet_params=phishlet_params, unauth_url=unauth_url))
@@ -583,19 +672,27 @@ def status(sdk, node):
 @click.option('--shellcode', required=True,
               help='S3 filename of shellcode to embed')
 @click.option('--variables', default=None,
-              help='JSON string of template variables')
-def payload_generate(sdk, shellcode, variables):
+              help='JSON string of template variables. Values passed inline are '
+                   'visible in process listings and shell history; use '
+                   '--variables-file for anything sensitive')
+@click.option('--variables-file', default=None,
+              help='Read the template variables JSON from PATH ("-" reads stdin). '
+                   'Use this for keys, tokens, and other sensitive values')
+def payload_generate(sdk, shellcode, variables, variables_file):
     """ Generate a payload from shellcode
+
+    \b
+    Pass template variables with --variables-file when any of them is sensitive:
+    a value given inline with --variables is visible in process listings and
+    shell history.
 
     \b
     Example usages:
         guard red-team payload-generate --shellcode beacon.bin
         guard red-team payload-generate --shellcode beacon.bin --variables '{"dll_filename":"update.dll"}'
+        guard red-team payload-generate --shellcode beacon.bin --variables-file payload-vars.json
     """
-    try:
-        vars_dict = json.loads(variables) if variables else None
-    except json.JSONDecodeError:
-        raise click.UsageError('Invalid JSON input')
+    vars_dict = _json_option(variables, '--variables', variables_file, '--variables-file')
     print_json(sdk.red_team.payload_generate(shellcode, variables=vars_dict))
 
 

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -17,18 +17,39 @@ JSON_FILE_HELP = 'Read the JSON body from PATH ("-" reads stdin)'
 
 def _load_json_body(path=None):
     """Load a JSON request body from `path`, or from stdin when `path` is None or '-'."""
+    # JSON is UTF-8 by specification (RFC 8259 s.8.1), so both channels decode as
+    # UTF-8 rather than the platform's locale encoding -- otherwise a body with
+    # non-ASCII content (target names, accented lure text, smart quotes) silently
+    # mojibakes, or fails outright, wherever the locale is not UTF-8.
     if path in (None, '-'):
         if sys.stdin.isatty():
             raise click.UsageError('Pipe JSON input via stdin, or pass --file PATH')
-        data = sys.stdin.read().strip()
         source = 'stdin'
-    else:
+        # Re-decode the existing stdin wrapper in place. Reading sys.stdin.buffer
+        # instead would lose the body whenever a @click.confirmation_option has
+        # already consumed a line, because the text layer buffers the remainder
+        # past the newline and the raw layer is then empty. reconfigure() is
+        # refused once the stream has been read, and is absent on a stdin that is
+        # not a TextIOWrapper; in both cases the stream's own decoder stands.
+        # _decode_piped_stdin_as_utf8() normally gets there first -- this call is
+        # what covers a caller that reaches here without the red-team group.
         try:
-            with open(path) as f:
+            sys.stdin.reconfigure(encoding='utf-8')
+        except (AttributeError, OSError, ValueError):
+            pass
+        try:
+            data = sys.stdin.read().strip()
+        except UnicodeDecodeError:
+            raise click.UsageError(f'JSON body on {source} is not valid UTF-8')
+    else:
+        source = path
+        try:
+            with open(path, encoding='utf-8') as f:
                 data = f.read().strip()
         except OSError as e:
             raise click.UsageError(f'Cannot read JSON body from {path}: {e.strerror}')
-        source = path
+        except UnicodeDecodeError:
+            raise click.UsageError(f'JSON body on {source} is not valid UTF-8')
 
     if not data:
         raise click.UsageError(f'No JSON body provided on {source}')
@@ -58,10 +79,28 @@ def _json_option(inline_value, inline_flag, file_path, file_flag):
         raise click.UsageError('Invalid JSON input')
 
 
+def _decode_piped_stdin_as_utf8():
+    """Re-decode a piped stdin as UTF-8, before anything has read it."""
+    # reconfigure() is refused after the stream's first read, and
+    # @click.confirmation_option is an EAGER Click parameter -- its prompt
+    # consumes a line before any command body runs. The in-body call in
+    # _load_json_body therefore arrives too late on every confirmed command, and
+    # the locale decoder either mojibakes the body or raises inside Click's
+    # prompt, out of reach of any handler here. A group callback runs before a
+    # leaf command's eager parameters (measured), so this is the last point that
+    # still precedes that first read. A tty is left alone: it never carries a
+    # JSON body (see _load_json_body), and its encoding is the terminal's.
+    try:
+        if not sys.stdin.isatty():
+            sys.stdin.reconfigure(encoding='utf-8')
+    except (AttributeError, OSError, ValueError):
+        pass
+
+
 @chariot.group('red-team')
 def red_team():
     """ Red Team operations """
-    pass
+    _decode_piped_stdin_as_utf8()
 
 
 # ===================== Deployment =====================

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -5,19 +5,19 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import error, print_json
+from praetorian_cli.handlers.utils import print_json
 
 
 def _read_json_body():
     if sys.stdin.isatty():
-        error('Pipe JSON input via stdin (e.g., echo \'{"key":"val"}\' | guard red-team ...)')
+        raise click.UsageError('Pipe JSON input via stdin')
     data = sys.stdin.read().strip()
     if not data:
         raise click.UsageError('No JSON body provided on stdin')
     try:
         return json.loads(data)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    except json.JSONDecodeError:
+        raise click.UsageError('Invalid JSON input')
 
 
 @chariot.group('red-team')
@@ -172,6 +172,19 @@ def collaborators(sdk, collaborators):
     """
     collabs = [c.strip() for c in collaborators.split(',')]
     print_json(sdk.red_team.deployment_collaborators(collabs))
+
+
+@deployment.command('tags')
+@cli_handler
+@praetorian_only
+def deployment_tags(sdk):
+    """ List available infrastructure version tags
+
+    \b
+    Example usages:
+        guard red-team deployment tags
+    """
+    print_json(sdk.red_team.deployment_tags())
 
 
 # ===================== Campaigns =====================
@@ -329,6 +342,27 @@ def dns_create(sdk, domain, record_type, name, content, ttl):
     print_json(sdk.red_team.dns_create(domain, record_type, name, content, ttl))
 
 
+@domain.command('dns-update')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+@click.option('--record-id', required=True, help='DNS record ID')
+@click.option('--type', 'record_type', required=True,
+              type=click.Choice(['A', 'CNAME', 'MX', 'TXT']),
+              help='Record type')
+@click.option('--name', required=True, help='Record name')
+@click.option('--content', required=True, help='Record value')
+@click.option('--ttl', type=int, default=1, help='TTL in seconds (1=auto)')
+def dns_update(sdk, domain, record_id, record_type, name, content, ttl):
+    """ Update a DNS record for a parked domain
+
+    \b
+    Example usages:
+        guard red-team domain dns-update --domain evil.com --record-id abc123 --type A --name www --content 1.2.3.4
+    """
+    print_json(sdk.red_team.dns_update(domain, record_id, record_type, name, content, ttl))
+
+
 @domain.command('dns-delete')
 @cli_handler
 @praetorian_only
@@ -372,6 +406,24 @@ def mailgun_provision(sdk, domain):
     print_json(sdk.red_team.mailgun_domain_provision(domain))
 
 
+@domain.command('mailgun-domain-delete')
+@cli_handler
+@praetorian_only
+@click.option('--domain', required=True, help='Domain name')
+@click.confirmation_option(prompt='Delete the Mailgun domain?')
+def mailgun_domain_delete(sdk, domain):
+    """ Delete a Mailgun domain
+
+    \b
+    Prompts for confirmation.
+
+    \b
+    Example usages:
+        guard red-team domain mailgun-domain-delete --domain evil.com
+    """
+    print_json(sdk.red_team.mailgun_domain_delete(domain))
+
+
 @domain.command('mailgun-user')
 @cli_handler
 @praetorian_only
@@ -385,6 +437,25 @@ def mailgun_user(sdk, username, domain):
         guard red-team domain mailgun-user --username noreply --domain evil.com
     """
     print_json(sdk.red_team.mailgun_user_create(username, domain))
+
+
+@domain.command('mailgun-user-delete')
+@cli_handler
+@praetorian_only
+@click.option('--username', required=True, help='SMTP username')
+@click.option('--domain', required=True, help='Domain name')
+@click.confirmation_option(prompt='Delete the Mailgun SMTP user?')
+def mailgun_user_delete(sdk, username, domain):
+    """ Delete a Mailgun SMTP user
+
+    \b
+    Prompts for confirmation.
+
+    \b
+    Example usages:
+        guard red-team domain mailgun-user-delete --username noreply --domain evil.com
+    """
+    print_json(sdk.red_team.mailgun_user_delete(username, domain))
 
 
 # ===================== Evilginx =====================
@@ -473,8 +544,8 @@ def configure(sdk, node, domain, phishlet, params, unauth_url):
     """
     try:
         phishlet_params = json.loads(params) if params else None
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    except json.JSONDecodeError:
+        raise click.UsageError('Invalid JSON input')
     print_json(sdk.red_team.evilginx_configure(
         node, domain, phishlet,
         phishlet_params=phishlet_params, unauth_url=unauth_url))
@@ -513,8 +584,8 @@ def payload_generate(sdk, shellcode, variables):
     """
     try:
         vars_dict = json.loads(variables) if variables else None
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    except json.JSONDecodeError:
+        raise click.UsageError('Invalid JSON input')
     print_json(sdk.red_team.payload_generate(shellcode, variables=vars_dict))
 
 

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -5,7 +5,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import error, print_json
 
 
 def _read_json_body():
@@ -143,19 +143,22 @@ def plan(sdk, tag, sha):
 @praetorian_only
 @click.option('--tag', default=None, help='Infrastructure version tag')
 @click.option('--sha', default=None, help='Git commit SHA')
-@click.confirmation_option(prompt='Apply the Terraform deployment?')
-def apply(sdk, tag, sha):
+@click.option('--yes', '-y', is_flag=True, default=False, help='Skip confirmation prompt')
+def apply(sdk, tag, sha, yes):
     """ Run terraform apply from a builder state JSON on stdin
 
     \b
-    Prompts for confirmation.
+    Prompts for confirmation (unless stdin is piped or --yes is given).
 
     \b
     Example usages:
         cat builder.json | guard red-team deployment apply
     """
+    body = _read_json_body()
+    if not yes and sys.stdin.isatty():
+        click.confirm('Apply the Terraform deployment?', abort=True)
     print_json(sdk.red_team.deployment_terraform(
-        'apply', _read_json_body(), tag=tag, sha=sha))
+        'apply', body, tag=tag, sha=sha))
 
 
 @deployment.command()
@@ -238,7 +241,14 @@ def targets(sdk, campaign_id, segment):
         cat targets.json | guard red-team campaign targets --id camp-1
     """
     body = _read_json_body()
-    target_list = body.get('targets', body) if isinstance(body, dict) else body
+    if isinstance(body, dict):
+        target_list = body.get('targets')
+        if target_list is None:
+            error("Expected JSON with 'targets' key or a JSON array of targets")
+    elif isinstance(body, list):
+        target_list = body
+    else:
+        error('Expected JSON array or object with \'targets\' key')
     print_json(sdk.red_team.campaign_targets(
         campaign_id, target_list, segment=segment))
 

--- a/praetorian_cli/handlers/red_team.py
+++ b/praetorian_cli/handlers/red_team.py
@@ -32,13 +32,29 @@ def _load_json_body(path=None):
         # refused once the stream has been read, and is absent on a stdin that is
         # not a TextIOWrapper; in both cases the stream's own decoder stands.
         # _decode_piped_stdin_as_utf8() normally gets there first -- this call is
-        # what covers a caller that reaches here without the red-team group.
+        # what covers a caller that reaches here without the red-team group. Both
+        # sites install the same permissive error handler; they must agree, or a
+        # caller arriving without the group gets strict decoding back and the
+        # validation below never sees the undecodable bytes.
         try:
-            sys.stdin.reconfigure(encoding='utf-8')
+            sys.stdin.reconfigure(encoding='utf-8', errors='surrogateescape')
         except (AttributeError, OSError, ValueError):
             pass
         try:
             data = sys.stdin.read().strip()
+        except UnicodeDecodeError:
+            # Reached when reconfigure() above was refused and the stream's own
+            # decoder is a strict one.
+            raise click.UsageError(f'JSON body on {source} is not valid UTF-8')
+        # POLICY: stdin is decoded permissively but validated strictly, and this
+        # is where the strict check lives -- it cannot live in the decoder,
+        # because an eager @click.confirmation_option reads (and so decodes) the
+        # buffered body before any command body runs, where a decode error is out
+        # of reach of cli_handler (see _decode_piped_stdin_as_utf8). Undecodable
+        # bytes arrive here as lone surrogates; the round-trip is what rejects
+        # them, as a usage error the caller can act on.
+        try:
+            data.encode('utf-8', 'surrogateescape').decode('utf-8')
         except UnicodeDecodeError:
             raise click.UsageError(f'JSON body on {source} is not valid UTF-8')
     else:
@@ -85,14 +101,21 @@ def _decode_piped_stdin_as_utf8():
     # @click.confirmation_option is an EAGER Click parameter -- its prompt
     # consumes a line before any command body runs. The in-body call in
     # _load_json_body therefore arrives too late on every confirmed command, and
-    # the locale decoder either mojibakes the body or raises inside Click's
-    # prompt, out of reach of any handler here. A group callback runs before a
+    # the locale decoder would mojibake the body. A group callback runs before a
     # leaf command's eager parameters (measured), so this is the last point that
     # still precedes that first read. A tty is left alone: it never carries a
     # JSON body (see _load_json_body), and its encoding is the terminal's.
+    #
+    # POLICY: errors='surrogateescape', never strict. readline() decodes the
+    # whole buffered chunk while it hunts the newline, so an undecodable byte
+    # anywhere in the body -- not just in the prompt's own line -- raises inside
+    # Click's prompt, which handles only EOF and interrupts. That runs during
+    # parse_args, outside the command callback and so outside cli_handler, where
+    # nothing can turn it into a usage error. Permissive here carries those bytes
+    # through as lone surrogates; _load_json_body is what rejects them.
     try:
         if not sys.stdin.isatty():
-            sys.stdin.reconfigure(encoding='utf-8')
+            sys.stdin.reconfigure(encoding='utf-8', errors='surrogateescape')
     except (AttributeError, OSError, ValueError):
         pass
 

--- a/praetorian_cli/handlers/ssh_utils.py
+++ b/praetorian_cli/handlers/ssh_utils.py
@@ -3,7 +3,7 @@ Shared SSH utilities for Aegis CLI and TUI commands
 """
 
 from typing import List, Dict, Optional
-from praetorian_cli.sdk.model.aegis import Agent
+from praetorian_cli.sdk.model.aegis import validate_agent_for_ssh
 
 
 class SSHArgumentParser:
@@ -125,30 +125,3 @@ class SSHArgumentParser:
         else:
             # Fallback for CLI usage
             print(f"Error: {message}" if not dim else message)
-
-
-def validate_agent_for_ssh(agent: Agent) -> tuple[bool, str]:
-    """
-    Validate if an agent is ready for SSH connections
-    Returns (is_valid, error_message)
-    """
-    if not agent:
-        return False, "No agent specified"
-    
-    client_id = agent.client_id
-    hostname = agent.hostname or 'Unknown'
-    has_tunnel = agent.has_tunnel
-    
-    if not client_id:
-        return False, "Agent missing client_id"
-    
-    # Check if Cloudflare tunnel is available
-    if not has_tunnel:
-        return False, f"SSH not available for {hostname} - no active tunnel"
-    
-    # Check if tunnel has a public hostname
-    public_hostname = agent.health_check.cloudflared_status.hostname if has_tunnel else None
-    if not public_hostname:
-        return False, f"No public hostname found in tunnel configuration for {hostname}"
-    
-    return True, ""

--- a/praetorian_cli/handlers/test.py
+++ b/praetorian_cli/handlers/test.py
@@ -1,29 +1,202 @@
 import os
-import sys
 import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
 
 import click
-import pytest
 
 import praetorian_cli.sdk.test as test_module
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
 
 
+@dataclass(frozen=True)
+class TestSuite:
+    name: str
+    pytest_selector: tuple[str, ...]
+    local_safe: bool
+    live: bool
+    mutating: bool
+    tui: bool
+    requires_target: bool
+
+
+@dataclass(frozen=True)
+class TestTarget:
+    profile: str | None
+    account: str | None
+    proxy: str
+
+
+TEST_SUITES = {
+    "safe": TestSuite(
+        name="safe",
+        pytest_selector=("-m", "not coherence and not cli and not tui"),
+        local_safe=True,
+        live=False,
+        mutating=False,
+        tui=False,
+        requires_target=False,
+    ),
+    "coherence": TestSuite(
+        name="coherence",
+        pytest_selector=("-m", "coherence"),
+        local_safe=False,
+        live=True,
+        mutating=True,
+        tui=False,
+        requires_target=True,
+    ),
+    "cli": TestSuite(
+        name="cli",
+        pytest_selector=("-m", "cli"),
+        local_safe=False,
+        live=True,
+        mutating=True,
+        tui=False,
+        requires_target=True,
+    ),
+    "tui": TestSuite(
+        name="tui",
+        pytest_selector=("-m", "tui"),
+        local_safe=False,
+        live=False,
+        mutating=False,
+        tui=True,
+        requires_target=False,
+    ),
+}
+
+TEST_PROFILE_ENV = "CHARIOT_TEST_PROFILE"
+TEST_ACCOUNT_ENV = "CHARIOT_TEST_ACCOUNT"
+TEST_PROXY_ENV = "CHARIOT_PROXY"
+NON_LIVE_CREDENTIAL_ENV = (
+    "PRAETORIAN_CLI_USERNAME",
+    "PRAETORIAN_CLI_PASSWORD",
+    "PRAETORIAN_CLI_API_KEY_ID",
+    "PRAETORIAN_CLI_API_KEY_SECRET",
+    "PRAETORIAN_CLI_API",
+    "PRAETORIAN_CLI_CLIENT_ID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+)
+
+
+def _explicit_target(value, label):
+    if not isinstance(value, str) or not value or value != value.strip():
+        click.echo(f"Error: an explicit, unambiguous {label} is required for this test suite.", err=True)
+        raise SystemExit(2)
+    return value
+
+
+def _confirm_live_suite(suite, profile, account):
+    prompt = (
+        f"Suite: {suite.name}\n"
+        f"Profile: {profile}\n"
+        f"Account: {account}\n"
+        f"Mutation status: {'MUTATING' if suite.mutating else 'non-mutating'}\n"
+        f"Live status: {'LIVE' if suite.live else 'local'}\n"
+        "Run this suite"
+    )
+    try:
+        confirmed = click.confirm(prompt, default=False)
+    except click.Abort:
+        raise SystemExit(1)
+    if not confirmed:
+        raise SystemExit(1)
+
+
+def _test_environment(suite):
+    environment = os.environ.copy()
+    for name in (TEST_PROFILE_ENV, TEST_ACCOUNT_ENV, TEST_PROXY_ENV):
+        environment.pop(name, None)
+    if not suite.live and not suite.mutating:
+        for name in NON_LIVE_CREDENTIAL_ENV:
+            environment.pop(name, None)
+        environment["AWS_EC2_METADATA_DISABLED"] = "true"
+    return environment
+
+
+def _test_target(chariot):
+    if isinstance(chariot, TestTarget):
+        return chariot
+    # A TestTarget is the only carrier of an explicit target, and main.py's _supplied()
+    # is the only thing that fills one -- from COMMANDLINE/ENVIRONMENT values alone.
+    # Anything else arriving here is a context-wiring regression, not a target, so drop
+    # its profile and account: absent values are what _explicit_target rejects. Never
+    # read the keychain instead -- its profile carries the declared --profile default,
+    # which the user may never have chosen. Change the policy in main.py, not here.
+    click.echo(
+        'Warning: this invocation carries no explicit test target; '
+        'suites that require one will be refused.',
+        err=True,
+    )
+    return TestTarget(profile=None, account=None, proxy=getattr(chariot, 'proxy', ''))
+
+
+def _configure_live_target(suite, target, environment):
+    if not (suite.requires_target or suite.live or suite.mutating):
+        return
+    profile = _explicit_target(target.profile, 'profile')
+    account = _explicit_target(target.account, 'account')
+    environment[TEST_PROFILE_ENV] = profile
+    environment[TEST_ACCOUNT_ENV] = account
+    if target.proxy:
+        environment[TEST_PROXY_ENV] = target.proxy
+    if suite.live or suite.mutating:
+        _confirm_live_suite(suite, profile, account)
+
+
+def _pytest_args(suite, key):
+    command = [test_module.__path__[0], *suite.pytest_selector]
+    if key:
+        command.extend(['-k', key])
+    return [sys.executable, '-m', 'pytest', *command]
+
+
+def _run_pytest(args, environment, *, isolated):
+    if not isolated:
+        return subprocess.run(args, env=environment)
+    with tempfile.TemporaryDirectory(prefix="praetorian-cli-test-home-") as isolated_home:
+        environment["HOME"] = isolated_home
+        environment["USERPROFILE"] = isolated_home
+        environment["AWS_SHARED_CREDENTIALS_FILE"] = os.path.join(isolated_home, ".aws", "credentials")
+        environment["AWS_CONFIG_FILE"] = os.path.join(isolated_home, ".aws", "config")
+        environment["BOTO_CONFIG"] = os.path.join(isolated_home, ".boto")
+        return subprocess.run(args, env=environment)
+
+
 @chariot.command()
 @cli_handler
-@click.option('-s', '--suite', type=click.Choice(['coherence', 'cli', 'tui']), help='Run a specific test suite')
+@click.option(
+    '-s',
+    '--suite',
+    type=click.Choice(tuple(TEST_SUITES)),
+    default='safe',
+    show_default=True,
+    help='Run a specific test suite',
+)
 @click.argument('key', required=False)
 def test(chariot, key, suite):
     """ Run integration test suite """
-    os.environ['CHARIOT_TEST_PROFILE'] = chariot.keychain.profile
-    os.environ['CHARIOT_PROXY'] = chariot.proxy
-    command = [test_module.__path__[0]]
-    if key:
-        command.extend(['-k', key])
-    if suite:
-        command.extend(['-m', suite])
-    # Run pytest in a subprocess to isolate from CLI pre-imports
-    args = [sys.executable, '-m', 'pytest'] + command
-    result = subprocess.run(args)
+    selected_suite = TEST_SUITES[suite]
+    non_live = not selected_suite.live and not selected_suite.mutating
+    environment = _test_environment(selected_suite)
+    _configure_live_target(selected_suite, _test_target(chariot), environment)
+    result = _run_pytest(_pytest_args(selected_suite, key), environment, isolated=non_live)
     raise SystemExit(result.returncode)

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -32,6 +32,7 @@ import praetorian_cli.handlers.query
 import praetorian_cli.handlers.tenant
 import praetorian_cli.handlers.osint  # noqa: F401
 import praetorian_cli.handlers.remediation  # noqa: F401
+import praetorian_cli.handlers.red_team  # noqa: F401
 import praetorian_cli.handlers.report
 import praetorian_cli.handlers.script
 import praetorian_cli.handlers.search

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -4,6 +4,7 @@ import truststore
 truststore.inject_into_ssl()
 
 import click
+from click.core import ParameterSource
 
 import praetorian_cli.handlers.access
 import praetorian_cli.handlers.ad
@@ -44,7 +45,43 @@ from praetorian_cli.handlers.configure import configure
 from praetorian_cli.sdk.keychain import Keychain
 
 
-@click.group()
+class InvocationPathGroup(click.Group):
+    """Record the Click-resolved public command path before root setup runs."""
+
+    def resolve_command(self, ctx, args):
+        command_name, command, remaining = super().resolve_command(ctx, args)
+        nested_name = remaining[0] if remaining else None
+        ctx.meta["praetorian_invocation_path"] = (command_name, nested_name)
+        return command_name, command, remaining
+
+
+def _is_test_invocation(click_context):
+    path = click_context.meta.get("praetorian_invocation_path", ())
+    return click_context.invoked_subcommand == "test" or path == ("chariot", "test")
+
+
+# A test target may only be built from values the user actually supplied. Anything
+# else -- notably the declared --profile default -- must reach the explicit-target
+# check as a value it rejects, so a destructive suite can never run against a
+# default the user never chose.
+SUPPLIED_PARAMETER_SOURCES = (ParameterSource.COMMANDLINE, ParameterSource.ENVIRONMENT)
+
+
+def _supplied(click_context, name, value):
+    if click_context.get_parameter_source(name) in SUPPLIED_PARAMETER_SOURCES:
+        return value
+    return None
+
+
+def _test_target(click_context, profile, account, proxy):
+    return praetorian_cli.handlers.test.TestTarget(
+        profile=_supplied(click_context, 'profile', profile),
+        account=_supplied(click_context, 'account', account),
+        proxy=proxy,
+    )
+
+
+@click.group(cls=InvocationPathGroup)
 @click.option('--profile', default='United States', help='The profile to use in the keychain file', show_default=True)
 @click.option('--account', default=None, help='Assume role into this account')
 @click.option('--debug', is_flag=True, default=False, help='Run the CLI in debug mode')
@@ -55,6 +92,9 @@ def main(click_context, profile, account, debug, proxy):
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
+    if _is_test_invocation(click_context):
+        click_context.obj = _test_target(click_context, profile, account, proxy)
+        return
     click_context.obj = {'keychain': Keychain(profile, account), 'proxy': proxy}
     praetorian_cli.handlers.script.load_dynamic_commands()
 
@@ -72,10 +112,15 @@ main.add_command(configure)
 @click.version_option()
 def guard_main(click_context, profile, account, debug, proxy):
     """Guard CLI - Praetorian's offensive security platform."""
-    from praetorian_cli.sdk.chariot import Chariot
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
+
+    if _is_test_invocation(click_context):
+        click_context.obj = _test_target(click_context, profile, account, proxy)
+        return
+
+    from praetorian_cli.sdk.chariot import Chariot
     click_context.obj = Chariot(Keychain(profile, account), proxy=proxy)
     praetorian_cli.handlers.script.load_dynamic_commands()
 

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -22,6 +22,7 @@ from praetorian_cli.sdk.entities.osint import OSINT
 from praetorian_cli.sdk.entities.knossos import Knossos
 from praetorian_cli.sdk.entities.preseeds import Preseeds
 from praetorian_cli.sdk.entities.remediation import Remediation
+from praetorian_cli.sdk.entities.red_team import RedTeam
 from praetorian_cli.sdk.entities.reports import Reports
 from praetorian_cli.sdk.entities.risks import Risks
 from praetorian_cli.sdk.entities.scanners import Scanners
@@ -45,6 +46,7 @@ class Chariot:
         self.assets = Assets(self)
         self.seeds = Seeds(self)
         self.preseeds = Preseeds(self)
+        self.red_team = RedTeam(self)
         self.reports = Reports(self)
         self.risks = Risks(self)
         self.accounts = Accounts(self)

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -309,9 +309,12 @@ class Chariot:
         """ Start MCP server exposing SDK methods as tools
         
         Arguments:
-        allowable_tools: list
-            Optional list of tool names to expose. If None, all tools are exposed.
-            Tool names should be in format 'entity.method' (e.g., 'assets.add', 'risks.list')
+        allowable_tools: list or tuple of str
+            Optional list of tool names to expose. Tool names are in format
+            'entity_method' (e.g., 'assets_add', 'risks_list'). If None, all
+            non-sensitive tools are exposed; sensitive tools (see
+            praetorian_cli.sdk.mcp_server.SENSITIVE_TOOL_PATTERNS) require an
+            exact-name allow entry and never match wildcard patterns.
         """
         from praetorian_cli.sdk.mcp_server import MCPServer
         import anyio

--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -3,8 +3,7 @@ import shlex
 import shutil
 import subprocess
 import time
-from praetorian_cli.sdk.model.aegis import Agent
-from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
+from praetorian_cli.sdk.model.aegis import Agent, validate_agent_for_ssh
 
 
 def normalize_to_list(value, item_keys: List[str] = None) -> List:

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -1,4 +1,3 @@
-from praetorian_cli.handlers.utils import error
 from praetorian_cli.sdk.model.globals import Asset, Kind
 from praetorian_cli.sdk.model.query import Relationship, Node, Query, Filter, KIND_TO_LABEL, asset_of_key, RISK_NODE, ATTRIBUTE_NODE
 

--- a/praetorian_cli/sdk/entities/preseeds.py
+++ b/praetorian_cli/sdk/entities/preseeds.py
@@ -1,4 +1,4 @@
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import NotFoundError
 
 
 class Preseeds:
@@ -105,7 +105,7 @@ class Preseeds:
         :type comment: str or None
         :return: The updated preseed object with new status
         :rtype: dict
-        :raises: Prints error message if preseed with the specified key is not found
+        :raises NotFoundError: if no preseed with the specified key exists
 
         **Example Usage:**
 
@@ -143,7 +143,7 @@ class Preseeds:
 
             return self.api.update('preseed', update_payload)
         else:
-            error(f'Pre-seed {key} is not found.')
+            raise NotFoundError(f'Pre-seed {key} is not found.')
 
     def delete(self, key):
         """Delete a preseed from the Chariot database.

--- a/praetorian_cli/sdk/entities/red_team.py
+++ b/praetorian_cli/sdk/entities/red_team.py
@@ -134,7 +134,7 @@ class RedTeam:
     def evilginx_configure(self, node_ref, domain, phishlet,
                            phishlet_params=None, unauth_url=None):
         body = {'node_ref': node_ref, 'domain': domain, 'phishlet': phishlet}
-        if phishlet_params:
+        if phishlet_params is not None:
             body['phishlet_params'] = phishlet_params
         if unauth_url:
             body['unauth_url'] = unauth_url
@@ -148,7 +148,7 @@ class RedTeam:
 
     def payload_generate(self, shellcode_filename, variables=None):
         body = {'shellcode_s3_filename': shellcode_filename}
-        if variables:
+        if variables is not None:
             body['variables'] = variables
         return self.api.post('red-team/payload/generate', body)
 

--- a/praetorian_cli/sdk/entities/red_team.py
+++ b/praetorian_cli/sdk/entities/red_team.py
@@ -1,0 +1,154 @@
+class RedTeam:
+    def __init__(self, api):
+        self.api = api
+
+    # --- Deployment ---
+
+    def deployment_launch(self, desired_id=None):
+        body = {}
+        if desired_id:
+            body['desired_id'] = desired_id
+        return self.api.post('red-team/deployment/launch', body)
+
+    def deployment_delete(self, force=False):
+        params = {'force': 'true'} if force else {}
+        return self.api.delete('red-team/deployment/delete', {}, params)
+
+    def deployment_details(self):
+        return self.api.get('red-team/deployment/details')
+
+    def deployment_history(self):
+        return self.api.get('red-team/deployment/history')
+
+    def deployment_last_inputs(self):
+        return self.api.get('red-team/deployment/last-inputs')
+
+    def deployment_node_schema(self, tag=None):
+        params = {'tag': tag} if tag else {}
+        return self.api.get('red-team/deployment/node-schema', params=params)
+
+    def deployment_terraform(self, action, builder_state, tag=None, sha=None):
+        params = {}
+        if tag:
+            params['tag'] = tag
+        if sha:
+            params['sha'] = sha
+        return self.api.post(f'red-team/deployment/terraform/{action}',
+                             builder_state, params=params)
+
+    def deployment_collaborators(self, collaborators):
+        return self.api.post('red-team/deployment/collaborators',
+                             {'collaborators': collaborators})
+
+    def deployment_tags(self):
+        return self.api.get('red-team/deployment/tags')
+
+    # --- Campaigns ---
+
+    def campaign_create(self, campaign):
+        return self.api.put('red-team/campaigns', campaign)
+
+    def campaign_delete(self, key):
+        return self.api.delete('red-team/campaigns', {'key': key}, {})
+
+    def campaign_targets(self, campaign_id, targets, segment=None):
+        body = {'targets': targets}
+        if segment:
+            body['segment'] = segment
+        return self.api.post(f'red-team/campaigns/{campaign_id}/targets', body)
+
+    def campaign_authorize(self, campaign_id):
+        return self.api.post(f'red-team/campaigns/{campaign_id}/authorize', {})
+
+    def campaign_funnel(self, campaign_id):
+        return self.api.get(f'red-team/campaigns/{campaign_id}/funnel')
+
+    def campaign_activity(self, campaign_id, limit=None):
+        params = {'limit': str(limit)} if limit else {}
+        return self.api.get(f'red-team/campaigns/{campaign_id}/activity',
+                            params=params)
+
+    # --- Domain parking ---
+
+    def domain_update(self, domain_data):
+        return self.api.put('red-team/domain-parking', domain_data)
+
+    def dns_list(self, domain):
+        return self.api.get(f'red-team/domain-parking/dns/{domain}')
+
+    def dns_create(self, domain, record_type, name, content, ttl=1):
+        return self.api.post(f'red-team/domain-parking/dns/{domain}',
+                             {'type': record_type, 'name': name,
+                              'content': content, 'ttl': ttl})
+
+    def dns_update(self, domain, record_id, record_type, name, content, ttl=1):
+        return self.api.put(f'red-team/domain-parking/dns/{domain}/{record_id}',
+                            {'type': record_type, 'name': name,
+                             'content': content, 'ttl': ttl})
+
+    def dns_delete(self, domain, record_id):
+        return self.api.delete(
+            f'red-team/domain-parking/dns/{domain}/{record_id}', {}, {})
+
+    def mailgun_domain_status(self, domain):
+        return self.api.get(
+            f'red-team/domain-parking/mailgun/domain/{domain}')
+
+    def mailgun_domain_provision(self, domain):
+        return self.api.post(
+            f'red-team/domain-parking/mailgun/domain/{domain}', {})
+
+    def mailgun_domain_delete(self, domain):
+        return self.api.delete(
+            f'red-team/domain-parking/mailgun/domain/{domain}', {}, {})
+
+    def mailgun_user_create(self, username, domain):
+        return self.api.post('red-team/domain-parking/mailgun/user',
+                             {'username': username, 'domain': domain})
+
+    def mailgun_user_delete(self, username, domain):
+        return self.api.delete('red-team/domain-parking/mailgun/user',
+                               {'username': username, 'domain': domain}, {})
+
+    # --- Evilginx ---
+
+    def evilginx_phishlets(self, node):
+        return self.api.get('red-team/evilginx/phishlets',
+                            params={'node': node})
+
+    def evilginx_phishlet_params(self, node, name):
+        return self.api.get(f'red-team/evilginx/phishlets/{name}/params',
+                            params={'node': node})
+
+    def evilginx_lures(self, node):
+        return self.api.get('red-team/evilginx/lures',
+                            params={'node': node})
+
+    def evilginx_create_lure(self, node_ref, lure_path):
+        return self.api.post('red-team/evilginx/lures',
+                             {'node_ref': node_ref, 'lure_path': lure_path})
+
+    def evilginx_configure(self, node_ref, domain, phishlet,
+                           phishlet_params=None, unauth_url=None):
+        body = {'node_ref': node_ref, 'domain': domain, 'phishlet': phishlet}
+        if phishlet_params:
+            body['phishlet_params'] = phishlet_params
+        if unauth_url:
+            body['unauth_url'] = unauth_url
+        return self.api.post('red-team/evilginx/configure', body)
+
+    def evilginx_status(self, node):
+        return self.api.get('red-team/evilginx/status',
+                            params={'node': node})
+
+    # --- Payload & phishkit ---
+
+    def payload_generate(self, shellcode_filename, variables=None):
+        body = {'shellcode_s3_filename': shellcode_filename}
+        if variables:
+            body['variables'] = variables
+        return self.api.post('red-team/payload/generate', body)
+
+    def phishkit_nodes(self, status=None):
+        params = {'status': status} if status else {}
+        return self.api.get('red-team/phishkit-nodes', params=params)

--- a/praetorian_cli/sdk/entities/red_team.py
+++ b/praetorian_cli/sdk/entities/red_team.py
@@ -1,138 +1,644 @@
 from urllib.parse import quote
 
+# The terraform sub-steps this client is allowed to drive. `generate`, `outputs`
+# and `tag` are backend-only sub-steps of the deployment pipeline and are
+# deliberately NOT reachable from the CLI, the SDK, or the MCP surface.
+TERRAFORM_ACTIONS = ('plan', 'apply')
+
+
+def _segment(value):
+    """Encode one URL path segment, rejecting values that would redirect the route.
+
+    `quote` leaves dot-segments intact and `requests` normalizes them away before
+    transmission, so `..` as a segment silently retargets the request at the parent
+    route. Validate, then encode.
+    """
+    text = str(value)
+    if not text or text in ('.', '..'):
+        raise ValueError(f'invalid URL path segment: {value!r}')
+    return quote(text, safe='')
+
 
 class RedTeam:
+    """
+    Manage Red Team phishing infrastructure, campaigns, and payloads.
+
+    This class provides methods to drive the Red Team deployment lifecycle,
+    phishing campaigns, parked domains and their DNS, Mailgun mail delivery,
+    Evilginx phishing proxies, and payload generation. All operations are
+    restricted to Praetorian engineers only and require appropriate
+    authentication.
+
+    Red Team operations are accessed from sdk.red_team, where sdk is an
+    instance of Chariot.
+
+    Example:
+        >>> chariot = Chariot()
+        >>> chariot.red_team.deployment_launch()
+        >>> chariot.red_team.campaign_funnel('camp-1')
+    """
+
     def __init__(self, api):
         self.api = api
+
+    def _check_if_praetorian(self):
+        if not self.api.is_praetorian_user():
+            raise RuntimeError(
+                "This option is limited to Praetorian engineers only. "
+                "Please contact your Praetorian representative for assistance."
+            )
 
     # --- Deployment ---
 
     def deployment_launch(self, desired_id=None):
+        """
+        Launch a new Red Team deployment.
+
+        Provisions the Red Team infrastructure deployment for the current
+        account. At most one deployment exists per account.
+
+        :param desired_id: The deployment ID to request, or None to let the
+                           backend assign one
+        :type desired_id: str or None
+        :return: The launched deployment record
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         body = {}
         if desired_id:
             body['desired_id'] = desired_id
         return self.api.post('red-team/deployment/launch', body)
 
     def deployment_delete(self, force=False):
+        """
+        Destructively delete the Red Team deployment and all its infrastructure.
+
+        This action is irreversible. Every node, phishing proxy, and piece of
+        provisioned infrastructure in the deployment is torn down.
+
+        :param force: Whether to force deletion even when the backend reports
+                      the deployment is not in a deletable state
+        :type force: bool
+        :return: Result of the delete operation
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         params = {'force': 'true'} if force else {}
         return self.api.delete('red-team/deployment/delete', {}, params)
 
     def deployment_details(self):
+        """
+        Get the current Red Team deployment details.
+
+        Retrieves the deployment record for the current account, including its
+        nodes and their provisioning state.
+
+        :return: The current deployment details
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/deployment/details')
 
     def deployment_history(self):
+        """
+        Get the Red Team deployment action history.
+
+        Retrieves the audit trail of deployment actions (launches, plans,
+        applies, deletions) for the current account.
+
+        :return: The list of historical deployment actions
+        :rtype: list
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/deployment/history')
 
     def deployment_last_inputs(self):
+        """
+        Get the last submitted builder configuration.
+
+        Retrieves the most recent builder state that was submitted for a
+        terraform plan or apply, suitable for re-submission after editing.
+
+        :return: The last submitted builder state
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/deployment/last-inputs')
 
     def deployment_node_schema(self, tag=None):
+        """
+        Get the node catalog schema for Red Team infrastructure.
+
+        Retrieves the catalog of node types and their configurable parameters,
+        which describes the shape of a valid builder state.
+
+        :param tag: The infrastructure version tag to read the schema for, or
+                    None for the default version
+        :type tag: str or None
+        :return: The node catalog schema
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         params = {'tag': tag} if tag else {}
         return self.api.get('red-team/deployment/node-schema', params=params)
 
     def deployment_terraform(self, action, builder_state, tag=None, sha=None):
+        """
+        Run a terraform plan or apply against a builder state.
+
+        The 'apply' action mutates live infrastructure and is irreversible in
+        the sense that it provisions, reconfigures, or destroys nodes to match
+        the submitted builder state. Only 'plan' and 'apply' are reachable from
+        this client; the remaining backend-only sub-steps are not exposed.
+
+        :param action: The terraform action to run, either 'plan' or 'apply'
+        :type action: str
+        :param builder_state: The builder state document sent as the request
+                              body, describing the desired infrastructure
+        :type builder_state: dict
+        :param tag: The infrastructure version tag to run against, or None for
+                    the default version
+        :type tag: str or None
+        :param sha: The git commit SHA to run against, or None for the default
+        :type sha: str or None
+        :return: The queued terraform job record
+        :rtype: dict
+        :raises ValueError: If action is not 'plan' or 'apply'
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        if action not in TERRAFORM_ACTIONS:
+            raise ValueError(
+                f'invalid terraform action: {action!r}; '
+                f'expected one of {", ".join(repr(a) for a in TERRAFORM_ACTIONS)}'
+            )
         params = {}
         if tag:
             params['tag'] = tag
         if sha:
             params['sha'] = sha
-        return self.api.post(f'red-team/deployment/terraform/{quote(str(action), safe="")}',
+        return self.api.post(f'red-team/deployment/terraform/{_segment(action)}',
                              builder_state, params=params)
 
     def deployment_collaborators(self, collaborators):
+        """
+        Replace the collaborator list on the Red Team deployment.
+
+        The submitted list replaces the existing collaborators, so any address
+        omitted from it loses access to the deployment.
+
+        :param collaborators: The email addresses to grant deployment access to
+        :type collaborators: list
+        :return: The updated collaborator list
+        :rtype: list
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.post('red-team/deployment/collaborators',
                              {'collaborators': collaborators})
 
     def deployment_tags(self):
+        """
+        List the available Red Team infrastructure version tags.
+
+        Retrieves the infrastructure versions that can be passed as the `tag`
+        argument to the node-schema and terraform operations.
+
+        :return: The list of available version tags
+        :rtype: list
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/deployment/tags')
 
     # --- Campaigns ---
 
     def campaign_create(self, campaign):
+        """
+        Create or update a phishing campaign.
+
+        Upserts the campaign record. A campaign created here is not live until
+        it is explicitly authorized.
+
+        :param campaign: The campaign document sent as the request body
+        :type campaign: dict
+        :return: The created or updated campaign
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.put('red-team/campaigns', campaign)
 
     def campaign_delete(self, key):
+        """
+        Destructively delete a phishing campaign.
+
+        This action is irreversible. The campaign and its recorded activity are
+        removed.
+
+        :param key: The exact key of the campaign to delete
+                    (e.g., '#campaign#my-campaign')
+        :type key: str
+        :return: Result of the delete operation
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.delete('red-team/campaigns', {'key': key}, {})
 
     def campaign_targets(self, campaign_id, targets, segment=None):
+        """
+        Replace the full target roster of a campaign, discarding the previous one.
+
+        The submitted list replaces every target currently on the campaign, so
+        any recipient omitted from it is removed.
+
+        :param campaign_id: The ID of the campaign to set targets on
+        :type campaign_id: str
+        :param targets: The target recipient records that make up the new roster
+        :type targets: list
+        :param segment: The target segment name to assign, or None for the
+                        default segment
+        :type segment: str or None
+        :return: The stored target roster
+        :rtype: list
+        :raises ValueError: If campaign_id is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         body = {'targets': targets}
         if segment:
             body['segment'] = segment
-        return self.api.post(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/targets', body)
+        return self.api.post(f'red-team/campaigns/{_segment(campaign_id)}/targets', body)
 
     def campaign_authorize(self, campaign_id):
-        return self.api.post(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/authorize', {})
+        """
+        Authorize a campaign to go live, sending phishing email to real recipients.
+
+        This is the highest-consequence Red Team operation: once authorized, the
+        campaign begins delivering live phishing email to every target on its
+        roster.
+
+        :param campaign_id: The ID of the campaign to authorize
+        :type campaign_id: str
+        :return: The authorization result, including the campaign's live status
+        :rtype: dict
+        :raises ValueError: If campaign_id is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.post(f'red-team/campaigns/{_segment(campaign_id)}/authorize', {})
 
     def campaign_funnel(self, campaign_id):
-        return self.api.get(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/funnel')
+        """
+        Get the delivery and engagement funnel metrics for a campaign.
+
+        Retrieves aggregate counts across the campaign funnel (sent, opened,
+        clicked, submitted).
+
+        :param campaign_id: The ID of the campaign to read metrics for
+        :type campaign_id: str
+        :return: The campaign funnel metrics
+        :rtype: dict
+        :raises ValueError: If campaign_id is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.get(f'red-team/campaigns/{_segment(campaign_id)}/funnel')
 
     def campaign_activity(self, campaign_id, limit=None):
+        """
+        Get the recorded activity events for a campaign.
+
+        Retrieves the per-recipient event stream for the campaign (deliveries,
+        opens, clicks, credential submissions).
+
+        :param campaign_id: The ID of the campaign to read activity for
+        :type campaign_id: str
+        :param limit: The maximum number of events to return, or None to let the
+                      backend choose
+        :type limit: int
+        :return: The list of activity events
+        :rtype: list
+        :raises ValueError: If campaign_id is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         params = {'limit': str(limit)} if limit else {}
-        return self.api.get(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/activity',
+        return self.api.get(f'red-team/campaigns/{_segment(campaign_id)}/activity',
                             params=params)
 
     # --- Domain parking ---
 
     def domain_update(self, domain_data):
+        """
+        Update a parked domain record.
+
+        Upserts the parked-domain record, which controls how the domain is
+        allocated to engagements and phishing infrastructure.
+
+        :param domain_data: The parked domain document sent as the request body
+        :type domain_data: dict
+        :return: The updated parked domain record
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.put('red-team/domain-parking', domain_data)
 
     def dns_list(self, domain):
-        return self.api.get(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}')
+        """
+        List the DNS records of a parked domain.
+
+        Retrieves every DNS record currently configured at the DNS provider for
+        the parked domain.
+
+        :param domain: The parked domain name to list records for
+        :type domain: str
+        :return: The DNS records of the domain
+        :rtype: dict
+        :raises ValueError: If domain is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.get(f'red-team/domain-parking/dns/{_segment(domain)}')
 
     def dns_create(self, domain, record_type, name, content, ttl=1):
-        return self.api.post(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}',
+        """
+        Create a DNS record on a parked domain.
+
+        Adds a record at the DNS provider. This changes live DNS resolution for
+        the domain.
+
+        :param domain: The parked domain name to add the record to
+        :type domain: str
+        :param record_type: The DNS record type ('A', 'CNAME', 'MX', 'TXT')
+        :type record_type: str
+        :param name: The record name (the host portion, e.g., 'www')
+        :type name: str
+        :param content: The record value (e.g., an IP address or target host)
+        :type content: str
+        :param ttl: The record time-to-live in seconds; 1 means automatic
+        :type ttl: int
+        :return: The created DNS record
+        :rtype: dict
+        :raises ValueError: If domain is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.post(f'red-team/domain-parking/dns/{_segment(domain)}',
                              {'type': record_type, 'name': name,
                               'content': content, 'ttl': ttl})
 
     def dns_update(self, domain, record_id, record_type, name, content, ttl=1):
-        return self.api.put(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}/{quote(str(record_id), safe="")}',
-                            {'type': record_type, 'name': name,
-                             'content': content, 'ttl': ttl})
+        """
+        Overwrite an existing DNS record on a parked domain.
+
+        The submitted values replace the record's current type, name, content
+        and TTL, changing live DNS resolution for the domain.
+
+        :param domain: The parked domain name that owns the record
+        :type domain: str
+        :param record_id: The ID of the DNS record to overwrite
+        :type record_id: str
+        :param record_type: The DNS record type ('A', 'CNAME', 'MX', 'TXT')
+        :type record_type: str
+        :param name: The record name (the host portion, e.g., 'www')
+        :type name: str
+        :param content: The record value (e.g., an IP address or target host)
+        :type content: str
+        :param ttl: The record time-to-live in seconds; 1 means automatic
+        :type ttl: int
+        :return: The updated DNS record
+        :rtype: dict
+        :raises ValueError: If domain or record_id is not a usable URL path
+                            segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.put(
+            f'red-team/domain-parking/dns/{_segment(domain)}/{_segment(record_id)}',
+            {'type': record_type, 'name': name,
+             'content': content, 'ttl': ttl})
 
     def dns_delete(self, domain, record_id):
+        """
+        Destructively delete a DNS record from a parked domain.
+
+        This action is irreversible and changes live DNS resolution for the
+        domain immediately.
+
+        :param domain: The parked domain name that owns the record
+        :type domain: str
+        :param record_id: The ID of the DNS record to delete
+        :type record_id: str
+        :return: Result of the delete operation
+        :rtype: dict
+        :raises ValueError: If domain or record_id is not a usable URL path
+                            segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.delete(
-            f'red-team/domain-parking/dns/{quote(str(domain), safe="")}/{quote(str(record_id), safe="")}', {}, {})
+            f'red-team/domain-parking/dns/{_segment(domain)}/{_segment(record_id)}',
+            {}, {})
 
     def mailgun_domain_status(self, domain):
+        """
+        Get the Mailgun provisioning status of a parked domain.
+
+        Retrieves the mail-delivery state of the domain at Mailgun, including
+        its DNS verification records.
+
+        :param domain: The parked domain name to read Mailgun status for
+        :type domain: str
+        :return: The Mailgun domain status
+        :rtype: dict
+        :raises ValueError: If domain is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get(
-            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}')
+            f'red-team/domain-parking/mailgun/domain/{_segment(domain)}')
 
     def mailgun_domain_provision(self, domain):
+        """
+        Provision a parked domain for mail delivery at Mailgun.
+
+        Registers the domain at Mailgun and issues the sending credentials that
+        phishing campaigns deliver through.
+
+        :param domain: The parked domain name to provision
+        :type domain: str
+        :return: The provisioned Mailgun domain record
+        :rtype: dict
+        :raises ValueError: If domain is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.post(
-            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}', {})
+            f'red-team/domain-parking/mailgun/domain/{_segment(domain)}', {})
 
     def mailgun_domain_delete(self, domain):
+        """
+        Destructively delete a Mailgun domain and its sending credentials.
+
+        This action is irreversible. Campaigns that deliver through the domain
+        stop being able to send mail.
+
+        :param domain: The parked domain name to delete at Mailgun
+        :type domain: str
+        :return: Result of the delete operation
+        :rtype: dict
+        :raises ValueError: If domain is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.delete(
-            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}', {}, {})
+            f'red-team/domain-parking/mailgun/domain/{_segment(domain)}', {}, {})
 
     def mailgun_user_create(self, username, domain):
+        """
+        Create a Mailgun SMTP user and its sending credential.
+
+        Issues an SMTP credential on the domain, which campaigns use to send
+        phishing email.
+
+        :param username: The SMTP username to create
+        :type username: str
+        :param domain: The Mailgun domain to create the user on
+        :type domain: str
+        :return: The created SMTP user, including its credential
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.post('red-team/domain-parking/mailgun/user',
                              {'username': username, 'domain': domain})
 
     def mailgun_user_delete(self, username, domain):
+        """
+        Destructively delete a Mailgun SMTP user and revoke its credential.
+
+        This action is irreversible. Anything sending as that SMTP user stops
+        being able to deliver mail.
+
+        :param username: The SMTP username to delete
+        :type username: str
+        :param domain: The Mailgun domain that owns the user
+        :type domain: str
+        :return: Result of the delete operation
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.delete('red-team/domain-parking/mailgun/user',
                                {'username': username, 'domain': domain}, {})
 
     # --- Evilginx ---
 
     def evilginx_phishlets(self, node):
+        """
+        List the Evilginx phishlets available on a phishkit node.
+
+        Retrieves the phishlet definitions the node can be configured with.
+
+        :param node: The phishkit node reference to query
+        :type node: str
+        :return: The available phishlets
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/evilginx/phishlets',
                             params={'node': node})
 
     def evilginx_phishlet_params(self, node, name):
-        return self.api.get(f'red-team/evilginx/phishlets/{quote(str(name), safe="")}/params',
+        """
+        Get the configurable parameters of a specific Evilginx phishlet.
+
+        Retrieves the parameter names a phishlet expects, which are supplied
+        when configuring Evilginx on a node.
+
+        :param node: The phishkit node reference to query
+        :type node: str
+        :param name: The phishlet name to read parameters for (e.g., 'o365')
+        :type name: str
+        :return: The phishlet parameters
+        :rtype: dict
+        :raises ValueError: If name is not a usable URL path segment
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
+        return self.api.get(f'red-team/evilginx/phishlets/{_segment(name)}/params',
                             params={'node': node})
 
     def evilginx_lures(self, node):
+        """
+        List the Evilginx lures configured on a phishkit node.
+
+        Retrieves the lure URLs that route visitors into the phishing proxy.
+
+        :param node: The phishkit node reference to query
+        :type node: str
+        :return: The configured lures
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/evilginx/lures',
                             params={'node': node})
 
     def evilginx_create_lure(self, node_ref, lure_path):
+        """
+        Create an Evilginx lure on a phishkit node.
+
+        Publishes a live lure URL on the node's phishing proxy at the given
+        path.
+
+        :param node_ref: The phishkit node reference to create the lure on
+        :type node_ref: str
+        :param lure_path: The URL path the lure is served at (e.g., '/login')
+        :type lure_path: str
+        :return: The queued lure-creation job record
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.post('red-team/evilginx/lures',
                              {'node_ref': node_ref, 'lure_path': lure_path})
 
     def evilginx_configure(self, node_ref, domain, phishlet,
                            phishlet_params=None, unauth_url=None):
+        """
+        Overwrite the Evilginx phishing configuration on a phishkit node.
+
+        The submitted values replace the node's current phishing proxy
+        configuration, changing which domain and phishlet it serves live.
+
+        :param node_ref: The phishkit node reference to configure
+        :type node_ref: str
+        :param domain: The domain the phishing proxy serves
+        :type domain: str
+        :param phishlet: The phishlet name to activate (e.g., 'o365')
+        :type phishlet: str
+        :param phishlet_params: The phishlet parameter values, or None to leave
+                                them unset
+        :type phishlet_params: dict
+        :param unauth_url: The URL unauthenticated visitors are redirected to,
+                           or None for the default
+        :type unauth_url: str or None
+        :return: The queued configuration job record
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         body = {'node_ref': node_ref, 'domain': domain, 'phishlet': phishlet}
         if phishlet_params is not None:
             body['phishlet_params'] = phishlet_params
@@ -141,17 +647,61 @@ class RedTeam:
         return self.api.post('red-team/evilginx/configure', body)
 
     def evilginx_status(self, node):
+        """
+        Get the Evilginx configuration status of a phishkit node.
+
+        Retrieves whether the node's phishing proxy is configured and ready to
+        receive traffic.
+
+        :param node: The phishkit node reference to query
+        :type node: str
+        :return: The Evilginx status of the node
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         return self.api.get('red-team/evilginx/status',
                             params={'node': node})
 
     # --- Payload & phishkit ---
 
     def payload_generate(self, shellcode_filename, variables=None):
+        """
+        Generate an executable payload that embeds uploaded shellcode.
+
+        Builds a payload artifact around the named shellcode file, applying the
+        supplied template variables.
+
+        :param shellcode_filename: The S3 filename of the uploaded shellcode to
+                                   embed
+        :type shellcode_filename: str
+        :param variables: The payload template variable values, or None to use
+                          the defaults
+        :type variables: dict
+        :return: The queued payload-generation job record
+        :rtype: dict
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         body = {'shellcode_s3_filename': shellcode_filename}
         if variables is not None:
             body['variables'] = variables
         return self.api.post('red-team/payload/generate', body)
 
     def phishkit_nodes(self, status=None):
+        """
+        List the phishkit nodes of the Red Team deployment.
+
+        Retrieves the nodes that host phishing proxies and lures, optionally
+        filtered by their run state.
+
+        :param status: The node status to filter by (e.g., 'running', 'all'), or
+                       None for the backend default
+        :type status: str or None
+        :return: The list of phishkit nodes
+        :rtype: list
+        :raises RuntimeError: If the user is not a Praetorian engineer
+        """
+        self._check_if_praetorian()
         params = {'status': status} if status else {}
         return self.api.get('red-team/phishkit-nodes', params=params)

--- a/praetorian_cli/sdk/entities/red_team.py
+++ b/praetorian_cli/sdk/entities/red_team.py
@@ -1,3 +1,6 @@
+from urllib.parse import quote
+
+
 class RedTeam:
     def __init__(self, api):
         self.api = api
@@ -33,7 +36,7 @@ class RedTeam:
             params['tag'] = tag
         if sha:
             params['sha'] = sha
-        return self.api.post(f'red-team/deployment/terraform/{action}',
+        return self.api.post(f'red-team/deployment/terraform/{quote(str(action), safe="")}',
                              builder_state, params=params)
 
     def deployment_collaborators(self, collaborators):
@@ -55,17 +58,17 @@ class RedTeam:
         body = {'targets': targets}
         if segment:
             body['segment'] = segment
-        return self.api.post(f'red-team/campaigns/{campaign_id}/targets', body)
+        return self.api.post(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/targets', body)
 
     def campaign_authorize(self, campaign_id):
-        return self.api.post(f'red-team/campaigns/{campaign_id}/authorize', {})
+        return self.api.post(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/authorize', {})
 
     def campaign_funnel(self, campaign_id):
-        return self.api.get(f'red-team/campaigns/{campaign_id}/funnel')
+        return self.api.get(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/funnel')
 
     def campaign_activity(self, campaign_id, limit=None):
         params = {'limit': str(limit)} if limit else {}
-        return self.api.get(f'red-team/campaigns/{campaign_id}/activity',
+        return self.api.get(f'red-team/campaigns/{quote(str(campaign_id), safe="")}/activity',
                             params=params)
 
     # --- Domain parking ---
@@ -74,33 +77,33 @@ class RedTeam:
         return self.api.put('red-team/domain-parking', domain_data)
 
     def dns_list(self, domain):
-        return self.api.get(f'red-team/domain-parking/dns/{domain}')
+        return self.api.get(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}')
 
     def dns_create(self, domain, record_type, name, content, ttl=1):
-        return self.api.post(f'red-team/domain-parking/dns/{domain}',
+        return self.api.post(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}',
                              {'type': record_type, 'name': name,
                               'content': content, 'ttl': ttl})
 
     def dns_update(self, domain, record_id, record_type, name, content, ttl=1):
-        return self.api.put(f'red-team/domain-parking/dns/{domain}/{record_id}',
+        return self.api.put(f'red-team/domain-parking/dns/{quote(str(domain), safe="")}/{quote(str(record_id), safe="")}',
                             {'type': record_type, 'name': name,
                              'content': content, 'ttl': ttl})
 
     def dns_delete(self, domain, record_id):
         return self.api.delete(
-            f'red-team/domain-parking/dns/{domain}/{record_id}', {}, {})
+            f'red-team/domain-parking/dns/{quote(str(domain), safe="")}/{quote(str(record_id), safe="")}', {}, {})
 
     def mailgun_domain_status(self, domain):
         return self.api.get(
-            f'red-team/domain-parking/mailgun/domain/{domain}')
+            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}')
 
     def mailgun_domain_provision(self, domain):
         return self.api.post(
-            f'red-team/domain-parking/mailgun/domain/{domain}', {})
+            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}', {})
 
     def mailgun_domain_delete(self, domain):
         return self.api.delete(
-            f'red-team/domain-parking/mailgun/domain/{domain}', {}, {})
+            f'red-team/domain-parking/mailgun/domain/{quote(str(domain), safe="")}', {}, {})
 
     def mailgun_user_create(self, username, domain):
         return self.api.post('red-team/domain-parking/mailgun/user',
@@ -117,7 +120,7 @@ class RedTeam:
                             params={'node': node})
 
     def evilginx_phishlet_params(self, node, name):
-        return self.api.get(f'red-team/evilginx/phishlets/{name}/params',
+        return self.api.get(f'red-team/evilginx/phishlets/{quote(str(name), safe="")}/params',
                             params={'node': node})
 
     def evilginx_lures(self, node):

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -1,4 +1,4 @@
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import NotFoundError
 from praetorian_cli.sdk.model.globals import Seed, Kind
 from praetorian_cli.sdk.model.query import Query, Node, Filter, KIND_TO_LABEL
 
@@ -80,8 +80,9 @@ class Seeds:
         :param comment: Optional comment to include with the update (stored in History field)
         :type comment: str or None
         :param kwargs: Fields to update
-        :return: The updated seed, or None if the seed was not found
-        :rtype: dict or None
+        :return: The updated seed
+        :rtype: dict
+        :raises NotFoundError: if no seed with the specified key exists
 
         **Example Usage:**
 
@@ -111,7 +112,7 @@ class Seeds:
 
             return self.api.upsert('seed', update_payload)
         else:
-            error(f'Seed {key} not found.')
+            raise NotFoundError(f'Seed {key} not found.')
 
     def delete(self, key):
         """
@@ -119,8 +120,9 @@ class Seeds:
         
         :param key: Seed/Asset key (e.g., '#asset#domain#example.com')
         :type key: str
-        :return: The seed that was marked as deleted, or None if the seed was not found
-        :rtype: dict or None
+        :return: The seed that was marked as deleted
+        :rtype: dict
+        :raises NotFoundError: if no seed with the specified key exists
         """
         seed = self.get(key)  # This already handles old key format conversion
         
@@ -132,7 +134,7 @@ class Seeds:
             
             return self.api.upsert('seed', delete_payload)
         else:
-            error(f'Seed {key} not found.')
+            raise NotFoundError(f'Seed {key} not found.')
 
     def purge(self, filter_key):
         """Purge seeds matching a filter.

--- a/praetorian_cli/sdk/exceptions.py
+++ b/praetorian_cli/sdk/exceptions.py
@@ -1,0 +1,63 @@
+"""Public exception types raised by the Guard SDK.
+
+The SDK is a library: it reports failures by raising, and never by terminating
+the calling process. Before ENG-6570 eight call sites under `praetorian_cli/sdk`
+called `praetorian_cli.handlers.utils.error()` instead, whose `exit(1)` raises
+`SystemExit` -- a `BaseException`, and therefore invisible to every
+`except Exception` an embedder writes. The `except Exception` in
+`praetorian_cli/sdk/mcp_server.py` and the ones under `praetorian_cli/ui/` were
+all bypassed, so a bad keychain killed those long-lived hosts outright.
+
+Exiting is the CLI's job, and only the CLI's: `@cli_handler`
+(`praetorian_cli/handlers/cli_decorators.py`) catches whatever the SDK raises,
+surfaces its message, and exits non-zero. Nothing in the SDK catches these.
+
+WHERE TO CHANGE: this module is deliberately message-only -- no attributes, no
+error codes, no `__init__` overrides. A public attribute (`.key`, `.profile`,
+`.status_code`) is a permanent commitment that can be added later and removed
+never, so none is added speculatively. Classification of what is safe to
+*display* is ENG-6781, not here.
+
+The hierarchy is sized to what a caller would branch on, not to the number of
+call sites:
+
+    GuardError
+    +-- ConfigurationError
+    +-- AuthenticationError
+    +-- NotFoundError
+"""
+
+
+class GuardError(Exception):
+    """Base class for every error the Guard SDK raises.
+
+    `except GuardError` is the blanket arm for an embedder that wants to treat
+    any SDK failure alike, without also catching unrelated `Exception`s.
+    """
+
+
+class ConfigurationError(GuardError):
+    """The local configuration is unusable, so no request can be attempted.
+
+    A missing, corrupted, or incomplete keychain profile. Retrying is pointless:
+    the operator has to re-run `praetorian configure` (or set the environment
+    variable) before anything else can succeed.
+    """
+
+
+class AuthenticationError(GuardError):
+    """The backend rejected the credentials that were sent.
+
+    Distinct from `ConfigurationError` because the local configuration is fine
+    and the remote said no: the caller's move is to rotate the key or retry,
+    not to reconfigure.
+    """
+
+
+class NotFoundError(GuardError):
+    """The requested entity does not exist.
+
+    Ordinary control flow rather than a fault -- a caller walking a list of keys
+    writes `except NotFoundError: continue`, which the previous `exit(1)` made
+    impossible.
+    """

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -5,10 +5,9 @@ from pathlib import Path
 from time import time
 
 import boto3
-import click
 import requests
 
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import AuthenticationError, ConfigurationError
 from praetorian_cli.sdk.model.globals import DEFAULT_HTTP_TIMEOUT
 
 DEFAULT_API = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
@@ -29,6 +28,7 @@ class Keychain:
         self.data = data
         self.filepath = filepath
         self.config = None
+        self._loaded = False
         self.token_cache = None
         self.token_expiry = 0
 
@@ -42,7 +42,12 @@ class Keychain:
 
     def load(self):
         """ Loads backend and authentication data from the keychain file into this instance. """
-        if self.config:
+        # Gate on a load that finished, not on `self.config`: the parser is
+        # assigned below before any validation, and an empty ConfigParser is
+        # truthy (len 1 -- the DEFAULT section always counts, even with no
+        # sections), so testing it would cache a half-validated parser forever
+        # and never reread a keychain file the operator has since repaired.
+        if self._loaded:
             return self
 
         self.config = ConfigParser()
@@ -59,11 +64,12 @@ class Keychain:
                 self.config.read(self.filepath)
 
         if not self.config.sections():
-            error(
+            raise ConfigurationError(
                 f'Keychain file is corrupted. Run "praetorian configure" to configure your profile and credentials. Or, delete the corrupted keychain file at {self.filepath}')
 
         if self.profile not in self.config:
-            error(f'Could not find the "{self.profile}" profile in {self.filepath}. Run "praetorian configure" to fix.')
+            raise ConfigurationError(
+                f'Could not find the "{self.profile}" profile in {self.filepath}. Run "praetorian configure" to fix.')
 
         profile = self.config[self.profile]
         
@@ -75,11 +81,13 @@ class Keychain:
         self.load_env('client_id', 'PRAETORIAN_CLI_CLIENT_ID', required=False)
         
         if 'api' not in profile or 'client_id' not in profile:
-            error(f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
+            raise ConfigurationError(
+                f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
 
         if self.account is None:
             self.account = self.config.get(self.profile, 'account', fallback=None)
 
+        self._loaded = True
         return self
 
     def load_env(self, config_name, env_name, required=True):
@@ -87,7 +95,10 @@ class Keychain:
             # environment variable takes precedence
             self.config.set(self.profile, config_name, environ[env_name])
         elif required and not self.config.get(self.profile, config_name, fallback=None):
-            error(
+            # The message below instructs a repair, so this instance must be able
+            # to see one: invalidate the cached load instead of answering from it.
+            self._loaded = False
+            raise ConfigurationError(
                 f'{config_name} not in keychain file or the {env_name} environment variable. Run "praetorian configure" to fix. Or set the environment variable.')
 
     def token(self):
@@ -103,7 +114,7 @@ class Keychain:
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
                 if response.status_code != 200:
-                    error(f"API key authentication failed: {response.text}")
+                    raise AuthenticationError(f"API key authentication failed: {response.text}")
                 
                 token_data = response.json()
                 self.token_expiry = time() + 3600
@@ -196,5 +207,3 @@ class Keychain:
         Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(exist_ok=True, parents=True)
         with open(DEFAULT_KEYCHAIN_FILEPATH, 'w') as f:
             config.write(f)
-
-        click.echo(f'\nKeychain data written to {DEFAULT_KEYCHAIN_FILEPATH}')

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -1,8 +1,12 @@
+import os
+import tempfile
 from configparser import ConfigParser
+from ipaddress import ip_address
 from os import environ
-from os.path import join, split
+from os.path import join
 from pathlib import Path
 from time import time
+from urllib.parse import urlsplit
 
 import boto3
 import requests
@@ -17,7 +21,61 @@ DEFAULT_KEYCHAIN_FILEPATH = join(Path.home(), '.praetorian', 'keychain.ini')
 
 API_KEY_ID = 'api_key_id'
 API_KEY_SECRET = 'api_key_secret'
-    
+
+HTTP_LOOPBACK_OPT_IN_ENV = 'PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK'
+
+
+def _is_loopback_host(hostname):
+    """ True for localhost or a loopback IP address (127.0.0.0/8, ::1). """
+    if not hostname:
+        return False
+    if hostname.lower() == 'localhost':
+        return True
+    # DNS names other than localhost (e.g. localhost.example.com) resolve to
+    # arbitrary addresses, so only a literal loopback IP counts.
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _validated_backend_url(api):
+    """ Return `api` unchanged when it is safe to send credentials to; raise otherwise.
+        HTTPS only, except plaintext HTTP to a loopback endpoint (the local dev
+        emulator) under the explicit opt-in. """
+    try:
+        parsed = urlsplit(api or '')
+        # urlsplit defers port parsing; touching .port is what raises on a URL
+        # like https://host:not-a-port/x.
+        parsed.port
+    except ValueError:
+        raise ConfigurationError(
+            f'Invalid backend URL "{api}". Credentials are only sent over HTTPS; use an https:// URL.')
+
+    if parsed.scheme == 'https' and parsed.hostname:
+        return api
+
+    if parsed.scheme == 'http' and _is_loopback_host(parsed.hostname):
+        if environ.get(HTTP_LOOPBACK_OPT_IN_ENV) == '1':
+            return api
+        raise ConfigurationError(
+            f'Refusing to send credentials to the plaintext HTTP backend "{api}". Credentials are only '
+            f'sent over HTTPS. For local development against a loopback endpoint, set {HTTP_LOOPBACK_OPT_IN_ENV}=1.')
+
+    raise ConfigurationError(
+        f'Invalid backend URL "{api}". Credentials are only sent over HTTPS; use an https:// URL.')
+
+
+def _tighten_to_owner_only(path):
+    """ Repair a keychain file written group- or world-accessible by an older CLI. """
+    # Best-effort: the file is being read, not written, and configure() remains
+    # the authoritative enforcement point, so a keychain on a filesystem that
+    # refuses chmod must not brick every CLI command.
+    try:
+        if os.stat(path).st_mode & 0o077:
+            os.chmod(path, 0o600)
+    except OSError:
+        pass
 
 
 class Keychain:
@@ -61,6 +119,7 @@ class Keychain:
                 self.config.set(DEFAULT_PROFILE, 'api', DEFAULT_API)
                 self.config.set(DEFAULT_PROFILE, 'client_id', DEFAULT_CLIENT_ID)
             else:
+                _tighten_to_owner_only(self.filepath)
                 self.config.read(self.filepath)
 
         if not self.config.sections():
@@ -105,12 +164,18 @@ class Keychain:
         """ Authenticate using API key or AWS Cognito and get the token. Cache the token until expiry. """
         if not self.token_cache or time() >= (self.token_expiry - 10):
             if self.has_api_key():
+                # requests preserves custom headers across redirects (only the
+                # standard Authorization header is stripped), so following a
+                # redirect off the validated HTTPS URL could leak the key
+                # headers. With redirects disabled, a redirect response lands
+                # in the fail-closed status_code check below.
                 response = requests.get(
                     f"{self.base_url()}/token",
                     headers={
                         'X-GUARD-API-KEY-ID': self.api_key_id(),
                         'X-GUARD-API-KEY-SECRET': self.api_key_secret(),
                     },
+                    allow_redirects=False,
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
                 if response.status_code != 200:
@@ -124,8 +189,13 @@ class Keychain:
                 # LocalStack) for local dev; None (unset) uses real AWS.
                 # USER_PASSWORD_AUTH is an unsigned Cognito operation, so no AWS
                 # credentials are needed for either endpoint.
+                aws_endpoint_url = self.get_option('aws_endpoint_url')
+                if aws_endpoint_url is not None:
+                    # Same transport policy as base_url(): initiate_auth below
+                    # sends the password, which must not cross plaintext HTTP.
+                    aws_endpoint_url = _validated_backend_url(aws_endpoint_url)
                 cognito = boto3.client('cognito-idp', region_name='us-east-2',
-                                       endpoint_url=self.get_option('aws_endpoint_url'))
+                                       endpoint_url=aws_endpoint_url)
                 response = cognito.initiate_auth(
                     AuthFlow='USER_PASSWORD_AUTH',
                     AuthParameters=dict(USERNAME=self.username(), PASSWORD=self.password()),
@@ -136,7 +206,7 @@ class Keychain:
 
     def base_url(self):
         """ Get the base URL for the backend. It is the "api" field in the keychain file. """
-        return self.get_option('api')
+        return _validated_backend_url(self.get_option('api'))
 
     def username(self):
         """ Get the username field from the keychain profile """
@@ -178,6 +248,9 @@ class Keychain:
                   account=None, api_key_id=None, api_key_secret=None):
         """ Update or insert a new profile to the keychain file at the default location.
             If the keychain file does not exist, create it. """
+        # Reject a plaintext backend before the keychain file is created or modified.
+        _validated_backend_url(api)
+
         new_profile = {
             'name': 'chariot',
             'client_id': client_id,
@@ -204,6 +277,25 @@ class Keychain:
 
         config[profile] = new_profile
 
-        Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(exist_ok=True, parents=True)
-        with open(DEFAULT_KEYCHAIN_FILEPATH, 'w') as f:
-            config.write(f)
+        keychain_dir = Path(DEFAULT_KEYCHAIN_FILEPATH).parent
+        # mkdir's mode leaves a pre-existing directory alone; a new one is created
+        # owner-only to match the file it holds.
+        keychain_dir.mkdir(mode=0o700, exist_ok=True, parents=True)
+        # Write to a same-directory temp file (mkstemp creates it 0600 at the open
+        # syscall, regardless of umask) and atomically replace the keychain: a
+        # failure at any point leaves an existing keychain intact rather than
+        # truncated, and os.replace swaps out a symlink planted at the final path
+        # instead of following it.
+        fd, tmp_path = tempfile.mkstemp(dir=keychain_dir, prefix='.keychain.', suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                config.write(f)
+                f.flush()
+                os.fsync(fd)
+            os.replace(tmp_path, DEFAULT_KEYCHAIN_FILEPATH)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -8,6 +8,27 @@ from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import Tool, TextContent
 
+# Tool-name patterns classified as sensitive: their tools return or manage
+# secret material (credential-broker payloads, API-key secrets, the webhook
+# auth PIN, integration records that embed that PIN) or change account
+# membership. A sensitive tool never matches a wildcard allow pattern: it is
+# exposed only when an allow entry names it exactly. When adding a new entity
+# or method to the SDK that returns or manages secret material, add its family
+# to this tuple — nothing detects an unclassified secret-bearing tool
+# automatically.
+SENSITIVE_TOOL_PATTERNS = (
+    'accounts_*',
+    'credentials_*',
+    'integrations_*',
+    'keys_*',
+    'webhook_*',
+)
+
+
+def is_sensitive_tool(tool_name: str) -> bool:
+    return any(fnmatch.fnmatch(tool_name, pattern) for pattern in SENSITIVE_TOOL_PATTERNS)
+
+
 class MCPServer:
     def __init__(self, chariot_instance, allowable_tools: Optional[List[str]] = None):
         self.chariot = chariot_instance
@@ -18,9 +39,13 @@ class MCPServer:
         self._register_tools()
 
     def _is_tool_allowed(self, tool_name: str) -> bool:
-        """Check if tool_name matches any of the allowed patterns using wildcards"""
-        if fnmatch.fnmatch(tool_name, "*accounts*"):
-            return False
+        """Two-tier allow check: sensitive tools (SENSITIVE_TOOL_PATTERNS) are
+        exposed only by an exact-name allow entry — wildcards never match them,
+        and a None/empty allowlist exposes none of them; non-sensitive tools keep the
+        original semantics (no allowlist means allowed, otherwise fnmatch
+        against the allow patterns)."""
+        if is_sensitive_tool(tool_name):
+            return bool(self.allowable_tools) and tool_name in self.allowable_tools
 
         # Destructive purge operations (e.g. assets_purge, risks_purge,
         # seeds_purge) have no confirmation or dry-run gate when invoked via
@@ -32,11 +57,8 @@ class MCPServer:
 
         if not self.allowable_tools:
             return True
-        
-        for pattern in self.allowable_tools:
-            if fnmatch.fnmatch(tool_name, pattern):
-                return True
-        return False
+
+        return any(fnmatch.fnmatch(tool_name, pattern) for pattern in self.allowable_tools)
 
     def _discover_tools(self):
         excluded_methods = {'start_mcp_server', 'api'}

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -21,6 +21,13 @@ SENSITIVE_TOOL_PATTERNS = (
     'credentials_*',
     'integrations_*',
     'keys_*',
+    # The Red Team family manages Mailgun sending credentials, Evilginx phishing
+    # configuration (OAuth client IDs/secrets, session tokens), and live campaign
+    # authorization. Classifying the whole family removes the default exposure the
+    # read-only members used to get from a wildcard allow entry -- `red_team_dns_list`
+    # rode the common `*_list` pattern -- which is intended: no red_team tool is
+    # reachable now without an allow entry naming it exactly.
+    'red_team_*',
     'webhook_*',
 )
 

--- a/praetorian_cli/sdk/model/aegis.py
+++ b/praetorian_cli/sdk/model/aegis.py
@@ -154,3 +154,30 @@ class Agent:
             lines.append(f"  IP addresses: {', '.join(ips)}")
         
         return '\n'.join(lines)
+
+
+def validate_agent_for_ssh(agent: Agent) -> tuple[bool, str]:
+    """
+    Validate if an agent is ready for SSH connections
+    Returns (is_valid, error_message)
+    """
+    if not agent:
+        return False, "No agent specified"
+    
+    client_id = agent.client_id
+    hostname = agent.hostname or 'Unknown'
+    has_tunnel = agent.has_tunnel
+    
+    if not client_id:
+        return False, "Agent missing client_id"
+    
+    # Check if Cloudflare tunnel is available
+    if not has_tunnel:
+        return False, f"SSH not available for {hostname} - no active tunnel"
+    
+    # Check if tunnel has a public hostname
+    public_hostname = agent.health_check.cloudflared_status.hostname if has_tunnel else None
+    if not public_hostname:
+        return False, f"No public hostname found in tunnel configuration for {hostname}"
+    
+    return True, ""

--- a/praetorian_cli/sdk/test/test_account.py
+++ b/praetorian_cli/sdk/test/test_account.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import setup_chariot, email_address
+from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, email_address
 
 
 @pytest.mark.coherence
 class TestAccount:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         self.collaborator_email = email_address()
 
     def test_add_collaborator(self):

--- a/praetorian_cli/sdk/test/test_agent.py
+++ b/praetorian_cli/sdk/test/test_agent.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Risk
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestRisk:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_affiliation(self):

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestAsset:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_asset(self):

--- a/praetorian_cli/sdk/test/test_attribute.py
+++ b/praetorian_cli/sdk/test/test_attribute.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestAttribute:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.sdk.assets.add(self.asset_dns, self.asset_name)
 

--- a/praetorian_cli/sdk/test/test_capabilities.py
+++ b/praetorian_cli/sdk/test/test_capabilities.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestCapabilities:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
 
     def test_list_capabilities(self):
         capabilities = self.sdk.capabilities.list()

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -24,13 +24,17 @@ the process exited 0 on every failure. These tests pin the replacement contract:
 Message *redaction* is deliberately out of scope here: it needs the SDK exception
 hierarchy (ENG-6570) to classify what is safe to show, and is owned by ENG-6781.
 
-Offline only: every command raises before `upgrade_check` can reach the network,
-and each test arms `requests.get` to fail loudly if that ever stops being true.
+Offline only. Most tests here raise before `upgrade_check` can reach the network
+and arm `requests.get` to fail loudly if that ever stops being true; the final
+group deliberately lets the advisory run, with `requests.get` replaced and
+`XDG_CACHE_HOME` redirected at `tmp_path`, to pin that its failures cannot change
+a command's outcome.
 """
 
 import asyncio
 import subprocess
 import sys
+import threading
 from concurrent.futures import CancelledError as FutureCancelledError
 from unittest.mock import Mock
 
@@ -43,6 +47,10 @@ from click.testing import CliRunner
 # from the suite's silently -- and would turn a deliberate re-wording into a
 # spurious test failure here.
 from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+
+# Imported for the same reason: the deadline test asserts the join was handed the
+# module's own budget, so a re-tuned budget must not need a matching edit here.
+from praetorian_cli.handlers.cli_decorators import UPDATE_CHECK_DEADLINE_SECONDS
 
 # The exact shape `Chariot.process_failure` raises on a failed API call
 # (praetorian_cli/sdk/chariot.py). Both halves -- the status line and the response
@@ -109,6 +117,44 @@ def _debug_root(command):
     return root
 
 
+def _successful_command():
+    """A `@cli_handler` command that succeeds, so `upgrade_check` actually runs."""
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        return "done"
+
+    return command
+
+
+def _force_update_request(monkeypatch, tmp_path, side_effect):
+    """The inverse of `_disable_update_request`: let the advisory reach the network.
+
+    Two forces are needed and both are load-bearing. `_session_is_interactive()`
+    requires BOTH `sys.stdout.isatty()` and `sys.stderr.isatty()`, and `CliRunner`
+    replaces both with non-tty buffers, so the gate is closed inside any `invoke`
+    and the advisory returns before it does anything -- a test that did not force
+    it would assert against a check that never ran, and would keep passing if the
+    advisory stopped running altogether. Forcing the whole predicate rather than
+    one stream is what keeps that hole shut. `XDG_CACHE_HOME` is redirected at
+    `tmp_path` so nothing reads or writes the real user cache, and an empty cache
+    is what guarantees the network branch is the one taken.
+
+    The predicate's own behaviour is pinned in test_update_check.py, which drives
+    the real `_session_is_interactive` instead of replacing it.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.delenv("PRAETORIAN_CLI_DISABLE_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(decorators, "_session_is_interactive", lambda: True)
+    request = Mock(side_effect=side_effect)
+    monkeypatch.setattr(decorators.requests, "get", request)
+    return request
+
+
 def _disable_update_request(monkeypatch):
     import praetorian_cli.handlers.cli_decorators as decorators
 
@@ -117,9 +163,10 @@ def _disable_update_request(monkeypatch):
     return request
 
 
-# `upgrade_check`'s bare `except:` swallows anything raisable, so an in-process
-# guard cannot make a stray network call visible in a child process. `os._exit`
-# cannot be caught: if the advisory ever runs, the child's status is 97 and the
+# `_check_for_update`'s `except Exception: pass` arm swallows every ordinary
+# exception -- an in-process `AssertionError` included -- so an in-process guard
+# cannot make a stray network call visible in a child process. `os._exit` cannot
+# be caught: if the advisory ever runs, the child's status is 97 and the
 # return-code assertion fails instead of the request silently going out.
 _NETWORK_TRIPWIRE = """
 import os
@@ -595,4 +642,161 @@ def test_handled_user_facing_error_is_unchanged(monkeypatch):
     assert result.exit_code == 1
     assert "ERROR: profile 'staging' is not configured" in result.stderr
     assert "Error:" not in result.output
+    request.assert_not_called()
+
+
+# --- the update advisory on a SUCCESSFUL command --------------------------------
+#
+# The cases above all raise, so `upgrade_check` never reaches `_check_for_update`.
+# These pin the other half: when the command succeeds the advisory does run, and
+# its own failures must not be able to change the outcome the user already earned.
+#
+# That holds for a Ctrl-C too, which is the correction ENG-6643 makes: the
+# advisory is a trailing informational courtesy, so an interrupt arriving during
+# it cannot retroactively fail work the user has already been handed. Process
+# control that the *process itself* initiated -- `sys.exit()`, a cancelled task --
+# is the deliberate exception and still reaches the exit status.
+
+
+def test_ordinary_update_advisory_failure_remains_fail_open(monkeypatch, tmp_path):
+    """An ordinary advisory failure is swallowed; the command still succeeds."""
+    request = _force_update_request(monkeypatch, tmp_path, RuntimeError("advisory unavailable"))
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "advisory unavailable" not in result.output
+    request.assert_called_once()
+
+
+def _interrupt_the_deadline_wait(monkeypatch, exception):
+    """Raise `exception` in the main thread, where a real Ctrl-C would surface.
+
+    The advisory's fetch runs on a worker thread and the main thread waits it out
+    in `Thread.join(UPDATE_CHECK_DEADLINE_SECONDS)`, so that join -- not
+    `requests.get` -- is where an interrupt during the advisory actually lands:
+    CPython delivers SIGINT to the main thread only, and a worker parked in a
+    socket read never receives it. Injecting at `requests.get` instead would put
+    the exception inside the worker, whose `except BaseException: pass` discards
+    it, and the test would pass for the wrong reason.
+
+    The real `join` runs FIRST, before the exception is raised, so the worker has
+    already finished and its `requests.get` call is recorded by the time control
+    returns -- otherwise the call assertion would race the worker.
+
+    `threading` is referenced exactly once in the module under test (that join),
+    so shimming the module attribute reaches that one call and nothing else.
+    Returns the list of timeouts the shim observed, so a test can prove the seam
+    fired rather than passing because it was never reached.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    joined_with = []
+
+    class _InterruptedJoin(threading.Thread):
+        def join(self, timeout=None):
+            super().join(timeout)
+            joined_with.append(timeout)
+            raise exception
+
+    class _ThreadingShim:
+        Thread = _InterruptedJoin
+
+    monkeypatch.setattr(decorators, "threading", _ThreadingShim)
+    return joined_with
+
+
+def test_update_keyboard_interrupt_leaves_the_finished_command_successful(monkeypatch, tmp_path):
+    """A Ctrl-C during the trailing advisory must not fail a command that already succeeded.
+
+    This is the corrected contract (ENG-6643, finding R4-3). The command's own
+    work is complete and its output already delivered before `upgrade_check`
+    calls the advisory; letting a `KeyboardInterrupt` from that trailing courtesy
+    become `Aborted!` and exit 1 tells the user their command failed when it did
+    not -- and invites whoever wrote `guard list assets && next-step` to re-run
+    work that already succeeded. Measured on the real CLI before the fix: 968
+    asset rows and the pagination hint were printed, the process then sat alive
+    10.1s past its own output, and Ctrl-C there produced `Aborted!` and exit 1.
+
+    `upgrade_check`'s `except KeyboardInterrupt: pass` is what closes that, and it
+    is deliberately narrow: it wraps only the advisory call, so a Ctrl-C during
+    the command's own body still aborts (pinned by
+    `test_keyboard_interrupt_keeps_click_abort_semantics_and_skips_update`), and
+    it names `KeyboardInterrupt` alone, so `SystemExit` and cancellation still
+    propagate (pinned directly below).
+
+    The interrupt is injected at the deadline wait rather than at `requests.get`
+    -- see `_interrupt_the_deadline_wait` for why that is the only reachable
+    seam. `joined_with` is asserted first because every other assertion here
+    would also hold if the shim were never installed; without it a green run
+    would prove nothing.
+    """
+    request = _force_update_request(monkeypatch, tmp_path, TimeoutError("fetch still in flight"))
+    joined_with = _interrupt_the_deadline_wait(monkeypatch, KeyboardInterrupt())
+    command = _command_calling(lambda: click.echo("delivered-before-the-interrupt"))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert joined_with == [UPDATE_CHECK_DEADLINE_SECONDS]
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "Aborted!" not in result.output
+    assert "Error:" not in result.output
+    assert result.output == "delivered-before-the-interrupt\n"
+    request.assert_called_once()
+
+
+def _raise_from_the_throttle_write(monkeypatch, exception):
+    """Raise `exception` from the throttle-record write, on the main thread.
+
+    `_check_for_update` writes the throttle record *before* it goes anywhere near
+    the network, so this is the earliest main-thread step of the advisory that can
+    fail -- and it is reached through the real `_write_update_check_cache`, so that
+    function's own arms (`except CancelledError: raise`, then
+    `except Exception: return False`) are exercised rather than replaced.
+
+    It also makes the fetch provably unreached, which is what the
+    `request.assert_not_called()` in the caller records.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    def raise_during_the_write(*_args, **_kwargs):
+        raise exception
+
+    monkeypatch.setattr(decorators.json, "dump", raise_during_the_write)
+
+
+@pytest.mark.parametrize(
+    ("exception", "exit_code"),
+    [(SystemExit(73), 73), (FutureCancelledError("cancelled"), 1)],
+    ids=["system-exit", "future-cancelled"],
+)
+def test_update_process_control_exceptions_propagate(monkeypatch, tmp_path, exception, exit_code):
+    """Process control raised by the advisory still reaches the exit status.
+
+    `KeyboardInterrupt` is now absorbed (above); these two are not, and the
+    distinction is the point. A `SystemExit` means something in the process asked
+    to exit with that status, and a `CancelledError` means the surrounding task
+    was cancelled -- neither is "the user interrupted a courtesy message", so
+    neither may be reported as a clean success. `SystemExit` is a `BaseException`
+    and passes through `except Exception` untouched, keeping its own status;
+    `concurrent.futures.CancelledError` is `Exception`-derived on this runtime, so
+    the fail-open arm *would* swallow it and the dedicated
+    `except CancelledError: raise` arm is what makes it propagate instead.
+
+    Anchored at the throttle write, a main-thread step, rather than at
+    `requests.get`: the fetch now runs on a worker thread whose body is
+    `except BaseException: pass`, so nothing raised there reaches the main thread
+    at all. `request.assert_not_called()` is the negative half of that -- control
+    never got as far as the network.
+    """
+    assert issubclass(FutureCancelledError, Exception)
+    request = _force_update_request(monkeypatch, tmp_path, AssertionError("must not be reached"))
+    _raise_from_the_throttle_write(monkeypatch, exception)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == exit_code
+    assert result.exception is exception
     request.assert_not_called()

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -1,0 +1,598 @@
+"""Error-boundary contract for the shared `@cli_handler` decorator.
+
+`handle_error` used to end every unexpected failure with `error(str(e), quit=False)`,
+which printed and *returned* -- so the decorated command returned `None` normally and
+the process exited 0 on every failure. These tests pin the replacement contract:
+
+* an unexpected exception exits non-zero and keeps *its own* message, because the
+  SDK raises bare `Exception`/`ValueError` as its normal error-reporting mechanism
+  (`Chariot.process_failure` raises `Exception('[404] Request failed\\nError: ...')`,
+  `assets.py` raises `ValueError('Invalid asset type: ...')`) -- replacing that text
+  destroys the only actionable detail the user gets,
+* *every* non-debug error message ends with `cli_decorators.DEBUG_HINT` on its own
+  trailing line, exactly once, with the original message left intact ahead of it --
+  so a user who gets only a one-line message still learns how to obtain the
+  traceback. A message-less exception falls back to the exception's type name and
+  carries the hint just the same,
+* no raw traceback reaches the user unless `--debug` is passed,
+* `--debug` gives the original exception (and its traceback, on stderr) back --
+  unwrapped and hint-free, since the traceback the hint advertises is already there,
+* and the deliberate control-flow exceptions -- `ClickException`, `Abort`,
+  `Exit`, `CancelledError`, `SystemExit` -- keep their own status and text
+  instead of being flattened into a generic failure.
+
+Message *redaction* is deliberately out of scope here: it needs the SDK exception
+hierarchy (ENG-6570) to classify what is safe to show, and is owned by ENG-6781.
+
+Offline only: every command raises before `upgrade_check` can reach the network,
+and each test arms `requests.get` to fail loudly if that ever stops being true.
+"""
+
+import asyncio
+import subprocess
+import sys
+from concurrent.futures import CancelledError as FutureCancelledError
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+# Imported, never transcribed: these tests pin that the hint is *appended*, not
+# what its wording is. A copied literal would let the source's text drift away
+# from the suite's silently -- and would turn a deliberate re-wording into a
+# spurious test failure here.
+from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+
+# The exact shape `Chariot.process_failure` raises on a failed API call
+# (praetorian_cli/sdk/chariot.py). Both halves -- the status line and the response
+# body -- have to reach the user.
+SDK_API_FAILURE_MESSAGE = '[404] Request failed\nError: {"message":"asset not found"}'
+
+# The shape the SDK entity helpers raise on bad input, e.g.
+# `raise ValueError(f'Invalid asset type: {asset_type}')` in
+# praetorian_cli/sdk/entities/assets.py.
+SDK_VALIDATION_MESSAGE = 'Invalid asset type: bogus'
+
+TRACEBACK_HEADER = "Traceback (most recent call last)"
+
+
+class SentinelBaseException(BaseException):
+    pass
+
+
+def _command_raising(exception):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        raise exception
+
+    return command
+
+
+def _command_calling(action):
+    """A `@cli_handler` command whose body runs `action()` instead of raising.
+
+    Needed for the paths a bare `raise` cannot express: `ctx.exit(...)`, which
+    Click raises for you, and `utils.error(...)`, which exits from inside the
+    handled-error helper.
+    """
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        return action()
+
+    return command
+
+
+def _debug_root(command):
+    """A root group carrying the real `--debug` flag, with `command` mounted on it.
+
+    `handle_error` reads the flag off the root context's params
+    (`ctx.find_root().params["debug"]`), not off the `chariot` group -- so a
+    synthetic root that declares `--debug` is a faithful stand-in. The real
+    `guard_main` is deliberately NOT used: it builds a `Chariot(Keychain(...))`
+    and is not offline-safe.
+    """
+
+    @click.group()
+    @click.option("--debug", is_flag=True)
+    @click.pass_context
+    def root(ctx, debug):
+        ctx.obj = object()
+
+    root.add_command(command)
+    return root
+
+
+def _disable_update_request(monkeypatch):
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    request = Mock(side_effect=AssertionError("update check ran after failed command"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    return request
+
+
+# `upgrade_check`'s bare `except:` swallows anything raisable, so an in-process
+# guard cannot make a stray network call visible in a child process. `os._exit`
+# cannot be caught: if the advisory ever runs, the child's status is 97 and the
+# return-code assertion fails instead of the request silently going out.
+_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.handlers.cli_decorators as decorators
+decorators.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+
+def _run_child(script):
+    return subprocess.run(
+        [sys.executable, "-c", _NETWORK_TRIPWIRE + script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_ordinary_exception_keeps_its_message_in_normal_mode_and_chained(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("UNEXPECTED_SENTINEL")
+
+    result = CliRunner().invoke(
+        _command_raising(cause),
+        obj=object(),
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, click.ClickException)
+    assert result.exception.__cause__ is cause
+    assert str(result.exception) == f"UNEXPECTED_SENTINEL\n{DEBUG_HINT}"
+    request.assert_not_called()
+
+
+# --- SDK-shaped failures: the messages the CLI exists to relay ------------------
+#
+# The SDK reports every API and validation failure by raising bare `Exception` /
+# `ValueError` with the actionable text in the message. A handler that replaces
+# that text with a generic string satisfies ENG-6641's exit-code AC while
+# destroying the only thing the user can act on -- these tests catch that.
+
+
+def test_sdk_api_failure_message_reaches_the_user(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(Exception(SDK_API_FAILURE_MESSAGE)),
+        obj=object(),
+    )
+
+    assert result.exit_code == 1
+    # `result.output` is the interleaved stdout+stderr stream; `result.stdout` is
+    # empty on this path, so asserting against it would be vacuous.
+    assert "[404] Request failed" in result.output
+    assert "asset not found" in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+def test_sdk_validation_failure_message_reaches_the_user(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(ValueError(SDK_VALIDATION_MESSAGE)),
+        obj=object(),
+    )
+
+    assert result.exit_code == 1
+    assert SDK_VALIDATION_MESSAGE in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+def test_blank_message_falls_back_to_the_exception_type(monkeypatch):
+    """A message-less exception must not render as a bare `Error:` with nothing after it."""
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(Exception()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Error: Exception" in result.output
+    assert "--debug" in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+# --- the `--debug` hint: appended to EVERY non-debug message ---------------------
+#
+# The hint used to appear only when `str(exc)` was blank, which left the common
+# case -- a real SDK message -- with no way for the user to discover `--debug`.
+# It is now appended unconditionally, so the non-blank cases below are the newly
+# introduced behaviour and the blank ones pin the half that was preserved.
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_body"),
+    [
+        (Exception(SDK_API_FAILURE_MESSAGE), SDK_API_FAILURE_MESSAGE),
+        (ValueError(SDK_VALIDATION_MESSAGE), SDK_VALIDATION_MESSAGE),
+        (Exception(SDK_API_FAILURE_MESSAGE + '\n'), SDK_API_FAILURE_MESSAGE),
+        (Exception(), "Exception"),
+        (ValueError("   "), "ValueError"),
+    ],
+    ids=[
+        "multi-line-sdk-message",
+        "single-line-sdk-message",
+        "sdk-message-with-trailing-newline",
+        "no-message",
+        "whitespace-only-message",
+    ],
+)
+def test_debug_hint_is_appended_once_after_the_intact_message(
+    monkeypatch,
+    exception,
+    expected_body,
+):
+    """The hint is a trailing line appended to the message, exactly once.
+
+    Exact equality is what makes this a contract rather than a smoke test: it pins
+    that the body survives *verbatim and in full* ahead of the hint. A containment
+    check would pass on a message the boundary had truncated, reordered, or spliced
+    the hint into the middle of -- the multi-line SDK case is precisely where that
+    could happen unnoticed.
+
+    The `count` assertion is not redundant with it. Equality pins today's single
+    occurrence; `count` names *double-appending* as the specific regression being
+    guarded -- a second `@handle_error` in the decorator chain, or a hint added to
+    both branches of a re-split `_error_message`, would append it twice.
+
+    The two blank cases also pin the preserved fallback to the exception's type
+    name (`.strip()` is what makes whitespace-only count as blank). The
+    trailing-newline case is the other half of that same trim -- a real HTTP
+    response body can end in one -- and pins that the hint still lands on the
+    line *immediately* after the message, never after a blank one.
+    """
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(exception),
+        obj=object(),
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 1
+    assert str(result.exception) == f"{expected_body}\n{DEBUG_HINT}"
+    assert str(result.exception).count(DEBUG_HINT) == 1
+    request.assert_not_called()
+
+
+def test_debug_mode_adds_no_hint_and_leaves_the_exception_unwrapped(monkeypatch):
+    """`--debug` is unaffected: the original exception propagates, hint-free.
+
+    The hint exists to tell a user how to reach a traceback. Under `--debug` they
+    already have one, and `_error_message` is never reached -- so the hint must not
+    appear anywhere in the traceback path, and the exception must arrive unwrapped
+    rather than as a `ClickException` carrying an annotated message.
+
+    Identity is measured in-process; the absence of the hint from the real output
+    stream has to be measured in a child process, because `CliRunner` intercepts
+    the re-raise before Python prints anything.
+    """
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("DEBUG_NO_HINT_SENTINEL")
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    # Not re-wrapped, and no hint spliced into its message.
+    assert str(result.exception) == "DEBUG_NO_HINT_SENTINEL"
+    request.assert_not_called()
+
+    child = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("DEBUG_NO_HINT_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    output = child.stdout + child.stderr
+    assert child.returncode == 1
+    assert TRACEBACK_HEADER in child.stderr
+    assert "DEBUG_NO_HINT_SENTINEL" in child.stderr
+    assert DEBUG_HINT not in output
+
+
+def test_debug_mode_preserves_sdk_error_identity_and_traceback(monkeypatch):
+    """`--debug` on an SDK-shaped failure: same exception object, real traceback.
+
+    Identity is measured in-process (`CliRunner` intercepts the re-raise), while
+    the traceback has to be measured in a real child process -- `CliRunner`
+    catches the exception before Python can print one.
+    """
+    request = _disable_update_request(monkeypatch)
+    cause = Exception(SDK_API_FAILURE_MESSAGE)
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    request.assert_not_called()
+
+    child = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise Exception('[404] Request failed\\nError: {"message":"asset not found"}')
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    assert child.returncode == 1
+    assert TRACEBACK_HEADER in child.stderr
+    assert "[404] Request failed" in child.stderr
+    assert "asset not found" in child.stderr
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status", "expected_text"),
+    [
+        (click.ClickException("actionable failure"), 1, "actionable failure"),
+        (click.UsageError("actionable usage guidance"), 2, "actionable usage guidance"),
+    ],
+)
+def test_deliberate_click_exceptions_preserve_status_and_actionable_text(
+    monkeypatch,
+    exception,
+    expected_status,
+    expected_text,
+):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert result.exit_code == expected_status
+    assert expected_text in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+def test_explicit_debug_mode_preserves_unexpected_exception_identity(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("debug details")
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    assert result.exc_info is not None
+    request.assert_not_called()
+
+
+def test_real_process_normal_mode_shows_message_without_traceback():
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("UNEXPECTED_SENTINEL")
+
+command.main(obj=object())
+"""
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    # Whole rendered stream, exactly: Click's `Error: ` prefix, the message, then
+    # the hint on its own line. Nothing else -- no traceback, no update advisory.
+    assert output == f"Error: UNEXPECTED_SENTINEL\n{DEBUG_HINT}\n"
+    assert "Traceback" not in output
+
+
+def test_real_process_debug_mode_preserves_unexpected_traceback_and_message():
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("DEBUG_UNEXPECTED_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "DEBUG_UNEXPECTED_SENTINEL" in output
+    assert "Traceback" in output
+
+
+def test_debug_traceback_goes_to_stderr_not_stdout():
+    """A caller piping stdout must not receive a traceback in its data stream.
+
+    The old implementation printed it with `click.echo(traceback.format_exc())`
+    -- no `err=True` -- so `guard --debug ... > data.json` interleaved a
+    traceback into the file. Measured in a real child process rather than with
+    `CliRunner`: `CliRunner`'s `catch_exceptions=True` intercepts the re-raised
+    exception before any traceback is printed, so it cannot observe the stream
+    the traceback lands on at all.
+    """
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("STREAM_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" in result.stderr
+    assert "STREAM_SENTINEL" in result.stderr
+    assert result.stdout == ""
+
+
+def test_keyboard_interrupt_keeps_click_abort_semantics_and_skips_update(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(KeyboardInterrupt()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.output
+    assert "Error:" not in result.output
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize("exception", [asyncio.CancelledError(), SentinelBaseException("stop")])
+def test_cancellation_and_base_exception_are_not_translated_or_swallowed(monkeypatch, exception):
+    request = _disable_update_request(monkeypatch)
+
+    with pytest.raises(type(exception)) as raised:
+        CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert raised.value is exception
+    request.assert_not_called()
+
+
+def test_future_cancellation_is_not_translated_or_swallowed(monkeypatch):
+    """`concurrent.futures.CancelledError` derives from `Exception` on this runtime.
+
+    Unlike `asyncio.CancelledError` (a `BaseException` since 3.8) the futures
+    variant is caught by a bare `except Exception`, so the dedicated arm is what
+    keeps a cancelled background task from being reported as an unexpected bug.
+    """
+    request = _disable_update_request(monkeypatch)
+    exception = FutureCancelledError("cancelled")
+
+    assert issubclass(FutureCancelledError, Exception)
+    assert FutureCancelledError is not asyncio.CancelledError
+
+    result = CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert result.exit_code == 1
+    assert result.exception is exception
+    request.assert_not_called()
+
+
+def test_abort_keeps_its_own_message_and_exit_code(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(click.Abort()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.output
+    assert "Error:" not in result.output
+    request.assert_not_called()
+
+
+def test_ctx_exit_zero_stays_a_success(monkeypatch):
+    """`ctx.exit(0)` must remain a success.
+
+    `click.exceptions.Exit` is a `RuntimeError`, so without its own arm a
+    deliberate early success is caught by the generic handler and reported as a
+    failure -- turning `exit 0` into `exit 1`.
+    """
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: click.get_current_context().exit(0))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 0
+    assert result.output == ""
+    assert result.exception is None
+    request.assert_not_called()
+
+
+def test_ctx_exit_nonzero_preserves_its_status(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: click.get_current_context().exit(3))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 3
+    assert result.output == ""
+    request.assert_not_called()
+
+
+def test_sys_exit_passes_through_unchanged(monkeypatch):
+    """`SystemExit` is a `BaseException`; the chain must not start catching it."""
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_calling(lambda: sys.exit(7)), obj=object())
+
+    assert result.exit_code == 7
+    assert "Error:" not in result.output
+    request.assert_not_called()
+
+
+def test_handled_user_facing_error_is_unchanged(monkeypatch):
+    """The *handled* error path is untouched by this change.
+
+    `utils.error` prints `ERROR: <message>` to stderr and exits 1. It must keep
+    its own actionable text and must not be re-labelled with Click's `Error:`
+    prefix.
+    """
+    from praetorian_cli.handlers.utils import error
+
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: error("profile 'staging' is not configured"))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 1
+    assert "ERROR: profile 'staging' is not configured" in result.stderr
+    assert "Error:" not in result.output
+    request.assert_not_called()

--- a/praetorian_cli/sdk/test/test_configuration.py
+++ b/praetorian_cli/sdk/test/test_configuration.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestConfigurations:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         if not self.sdk.is_praetorian_user():
             pytest.skip("This test is only available to Praetorian engineers")

--- a/praetorian_cli/sdk/test/test_conversation.py
+++ b/praetorian_cli/sdk/test/test_conversation.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import time
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
@@ -10,7 +10,8 @@ class TestConversation:
     """Test conversation functionality with the Chariot agent"""
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.conversation_id = None
         self.message_keys = []

--- a/praetorian_cli/sdk/test/test_definition.py
+++ b/praetorian_cli/sdk/test/test_definition.py
@@ -2,14 +2,15 @@ import os
 
 import pytest
 
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, setup_chariot
 
 
 @pytest.mark.coherence
 class TestDefinition:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         self.definition_name = f'test-definition-{epoch_micro()}'
         self.local_filepath = f'./{self.definition_name}.md'
         self.content = random_ip()

--- a/praetorian_cli/sdk/test/test_file.py
+++ b/praetorian_cli/sdk/test/test_file.py
@@ -2,14 +2,15 @@ import os
 
 import pytest
 
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, setup_chariot
 
 
 @pytest.mark.coherence
 class TestFile:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         micro = epoch_micro()
         self.chariot_filepath = f'home/test-file-{micro}.txt'
         self.encrypted_chariot_filepath = f'_encrypted/test-file-{micro}.txt'

--- a/praetorian_cli/sdk/test/test_job.py
+++ b/praetorian_cli/sdk/test/test_job.py
@@ -2,14 +2,15 @@ import pytest
 import json
 
 from praetorian_cli.sdk.model.utils import asset_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestJob:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
         self.was_frozen = False

--- a/praetorian_cli/sdk/test/test_key.py
+++ b/praetorian_cli/sdk/test/test_key.py
@@ -1,14 +1,15 @@
 import pytest
 import datetime
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestKey:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_key(self):

--- a/praetorian_cli/sdk/test/test_keychain.py
+++ b/praetorian_cli/sdk/test/test_keychain.py
@@ -1,0 +1,321 @@
+"""Keychain storage-permission and backend-URL scheme tests (ENG-6636).
+
+Two properties, both purely local (no backend access):
+
+1. At rest: the keychain file holding passwords / API keys is created with
+   owner-only permissions, and a pre-existing file written looser by an older
+   CLI is tightened whenever the keychain is written or read.
+2. In transit: credentials are only ever sent to an HTTPS backend. A plaintext
+   ``http://`` backend is rejected before any request is made; the sole
+   exception is a loopback endpoint (the local Cognito/LocalStack dev flow)
+   under the explicit ``PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1`` opt-in.
+"""
+
+import os
+import stat
+import sys
+from configparser import ConfigParser
+
+import pytest
+
+import praetorian_cli.sdk.keychain as keychain_module
+from praetorian_cli.sdk.exceptions import ConfigurationError
+from praetorian_cli.sdk.keychain import Keychain
+
+# The documented opt-in interface. A literal on purpose: renaming the variable
+# in keychain.py must fail these tests, since the old name is what operators
+# have in their dev environments.
+OPT_IN_ENV = 'PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK'
+
+posix_modes = pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason='POSIX file modes; on Windows chmod is close to a no-op',
+)
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _profile(api='https://api.example.com/chariot', extra=''):
+    return f'[United States]\napi = {api}\nclient_id = test-client-id\n{extra}'
+
+
+@pytest.fixture(autouse=True)
+def _clean_cli_environment(monkeypatch):
+    """PRAETORIAN_CLI_* variables in the operator's real environment override
+    keychain fields inside load(); strip them so tests see only their own."""
+    for name in list(os.environ):
+        if name.startswith('PRAETORIAN_CLI_'):
+            monkeypatch.delenv(name)
+
+
+@pytest.fixture
+def keychain_path(tmp_path, monkeypatch):
+    path = tmp_path / '.praetorian' / 'keychain.ini'
+    monkeypatch.setattr(keychain_module, 'DEFAULT_KEYCHAIN_FILEPATH', str(path))
+    return path
+
+
+@pytest.fixture
+def permissive_umask():
+    previous = os.umask(0)
+    yield
+    os.umask(previous)
+
+
+# ---------------------------------------------------------------- at rest
+
+
+@posix_modes
+def test_configure_creates_keychain_owner_only_under_permissive_umask(
+        keychain_path, permissive_umask):
+    """A plain open(path, 'w') under umask 0 would land at 0666; the mode must
+    come from the code, not from whatever umask the operator happens to run."""
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    assert _mode(keychain_path) == 0o600
+
+
+@posix_modes
+def test_configure_tightens_pre_existing_world_readable_keychain(keychain_path):
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text(_profile())
+    keychain_path.chmod(0o644)
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    assert _mode(keychain_path) == 0o600
+
+
+@posix_modes
+def test_load_tightens_pre_existing_world_readable_keychain(keychain_path):
+    """Existing installs have 0644 keychains from older CLI versions and may
+    never re-run configure; any read of the keychain repairs the mode."""
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text(_profile())
+    keychain_path.chmod(0o644)
+    Keychain(filepath=str(keychain_path)).load()
+    assert _mode(keychain_path) == 0o600
+
+
+def test_configure_preserves_other_profiles(keychain_path):
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text('[Other]\napi = https://other.example.com\nclient_id = other\n')
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    config = ConfigParser()
+    config.read(keychain_path)
+    assert 'Other' in config
+    assert 'United States' in config
+    assert config.get('United States', 'api_key_secret') == 'ksecret'
+
+
+def test_failed_configure_write_preserves_existing_keychain(keychain_path, monkeypatch):
+    """The O_TRUNC regression: writing the final path directly would zero the
+    existing keychain before the new content lands, so a failure mid-write
+    destroys the operator's credentials. The atomic tmp-file + os.replace path
+    must leave the old keychain byte-identical when the swap fails, and must
+    not litter the directory with the temp file."""
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    original = keychain_path.read_bytes()
+
+    def broken_replace(src, dst):
+        raise OSError('simulated')
+
+    monkeypatch.setattr(keychain_module.os, 'replace', broken_replace)
+    with pytest.raises(OSError):
+        Keychain.configure('someone@example.com', 'hunter2', profile='Other')
+    assert keychain_path.read_bytes() == original
+    assert list(keychain_path.parent.glob('.keychain.*.tmp')) == []
+
+
+@posix_modes
+def test_configure_replaces_symlinked_keychain_instead_of_following_it(
+        keychain_path, permissive_umask):
+    """A symlink planted at the keychain path must not trick configure into
+    writing credentials wherever the link points; os.replace swaps the link
+    out for a regular owner-only file and leaves the target untouched."""
+    keychain_path.parent.mkdir(parents=True)
+    target = keychain_path.parent.parent / 'symlink-target.ini'
+    target_content = '[Other]\napi = https://other.example.com\nclient_id = other\n'
+    target.write_text(target_content)
+    keychain_path.symlink_to(target)
+
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+
+    assert not keychain_path.is_symlink()
+    assert keychain_path.is_file()
+    assert target.read_text() == target_content
+    assert _mode(keychain_path) == 0o600
+
+
+# ------------------------------------------------------------- in transit
+
+
+def test_base_url_returns_https_backend_verbatim():
+    api = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
+    assert Keychain(data=_profile(api)).base_url() == api
+
+
+def test_http_loopback_is_rejected_without_opt_in():
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile('http://localhost:3000/chariot')).base_url()
+
+
+@pytest.mark.parametrize('api', [
+    'http://localhost:3000/chariot',
+    'http://127.0.0.1:8010',
+    'http://[::1]:9000/chariot',
+])
+def test_opt_in_allows_loopback_http(monkeypatch, api):
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    assert Keychain(data=_profile(api)).base_url() == api
+
+
+@pytest.mark.parametrize('api', [
+    'http://api.example.com/chariot',
+    'http://192.168.1.10:8000',
+    'http://localhost.example.com',
+])
+def test_opt_in_never_allows_non_loopback_http(monkeypatch, api):
+    """The opt-in is for the local dev emulator only; a plaintext backend on a
+    real network stays rejected even with the variable set."""
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile(api)).base_url()
+
+
+@pytest.mark.parametrize('value', ['true', 'yes', '0', ''])
+def test_opt_in_value_must_be_exactly_1(monkeypatch, value):
+    monkeypatch.setenv(OPT_IN_ENV, value)
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile('http://localhost:3000/chariot')).base_url()
+
+
+@pytest.mark.parametrize('api', [
+    'ftp://api.example.com/chariot',
+    'api.example.com/chariot',
+    'https://',
+    'https://api.example.com:not-a-port/chariot',
+])
+def test_malformed_or_non_http_backends_are_rejected(api):
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile(api)).base_url()
+
+
+def test_token_never_sends_api_key_to_plaintext_backend(monkeypatch):
+    """The property the ticket actually cares about: a poisoned profile must
+    fail before the API-key id/secret headers leave the process."""
+    calls = []
+    monkeypatch.setattr(keychain_module.requests, 'get',
+                        lambda *args, **kwargs: calls.append((args, kwargs)))
+    keychain = Keychain(data=_profile(
+        'http://api.example.com/chariot',
+        extra='api_key_id = kid\napi_key_secret = ksecret\n'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_env_var_backend_override_is_validated(monkeypatch):
+    """PRAETORIAN_CLI_API takes precedence over the keychain file, so it is a
+    second injection point for a plaintext endpoint."""
+    monkeypatch.setenv('PRAETORIAN_CLI_API', 'http://api.example.com/chariot')
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile()).base_url()
+
+
+def test_configure_rejects_plaintext_backend_before_writing(keychain_path):
+    with pytest.raises(ConfigurationError):
+        Keychain.configure(None, None, api='http://api.example.com/chariot',
+                           api_key_id='kid', api_key_secret='ksecret')
+    assert not keychain_path.exists()
+
+
+def test_token_sends_api_key_with_redirects_disabled(monkeypatch):
+    """requests preserves the custom API-key headers across redirects, so the
+    token request must not follow one off the validated HTTPS URL."""
+    calls = []
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {'token': 'x'}
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _Response()
+
+    monkeypatch.setattr(keychain_module.requests, 'get', record)
+    keychain = Keychain(data=_profile(
+        extra='api_key_id = kid\napi_key_secret = ksecret\n'))
+    assert keychain.token() == 'x'
+    assert len(calls) == 1
+    assert calls[0][1]['allow_redirects'] is False
+
+
+# The Cognito username/password branch: aws_endpoint_url points initiate_auth
+# (which carries the password) at a local emulator, so it is a third injection
+# point for a plaintext endpoint alongside the keychain api field and
+# PRAETORIAN_CLI_API.
+
+
+def _cognito_profile(aws_endpoint_url=None):
+    extra = 'username = user\npassword = secret\n'
+    if aws_endpoint_url:
+        extra += f'aws_endpoint_url = {aws_endpoint_url}\n'
+    return _profile(extra=extra)
+
+
+def _record_boto3_client(monkeypatch):
+    """Replace boto3.client with a recorder returning a stub Cognito client."""
+    calls = []
+
+    class _StubCognito:
+        @staticmethod
+        def initiate_auth(**kwargs):
+            return {'AuthenticationResult': {'ExpiresIn': 3600, 'IdToken': 't'}}
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _StubCognito()
+
+    monkeypatch.setattr(keychain_module.boto3, 'client', record)
+    return calls
+
+
+def test_cognito_emulator_endpoint_rejected_without_opt_in(monkeypatch):
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://localhost:4566'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_opt_in_allows_loopback_cognito_emulator(monkeypatch):
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://localhost:4566'))
+    assert keychain.token() == 't'
+    assert len(calls) == 1
+    assert calls[0][1]['endpoint_url'] == 'http://localhost:4566'
+
+
+def test_opt_in_never_allows_non_loopback_cognito_emulator(monkeypatch):
+    """Same policy as base_url(): the opt-in admits loopback only, so a
+    plaintext emulator URL on a real network stays rejected even when set."""
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://198.51.100.7:4566'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_absent_aws_endpoint_url_still_means_real_aws(monkeypatch):
+    """Unset must keep meaning real AWS: the validation of a configured
+    emulator URL must not turn None into a rejected or mangled endpoint."""
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile())
+    assert keychain.token() == 't'
+    assert len(calls) == 1
+    assert calls[0][1]['endpoint_url'] is None

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -224,6 +224,15 @@ class TestMCPSensitiveTools:
         assert 'credentials_list' not in tools
         assert 'keys_get' not in tools
 
+    def test_exact_name_exposes_a_red_team_tool(self):
+        # Deny-by-default must not silently become deny-always: 'red_team_*' is a
+        # sensitive family, but an exact-name allow entry is still the documented
+        # way to opt one member in. red_team_dns_list is the regression case --
+        # it lost its '*_list' wildcard exposure, not its exact-name exposure.
+        tools = _discovered(['red_team_dns_list'])
+        assert 'red_team_dns_list' in tools
+        assert 'red_team_campaign_authorize' not in tools
+
     def test_exact_name_composes_with_default_profile(self):
         tools = _discovered(list(DEFAULT_MCP_TOOLS) + ['credentials_list'])
         assert 'credentials_list' in tools

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.mcp_server import MCPServer
-from praetorian_cli.sdk.test.utils import setup_chariot, make_test_values, clean_test_entities
+from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, make_test_values, clean_test_entities
 
 
 @pytest.mark.coherence
 class TestMCP:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_mcp_default(self):

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -1,7 +1,221 @@
 import pytest
 
+from praetorian_cli.handlers.agent import DEFAULT_MCP_TOOLS
 from praetorian_cli.sdk.mcp_server import MCPServer
 from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, make_test_values, clean_test_entities
+
+# Sensitive tool names that MCPServer discovery would build from the fake
+# chariot below. Every one of these returns or embeds secret material
+# (broker credentials, API keys, webhook auth PINs, account assumption).
+SENSITIVE_SAMPLES = (
+    'credentials_get',
+    'credentials_list',
+    'credentials_add',
+    'keys_get',
+    'keys_list',
+    'keys_add',
+    'integrations_get',
+    'integrations_list',
+    'webhook_get_url',
+    'webhook_upsert',
+    'accounts_list',
+    'accounts_assume_role',
+)
+
+
+class _FakeSearch:
+    def __init__(self):
+        self.api = object()
+
+    def by_query(self, query):
+        """Search entities by query."""
+        return []
+
+
+class _FakeAssets:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an asset."""
+        return {}
+
+    def list(self, offset=None):
+        """List assets."""
+        return []
+
+
+class _FakeRisks:
+    def __init__(self):
+        self.api = object()
+
+    def add(self, name):
+        """Add a risk."""
+        return {}
+
+    def list(self, offset=None):
+        """List risks."""
+        return []
+
+
+class _FakeCredentials:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, credential_id):
+        """Get a credential, including its raw secret."""
+        return {}
+
+    def list(self, offset=None):
+        """List credentials."""
+        return []
+
+    def add(self, resource_key):
+        """Add a credential."""
+        return {}
+
+
+class _FakeKeys:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an API key."""
+        return {}
+
+    def list(self, offset=None):
+        """List API keys."""
+        return []
+
+    def add(self, name):
+        """Add an API key."""
+        return {}
+
+
+class _FakeIntegrations:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an integration, whose record embeds the webhook auth PIN."""
+        return {}
+
+    def list(self, offset=None):
+        """List integrations."""
+        return []
+
+
+class _FakeWebhook:
+    def __init__(self):
+        self.api = object()
+
+    def get_url(self):
+        """Get the webhook URL, which embeds the auth PIN."""
+        return ''
+
+    def upsert(self):
+        """Create or rotate the webhook."""
+        return ''
+
+
+class _FakeAccounts:
+    def __init__(self):
+        self.api = object()
+
+    def list(self, offset=None):
+        """List accounts."""
+        return []
+
+    def assume_role(self, account_email):
+        """Assume the role of another account."""
+        return None
+
+
+class _FakeChariot:
+    """Offline stand-in for the Chariot SDK object MCP discovery walks."""
+
+    def __init__(self):
+        self.search = _FakeSearch()
+        self.assets = _FakeAssets()
+        self.risks = _FakeRisks()
+        self.credentials = _FakeCredentials()
+        self.keys = _FakeKeys()
+        self.integrations = _FakeIntegrations()
+        self.webhook = _FakeWebhook()
+        self.accounts = _FakeAccounts()
+
+
+def _discovered(allowed):
+    """Discovered tool names for a fake chariot under the given allowlist."""
+    return MCPServer(_FakeChariot(), allowed).discovered_tools
+
+
+class TestMCPSensitiveTools:
+    """ENG-6639: sensitive tools must be deny-by-default in the MCP server.
+
+    Contract under test:
+    - mcp_server.SENSITIVE_TOOL_PATTERNS names the sensitive families
+      ('accounts_*', 'credentials_*', 'integrations_*', 'keys_*',
+      'webhook_*').
+    - A tool matching a sensitive pattern is NEVER exposed by wildcard
+      allow patterns, and NEVER exposed when allowable_tools is
+      None/empty; it is exposed ONLY when an allow entry equals the tool
+      name exactly (explicit opt-in, e.g. 'credentials_get').
+    - Non-sensitive tools keep current semantics: no allowlist means
+      allowed; otherwise fnmatch against the allow patterns.
+    - The CLI default profile (handlers.agent.DEFAULT_MCP_TOOLS =
+      ['search_by_query', '*_list', '*_get']) must therefore expose only
+      non-sensitive read tools.
+    """
+
+    def test_default_profile_exposes_read_tools(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS))
+        assert 'search_by_query' in tools
+        assert 'assets_get' in tools
+        assert 'assets_list' in tools
+        assert 'risks_list' in tools
+
+    def test_default_profile_denies_all_sensitive_tools(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS))
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed under the default read-only MCP profile'
+            )
+
+    def test_no_allowlist_still_denies_sensitive_tools(self):
+        tools = _discovered(None)
+        assert 'assets_list' in tools
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed with no allowlist configured'
+            )
+
+    def test_wildcards_never_match_sensitive_tools(self):
+        tools = _discovered(
+            ['credentials_*', 'keys_*', 'integrations_*', 'webhook_*', 'accounts_*', '*']
+        )
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed via a wildcard allow pattern'
+            )
+
+    def test_exact_name_exposes_only_that_tool(self):
+        tools = _discovered(['credentials_get'])
+        assert 'credentials_get' in tools
+        assert 'credentials_list' not in tools
+        assert 'keys_get' not in tools
+
+    def test_exact_name_composes_with_default_profile(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS) + ['credentials_list'])
+        assert 'credentials_list' in tools
+        assert 'credentials_get' not in tools
+        assert 'assets_list' in tools
+
+    def test_wildcards_still_match_non_sensitive_tools(self):
+        tools = _discovered(['risks_*'])
+        assert 'risks_add' in tools
+        assert 'risks_list' in tools
+        assert 'assets_list' not in tools
 
 
 @pytest.mark.coherence

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -6,7 +6,8 @@ from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, m
 
 # Sensitive tool names that MCPServer discovery would build from the fake
 # chariot below. Every one of these returns or embeds secret material
-# (broker credentials, API keys, webhook auth PINs, account assumption).
+# (broker credentials, API keys, webhook auth PINs, account assumption,
+# red team phishing infrastructure and live campaign authorization).
 SENSITIVE_SAMPLES = (
     'credentials_get',
     'credentials_list',
@@ -20,6 +21,10 @@ SENSITIVE_SAMPLES = (
     'webhook_upsert',
     'accounts_list',
     'accounts_assume_role',
+    # red_team_dns_list is the regression case: it used to be exposed by
+    # default because it rode the '*_list' allow pattern.
+    'red_team_dns_list',
+    'red_team_campaign_authorize',
 )
 
 
@@ -131,6 +136,19 @@ class _FakeAccounts:
         return None
 
 
+class _FakeRedTeam:
+    def __init__(self):
+        self.api = object()
+
+    def dns_list(self, domain, offset=None):
+        """List DNS records for a red team domain."""
+        return []
+
+    def campaign_authorize(self, campaign_id):
+        """Authorize a campaign to send live phishing email."""
+        return {}
+
+
 class _FakeChariot:
     """Offline stand-in for the Chariot SDK object MCP discovery walks."""
 
@@ -143,6 +161,7 @@ class _FakeChariot:
         self.integrations = _FakeIntegrations()
         self.webhook = _FakeWebhook()
         self.accounts = _FakeAccounts()
+        self.red_team = _FakeRedTeam()
 
 
 def _discovered(allowed):
@@ -156,7 +175,7 @@ class TestMCPSensitiveTools:
     Contract under test:
     - mcp_server.SENSITIVE_TOOL_PATTERNS names the sensitive families
       ('accounts_*', 'credentials_*', 'integrations_*', 'keys_*',
-      'webhook_*').
+      'red_team_*', 'webhook_*').
     - A tool matching a sensitive pattern is NEVER exposed by wildcard
       allow patterns, and NEVER exposed when allowable_tools is
       None/empty; it is exposed ONLY when an allow entry equals the tool

--- a/praetorian_cli/sdk/test/test_preseed.py
+++ b/praetorian_cli/sdk/test/test_preseed.py
@@ -2,14 +2,15 @@ import pytest
 
 from praetorian_cli.sdk.model.globals import Preseed
 from praetorian_cli.sdk.model.utils import asset_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestPreseed:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_preseed(self):

--- a/praetorian_cli/sdk/test/test_red_team_cli.py
+++ b/praetorian_cli/sdk/test/test_red_team_cli.py
@@ -20,6 +20,7 @@ def _invoke(*args, stdin=None):
     mock_sdk.red_team.deployment_node_schema.return_value = {'catalog': {}}
     mock_sdk.red_team.deployment_terraform.return_value = {'job_id': 'j1'}
     mock_sdk.red_team.deployment_collaborators.return_value = ['a@co.com']
+    mock_sdk.red_team.deployment_tags.return_value = ['v1.0', 'v1.1']
     mock_sdk.red_team.campaign_create.return_value = OK
     mock_sdk.red_team.campaign_delete.return_value = OK
     mock_sdk.red_team.campaign_targets.return_value = [{'email': 'a@co.com'}]
@@ -30,9 +31,12 @@ def _invoke(*args, stdin=None):
     mock_sdk.red_team.dns_list.return_value = {'records': []}
     mock_sdk.red_team.dns_create.return_value = {'id': 'r1'}
     mock_sdk.red_team.dns_delete.return_value = OK
+    mock_sdk.red_team.dns_update.return_value = OK
     mock_sdk.red_team.mailgun_domain_status.return_value = {'state': 'active'}
     mock_sdk.red_team.mailgun_domain_provision.return_value = OK
+    mock_sdk.red_team.mailgun_domain_delete.return_value = OK
     mock_sdk.red_team.mailgun_user_create.return_value = {'username': 'u'}
+    mock_sdk.red_team.mailgun_user_delete.return_value = OK
     mock_sdk.red_team.evilginx_phishlets.return_value = {'phishlets': []}
     mock_sdk.red_team.evilginx_phishlet_params.return_value = {'params': []}
     mock_sdk.red_team.evilginx_lures.return_value = {'lures': []}
@@ -68,7 +72,7 @@ def test_deployment_launch_with_id():
 def test_deployment_delete():
     result, sdk = _invoke('red-team', 'deployment', 'delete', '--yes')
     assert result.exit_code == 0
-    sdk.red_team.deployment_delete.assert_called_once()
+    sdk.red_team.deployment_delete.assert_called_once_with(force=False)
 
 
 def test_deployment_details():
@@ -125,6 +129,12 @@ def test_deployment_collaborators():
     assert result.exit_code == 0
     sdk.red_team.deployment_collaborators.assert_called_once_with(
         ['a@co.com', 'b@co.com'])
+
+
+def test_deployment_tags():
+    result, sdk = _invoke('red-team', 'deployment', 'tags')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_tags.assert_called_once_with()
 
 
 # --- Campaigns ---
@@ -199,6 +209,16 @@ def test_dns_create():
     sdk.red_team.dns_create.assert_called_once_with('evil.com', 'A', 'www', '1.2.3.4', 1)
 
 
+def test_dns_update():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'dns-update',
+        '--domain', 'evil.com', '--record-id', 'r1', '--type', 'A',
+        '--name', 'www', '--content', '1.2.3.4')
+    assert result.exit_code == 0
+    sdk.red_team.dns_update.assert_called_once_with(
+        'evil.com', 'r1', 'A', 'www', '1.2.3.4', 1)
+
+
 def test_dns_delete():
     result, sdk = _invoke(
         'red-team', 'domain', 'dns-delete',
@@ -221,12 +241,27 @@ def test_mailgun_provision():
     sdk.red_team.mailgun_domain_provision.assert_called_once_with('evil.com')
 
 
+def test_mailgun_domain_delete():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'mailgun-domain-delete', '--domain', 'evil.com', '--yes')
+    assert result.exit_code == 0
+    sdk.red_team.mailgun_domain_delete.assert_called_once_with('evil.com')
+
+
 def test_mailgun_user():
     result, sdk = _invoke(
         'red-team', 'domain', 'mailgun-user',
         '--username', 'noreply', '--domain', 'evil.com')
     assert result.exit_code == 0
     sdk.red_team.mailgun_user_create.assert_called_once_with('noreply', 'evil.com')
+
+
+def test_mailgun_user_delete():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'mailgun-user-delete',
+        '--username', 'noreply', '--domain', 'evil.com', '--yes')
+    assert result.exit_code == 0
+    sdk.red_team.mailgun_user_delete.assert_called_once_with('noreply', 'evil.com')
 
 
 # --- Evilginx ---
@@ -332,3 +367,46 @@ def test_evilginx_configure_missing_phishlet():
 def test_payload_generate_missing_shellcode():
     result, _ = _invoke('red-team', 'payload-generate')
     assert result.exit_code != 0
+
+
+# --- stdin / JSON error handling ---
+
+def test_read_json_body_tty_guard():
+    import click
+
+    from praetorian_cli.handlers.red_team import _read_json_body
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = True
+    with patch('praetorian_cli.handlers.red_team.sys.stdin', fake_stdin):
+        try:
+            _read_json_body()
+            assert False, 'expected click.UsageError'
+        except click.UsageError as e:
+            assert 'Pipe JSON input via stdin' in str(e)
+
+
+def test_read_json_body_invalid_json():
+    result, sdk = _invoke('red-team', 'campaign', 'create', stdin='not valid json')
+    assert result.exit_code != 0
+    assert 'Invalid JSON input' in result.output
+    sdk.red_team.campaign_create.assert_not_called()
+
+
+def test_evilginx_configure_invalid_params_json():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'configure',
+        '--node', 'n1', '--domain', 'evil.com', '--phishlet', 'o365',
+        '--params', 'not valid json')
+    assert result.exit_code != 0
+    assert 'Invalid JSON input' in result.output
+    sdk.red_team.evilginx_configure.assert_not_called()
+
+
+def test_payload_generate_invalid_variables_json():
+    result, sdk = _invoke(
+        'red-team', 'payload-generate', '--shellcode', 'beacon.bin',
+        '--variables', 'not valid json')
+    assert result.exit_code != 0
+    assert 'Invalid JSON input' in result.output
+    sdk.red_team.payload_generate.assert_not_called()

--- a/praetorian_cli/sdk/test/test_red_team_cli.py
+++ b/praetorian_cli/sdk/test/test_red_team_cli.py
@@ -629,6 +629,15 @@ def test_plan_reads_body_from_file(tmp_path):
         'globals': {}, 'nodes': []}
 
 
+def test_plan_reads_a_non_ascii_body_from_file(tmp_path):
+    body_file = tmp_path / 'builder.json'
+    body_file.write_text('{"globals":{"name":"Jos\u00e9"},"nodes":[]}', encoding='utf-8')
+    result, sdk = _invoke('red-team', 'deployment', 'plan', '--file', str(body_file))
+    assert result.exit_code == 0
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {
+        'globals': {'name': 'Jos\u00e9'}, 'nodes': []}
+
+
 def test_apply_reads_body_from_file_and_prompts_on_stdin(tmp_path):
     body_file = tmp_path / 'builder.json'
     body_file.write_text('{"globals":{},"nodes":[]}')
@@ -721,10 +730,10 @@ def test_targets_missing_key_is_a_usage_error():
 
 # --- Piped stdin is decoded as UTF-8 before anything reads it ---
 
-# Real locale decoding is unreachable from a test: CliRunner's stdin is a BytesIO
-# wrapper it decodes itself, and the process locale is fixed at interpreter start.
-# What IS testable is the mechanism -- that the reconfigure happens at all, that a
-# tty is left alone, and that it lands before the first read of the stream.
+# These stub-driven tests cover the mechanism -- that the reconfigure happens at
+# all, that a tty is left alone, and that it lands before the first read of the
+# stream. The stub wraps a StringIO, so it cannot decode anything; the decoding
+# behavior itself is covered by the byte-level tests further down.
 class _StdinStub:
     """A stdin that records reconfigure() and read calls, in order."""
 
@@ -784,8 +793,28 @@ def test_piped_stdin_is_reconfigured_to_utf8():
     stub = _StdinStub()
     exit_code, _, sdk = _invoke_with_stdin(stub, 'red-team', 'deployment', 'details')
     assert exit_code == 0
-    assert stub.reconfigure_calls == [{'encoding': 'utf-8'}]
+    # errors= is as load-bearing as encoding=. Under the strict default an
+    # undecodable byte raises inside Click's eager prompt, out of reach of any
+    # handler here; surrogateescape carries the byte through to _load_json_body,
+    # which is the only place that can report it as a usage error.
+    assert stub.reconfigure_calls == [
+        {'encoding': 'utf-8', 'errors': 'surrogateescape'}], stub.reconfigure_calls
     sdk.red_team.deployment_details.assert_called_once()
+
+
+def test_load_json_body_reconfigures_stdin_with_the_same_error_handler():
+    # _load_json_body has its own reconfigure for a caller that reaches it
+    # without the red-team group. It must install the same error handler: under
+    # the strict default that caller gets a raw UnicodeDecodeError out of
+    # sys.stdin.read() instead of the usage error, and the two paths disagree.
+    stub = _StdinStub('{"name":"t"}')
+    exit_code, _, sdk = _invoke_with_stdin(stub, 'red-team', 'campaign', 'create')
+    assert exit_code == 0
+    # Two calls: the group callback's, then _load_json_body's own.
+    assert len(stub.reconfigure_calls) == 2, stub.reconfigure_calls
+    assert stub.reconfigure_calls[1] == {
+        'encoding': 'utf-8', 'errors': 'surrogateescape'}, stub.reconfigure_calls
+    sdk.red_team.campaign_create.assert_called_once_with({'name': 't'})
 
 
 def test_tty_stdin_is_not_reconfigured():
@@ -829,3 +858,66 @@ def test_an_already_read_stdin_is_tolerated():
     assert exit_code == 0
     assert stub.reconfigure_calls, stub.events
     sdk.red_team.campaign_create.assert_called_once_with({'name': 't'})
+
+
+# --- Real decoding of a piped stdin (byte level) ---
+
+# The stub above wraps a StringIO, so it has no decoder and cannot exercise this
+# at all. These tests install a real TextIOWrapper over real bytes: it reports
+# isatty() False, honors reconfigure(), and raises UnicodeDecodeError on an
+# undecodable byte exactly as a piped stdin does under a UTF-8 locale.
+UNDECODABLE_BODY = b'{"a": "\xff\xfe bad"}'
+NON_ASCII_BODY = b'{"a": "Jos\xc3\xa9"}'
+
+
+def _byte_stdin(payload):
+    """A real text stdin over `payload`, decoding strictly as UTF-8."""
+    # encoding= is pinned so the test does not depend on the process locale.
+    # errors= is deliberately left at the strict default: the tolerant handler
+    # is what the code under test is supposed to install.
+    return io.TextIOWrapper(io.BytesIO(payload), encoding='utf-8')
+
+
+def test_an_undecodable_body_is_a_usage_error_on_a_confirmed_command():
+    # The eager confirmation prompt reads first, and readline() decodes the
+    # whole buffered chunk while hunting the newline -- so an undecodable byte
+    # anywhere in the body raises inside Click's prompt, which handles only EOF
+    # and interrupts. That is outside the command callback, so cli_handler never
+    # sees it. The body's bytes must survive the prompt and be reported by
+    # _load_json_body instead.
+    exit_code, output, sdk = _invoke_with_stdin(
+        _byte_stdin(b'y\n' + UNDECODABLE_BODY),
+        'red-team', 'deployment', 'apply')
+    assert exit_code == 2, output
+    assert 'JSON body on stdin is not valid UTF-8' in output, output
+    sdk.red_team.deployment_terraform.assert_not_called()
+
+
+def test_a_non_ascii_body_survives_the_confirmation_prompt():
+    # Tolerating an undecodable byte must not corrupt a valid one: a body that
+    # decodes cleanly still reaches the SDK intact.
+    exit_code, output, sdk = _invoke_with_stdin(
+        _byte_stdin(b'y\n' + NON_ASCII_BODY),
+        'red-team', 'deployment', 'apply')
+    assert exit_code == 0, output
+    assert 'Apply the Terraform deployment?' in output, output
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {'a': 'Jos\u00e9'}
+
+
+def test_a_non_ascii_body_survives_a_command_without_a_prompt():
+    exit_code, output, sdk = _invoke_with_stdin(
+        _byte_stdin(NON_ASCII_BODY), 'red-team', 'deployment', 'plan')
+    assert exit_code == 0, output
+    assert sdk.red_team.deployment_terraform.call_args[0][0] == 'plan'
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {'a': 'Jos\u00e9'}
+
+
+def test_an_undecodable_body_is_a_usage_error_without_a_prompt():
+    # No prompt reads first here, so the bytes reach sys.stdin.read(). The usage
+    # error must still be reported -- a tolerant error handler on the stream
+    # must not become silent acceptance of an undecodable body.
+    exit_code, output, sdk = _invoke_with_stdin(
+        _byte_stdin(UNDECODABLE_BODY), 'red-team', 'deployment', 'plan')
+    assert exit_code == 2, output
+    assert 'JSON body on stdin is not valid UTF-8' in output, output
+    sdk.red_team.deployment_terraform.assert_not_called()

--- a/praetorian_cli/sdk/test/test_red_team_cli.py
+++ b/praetorian_cli/sdk/test/test_red_team_cli.py
@@ -1,0 +1,334 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.red_team  # noqa: F401
+from praetorian_cli.handlers.chariot import chariot
+
+OK = {'status': 'ok'}
+
+
+def _invoke(*args, stdin=None):
+    runner = CliRunner()
+    mock_sdk = MagicMock()
+    mock_sdk.is_praetorian_user.return_value = True
+    mock_sdk.red_team.deployment_launch.return_value = {'project_id': 'p1'}
+    mock_sdk.red_team.deployment_delete.return_value = {'message': 'deleted'}
+    mock_sdk.red_team.deployment_details.return_value = {'nodes': []}
+    mock_sdk.red_team.deployment_history.return_value = [{'action': 'launch'}]
+    mock_sdk.red_team.deployment_last_inputs.return_value = {'globals': {}}
+    mock_sdk.red_team.deployment_node_schema.return_value = {'catalog': {}}
+    mock_sdk.red_team.deployment_terraform.return_value = {'job_id': 'j1'}
+    mock_sdk.red_team.deployment_collaborators.return_value = ['a@co.com']
+    mock_sdk.red_team.campaign_create.return_value = OK
+    mock_sdk.red_team.campaign_delete.return_value = OK
+    mock_sdk.red_team.campaign_targets.return_value = [{'email': 'a@co.com'}]
+    mock_sdk.red_team.campaign_authorize.return_value = {'status': 'live'}
+    mock_sdk.red_team.campaign_funnel.return_value = {'sent': 10}
+    mock_sdk.red_team.campaign_activity.return_value = [{'event': 'click'}]
+    mock_sdk.red_team.domain_update.return_value = OK
+    mock_sdk.red_team.dns_list.return_value = {'records': []}
+    mock_sdk.red_team.dns_create.return_value = {'id': 'r1'}
+    mock_sdk.red_team.dns_delete.return_value = OK
+    mock_sdk.red_team.mailgun_domain_status.return_value = {'state': 'active'}
+    mock_sdk.red_team.mailgun_domain_provision.return_value = OK
+    mock_sdk.red_team.mailgun_user_create.return_value = {'username': 'u'}
+    mock_sdk.red_team.evilginx_phishlets.return_value = {'phishlets': []}
+    mock_sdk.red_team.evilginx_phishlet_params.return_value = {'params': []}
+    mock_sdk.red_team.evilginx_lures.return_value = {'lures': []}
+    mock_sdk.red_team.evilginx_create_lure.return_value = {'job_id': 'j2'}
+    mock_sdk.red_team.evilginx_configure.return_value = {'job_id': 'j3'}
+    mock_sdk.red_team.evilginx_status.return_value = {'status': 'ready'}
+    mock_sdk.red_team.payload_generate.return_value = {'job_id': 'j4'}
+    mock_sdk.red_team.phishkit_nodes.return_value = [{'name': 'node-1'}]
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=mock_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        result = runner.invoke(
+            chariot, list(args),
+            obj={'keychain': MagicMock(), 'proxy': ''},
+            input=stdin,
+        )
+    return result, mock_sdk
+
+
+# --- Deployment ---
+
+def test_deployment_launch():
+    result, sdk = _invoke('red-team', 'deployment', 'launch')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_launch.assert_called_once()
+
+
+def test_deployment_launch_with_id():
+    result, sdk = _invoke('red-team', 'deployment', 'launch', '--id', 'my-dep')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_launch.assert_called_once_with(desired_id='my-dep')
+
+
+def test_deployment_delete():
+    result, sdk = _invoke('red-team', 'deployment', 'delete', '--yes')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_delete.assert_called_once()
+
+
+def test_deployment_details():
+    result, sdk = _invoke('red-team', 'deployment', 'details')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_details.assert_called_once()
+
+
+def test_deployment_history():
+    result, sdk = _invoke('red-team', 'deployment', 'history')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_history.assert_called_once()
+
+
+def test_deployment_last_inputs():
+    result, sdk = _invoke('red-team', 'deployment', 'last-inputs')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_last_inputs.assert_called_once()
+
+
+def test_deployment_node_schema():
+    result, sdk = _invoke('red-team', 'deployment', 'node-schema')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_node_schema.assert_called_once_with(tag=None)
+
+
+def test_deployment_node_schema_with_tag():
+    result, sdk = _invoke('red-team', 'deployment', 'node-schema', '--tag', 'v1.0')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_node_schema.assert_called_once_with(tag='v1.0')
+
+
+def test_deployment_plan():
+    body = '{"globals":{},"nodes":[]}'
+    result, sdk = _invoke('red-team', 'deployment', 'plan', stdin=body)
+    assert result.exit_code == 0
+    sdk.red_team.deployment_terraform.assert_called_once()
+    args = sdk.red_team.deployment_terraform.call_args
+    assert args[0][0] == 'plan'
+
+
+def test_deployment_apply():
+    body = '{"globals":{},"nodes":[]}'
+    result, sdk = _invoke('red-team', 'deployment', 'apply', '--yes', stdin=body)
+    assert result.exit_code == 0
+    sdk.red_team.deployment_terraform.assert_called_once()
+    assert sdk.red_team.deployment_terraform.call_args[0][0] == 'apply'
+
+
+def test_deployment_collaborators():
+    result, sdk = _invoke(
+        'red-team', 'deployment', 'collaborators',
+        '--collaborators', 'a@co.com,b@co.com')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_collaborators.assert_called_once_with(
+        ['a@co.com', 'b@co.com'])
+
+
+# --- Campaigns ---
+
+def test_campaign_create():
+    body = '{"name":"test","channel":"email"}'
+    result, sdk = _invoke('red-team', 'campaign', 'create', stdin=body)
+    assert result.exit_code == 0
+    sdk.red_team.campaign_create.assert_called_once()
+
+
+def test_campaign_delete():
+    result, sdk = _invoke('red-team', 'campaign', 'delete', '--key', 'k1')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_delete.assert_called_once_with('k1')
+
+
+def test_campaign_targets():
+    body = '{"targets":[{"email":"a@co.com","name":"A"}]}'
+    result, sdk = _invoke(
+        'red-team', 'campaign', 'targets', '--id', 'c1', stdin=body)
+    assert result.exit_code == 0
+    sdk.red_team.campaign_targets.assert_called_once()
+
+
+def test_campaign_authorize():
+    result, sdk = _invoke('red-team', 'campaign', 'authorize', '--id', 'c1')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_authorize.assert_called_once_with('c1')
+
+
+def test_campaign_funnel():
+    result, sdk = _invoke('red-team', 'campaign', 'funnel', '--id', 'c1')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_funnel.assert_called_once_with('c1')
+
+
+def test_campaign_activity():
+    result, sdk = _invoke('red-team', 'campaign', 'activity', '--id', 'c1')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_activity.assert_called_once_with('c1', limit=None)
+
+
+def test_campaign_activity_with_limit():
+    result, sdk = _invoke(
+        'red-team', 'campaign', 'activity', '--id', 'c1', '--limit', '25')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_activity.assert_called_once_with('c1', limit=25)
+
+
+# --- Domain parking ---
+
+def test_domain_update():
+    body = '{"domain":"evil.com","status":"in-use"}'
+    result, sdk = _invoke('red-team', 'domain', 'update', stdin=body)
+    assert result.exit_code == 0
+    sdk.red_team.domain_update.assert_called_once()
+
+
+def test_dns_list():
+    result, sdk = _invoke('red-team', 'domain', 'dns-list', '--domain', 'evil.com')
+    assert result.exit_code == 0
+    sdk.red_team.dns_list.assert_called_once_with('evil.com')
+
+
+def test_dns_create():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'dns-create',
+        '--domain', 'evil.com', '--type', 'A',
+        '--name', 'www', '--content', '1.2.3.4')
+    assert result.exit_code == 0
+    sdk.red_team.dns_create.assert_called_once_with('evil.com', 'A', 'www', '1.2.3.4', 1)
+
+
+def test_dns_delete():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'dns-delete',
+        '--domain', 'evil.com', '--record-id', 'r1')
+    assert result.exit_code == 0
+    sdk.red_team.dns_delete.assert_called_once_with('evil.com', 'r1')
+
+
+def test_mailgun_status():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'mailgun-status', '--domain', 'evil.com')
+    assert result.exit_code == 0
+    sdk.red_team.mailgun_domain_status.assert_called_once_with('evil.com')
+
+
+def test_mailgun_provision():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'mailgun-provision', '--domain', 'evil.com')
+    assert result.exit_code == 0
+    sdk.red_team.mailgun_domain_provision.assert_called_once_with('evil.com')
+
+
+def test_mailgun_user():
+    result, sdk = _invoke(
+        'red-team', 'domain', 'mailgun-user',
+        '--username', 'noreply', '--domain', 'evil.com')
+    assert result.exit_code == 0
+    sdk.red_team.mailgun_user_create.assert_called_once_with('noreply', 'evil.com')
+
+
+# --- Evilginx ---
+
+def test_evilginx_phishlets():
+    result, sdk = _invoke('red-team', 'evilginx', 'phishlets', '--node', 'n1')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_phishlets.assert_called_once_with('n1')
+
+
+def test_evilginx_phishlet_params():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'phishlet-params', '--node', 'n1', '--name', 'o365')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_phishlet_params.assert_called_once_with('n1', 'o365')
+
+
+def test_evilginx_lures():
+    result, sdk = _invoke('red-team', 'evilginx', 'lures', '--node', 'n1')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_lures.assert_called_once_with('n1')
+
+
+def test_evilginx_create_lure():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'create-lure', '--node', 'n1', '--path', '/login')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_create_lure.assert_called_once_with('n1', '/login')
+
+
+def test_evilginx_configure():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'configure',
+        '--node', 'n1', '--domain', 'evil.com', '--phishlet', 'o365')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_configure.assert_called_once_with(
+        'n1', 'evil.com', 'o365', phishlet_params=None, unauth_url=None)
+
+
+def test_evilginx_configure_with_params():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'configure',
+        '--node', 'n1', '--domain', 'evil.com', '--phishlet', 'o365',
+        '--params', '{"client_id":"abc"}')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_configure.assert_called_once_with(
+        'n1', 'evil.com', 'o365',
+        phishlet_params={'client_id': 'abc'}, unauth_url=None)
+
+
+def test_evilginx_status():
+    result, sdk = _invoke('red-team', 'evilginx', 'status', '--node', 'n1')
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_status.assert_called_once_with('n1')
+
+
+# --- Payload & phishkit ---
+
+def test_payload_generate():
+    result, sdk = _invoke(
+        'red-team', 'payload-generate', '--shellcode', 'beacon.bin')
+    assert result.exit_code == 0
+    sdk.red_team.payload_generate.assert_called_once_with(
+        'beacon.bin', variables=None)
+
+
+def test_payload_generate_with_variables():
+    result, sdk = _invoke(
+        'red-team', 'payload-generate', '--shellcode', 'beacon.bin',
+        '--variables', '{"dll_filename":"update.dll"}')
+    assert result.exit_code == 0
+    sdk.red_team.payload_generate.assert_called_once_with(
+        'beacon.bin', variables={'dll_filename': 'update.dll'})
+
+
+def test_phishkit_nodes():
+    result, sdk = _invoke('red-team', 'phishkit-nodes')
+    assert result.exit_code == 0
+    sdk.red_team.phishkit_nodes.assert_called_once_with(status=None)
+
+
+def test_phishkit_nodes_with_status():
+    result, sdk = _invoke('red-team', 'phishkit-nodes', '--status', 'all')
+    assert result.exit_code == 0
+    sdk.red_team.phishkit_nodes.assert_called_once_with(status='all')
+
+
+# --- Missing required args ---
+
+def test_dns_create_missing_type():
+    result, _ = _invoke(
+        'red-team', 'domain', 'dns-create',
+        '--domain', 'evil.com', '--name', 'www', '--content', '1.2.3.4')
+    assert result.exit_code != 0
+
+
+def test_evilginx_configure_missing_phishlet():
+    result, _ = _invoke(
+        'red-team', 'evilginx', 'configure', '--node', 'n1', '--domain', 'evil.com')
+    assert result.exit_code != 0
+
+
+def test_payload_generate_missing_shellcode():
+    result, _ = _invoke('red-team', 'payload-generate')
+    assert result.exit_code != 0

--- a/praetorian_cli/sdk/test/test_red_team_cli.py
+++ b/praetorian_cli/sdk/test/test_red_team_cli.py
@@ -147,7 +147,7 @@ def test_campaign_create():
 
 
 def test_campaign_delete():
-    result, sdk = _invoke('red-team', 'campaign', 'delete', '--key', 'k1')
+    result, sdk = _invoke('red-team', 'campaign', 'delete', '--key', 'k1', '--yes')
     assert result.exit_code == 0
     sdk.red_team.campaign_delete.assert_called_once_with('k1')
 
@@ -161,7 +161,7 @@ def test_campaign_targets():
 
 
 def test_campaign_authorize():
-    result, sdk = _invoke('red-team', 'campaign', 'authorize', '--id', 'c1')
+    result, sdk = _invoke('red-team', 'campaign', 'authorize', '--id', 'c1', '--yes')
     assert result.exit_code == 0
     sdk.red_team.campaign_authorize.assert_called_once_with('c1')
 
@@ -222,7 +222,7 @@ def test_dns_update():
 def test_dns_delete():
     result, sdk = _invoke(
         'red-team', 'domain', 'dns-delete',
-        '--domain', 'evil.com', '--record-id', 'r1')
+        '--domain', 'evil.com', '--record-id', 'r1', '--yes')
     assert result.exit_code == 0
     sdk.red_team.dns_delete.assert_called_once_with('evil.com', 'r1')
 
@@ -371,16 +371,16 @@ def test_payload_generate_missing_shellcode():
 
 # --- stdin / JSON error handling ---
 
-def test_read_json_body_tty_guard():
+def test_load_json_body_tty_guard():
     import click
 
-    from praetorian_cli.handlers.red_team import _read_json_body
+    from praetorian_cli.handlers.red_team import _load_json_body
 
     fake_stdin = MagicMock()
     fake_stdin.isatty.return_value = True
     with patch('praetorian_cli.handlers.red_team.sys.stdin', fake_stdin):
         try:
-            _read_json_body()
+            _load_json_body()
             assert False, 'expected click.UsageError'
         except click.UsageError as e:
             assert 'Pipe JSON input via stdin' in str(e)
@@ -410,3 +410,264 @@ def test_payload_generate_invalid_variables_json():
     assert result.exit_code != 0
     assert 'Invalid JSON input' in result.output
     sdk.red_team.payload_generate.assert_not_called()
+
+
+# --- Path segment validation (entity layer) ---
+
+def test_segment_rejects_dot_segments():
+    import pytest
+
+    from praetorian_cli.sdk.entities.red_team import _segment
+
+    for bad in ('..', '.', ''):
+        with pytest.raises(ValueError, match='invalid URL path segment'):
+            _segment(bad)
+
+
+def test_segment_encodes_normal_values():
+    from praetorian_cli.sdk.entities.red_team import _segment
+
+    assert _segment('evil.com') == 'evil.com'
+    assert _segment('a/b') == 'a%2Fb'
+    assert _segment(7) == '7'
+
+
+def _entity(is_praetorian=True):
+    from praetorian_cli.sdk.entities.red_team import RedTeam
+
+    api = MagicMock()
+    api.is_praetorian_user.return_value = is_praetorian
+    return RedTeam(api), api
+
+
+def test_dns_delete_rejects_dot_segments_before_transmitting():
+    import pytest
+
+    rt, api = _entity()
+    with pytest.raises(ValueError, match='invalid URL path segment'):
+        rt.dns_delete('..', '..')
+    api.delete.assert_not_called()
+
+
+def test_campaign_activity_rejects_dot_segment():
+    import pytest
+
+    rt, api = _entity()
+    with pytest.raises(ValueError, match='invalid URL path segment'):
+        rt.campaign_activity('..')
+    api.get.assert_not_called()
+
+
+# --- SDK-layer Praetorian gating ---
+
+def _required_arity(cls, name):
+    import inspect
+
+    sig = inspect.signature(getattr(cls, name))
+    return len([p for p in sig.parameters.values()
+                if p.name != 'self' and p.default is inspect.Parameter.empty])
+
+
+def test_entity_methods_are_gated_for_non_praetorian_users():
+    import pytest
+
+    from praetorian_cli.sdk.entities.red_team import RedTeam
+
+    rt, api = _entity(is_praetorian=False)
+    public = [n for n in dir(RedTeam)
+              if not n.startswith('_') and callable(getattr(RedTeam, n))]
+    assert len(public) == 33
+    for name in public:
+        with pytest.raises(RuntimeError, match='limited to Praetorian engineers'):
+            getattr(rt, name)(*(['x'] * _required_arity(RedTeam, name)))
+    api.get.assert_not_called()
+    api.post.assert_not_called()
+    api.put.assert_not_called()
+    api.delete.assert_not_called()
+
+
+def test_red_team_is_a_sensitive_mcp_family():
+    from praetorian_cli.sdk.mcp_server import (SENSITIVE_TOOL_PATTERNS,
+                                               is_sensitive_tool)
+
+    assert 'red_team_*' in SENSITIVE_TOOL_PATTERNS
+    # Including the read-only members: they no longer ride a wildcard allow entry.
+    assert is_sensitive_tool('red_team_dns_list')
+    assert is_sensitive_tool('red_team_campaign_authorize')
+
+
+# --- Terraform action constraint ---
+
+def test_deployment_terraform_rejects_backend_only_actions():
+    import pytest
+
+    rt, api = _entity()
+    for action in ('generate', 'outputs', 'tag'):
+        with pytest.raises(ValueError, match='invalid terraform action'):
+            rt.deployment_terraform(action, {})
+    api.post.assert_not_called()
+
+
+def test_deployment_terraform_allows_plan_and_apply():
+    rt, api = _entity()
+    rt.deployment_terraform('plan', {'nodes': []})
+    rt.deployment_terraform('apply', {'nodes': []})
+    assert [c[0][0] for c in api.post.call_args_list] == [
+        'red-team/deployment/terraform/plan',
+        'red-team/deployment/terraform/apply',
+    ]
+
+
+# --- MCP schema source (docstrings) ---
+
+def test_every_entity_method_has_a_docstring():
+    from praetorian_cli.sdk.entities.red_team import RedTeam
+
+    for name in dir(RedTeam):
+        if name.startswith('_'):
+            continue
+        method = getattr(RedTeam, name)
+        if callable(method):
+            assert (method.__doc__ or '').strip(), f'{name} has no docstring'
+
+
+def test_builder_state_is_advertised_as_a_dict():
+    from praetorian_cli.sdk.entities.red_team import RedTeam
+
+    assert ':type builder_state: dict' in RedTeam.deployment_terraform.__doc__
+
+
+# --- Confirmation on destructive commands ---
+
+def test_apply_prompts_and_aborts_without_yes():
+    result, sdk = _invoke('red-team', 'deployment', 'apply',
+                          '--file', 'unused.json', stdin='n\n')
+    assert result.exit_code != 0
+    assert 'Apply the Terraform deployment?' in result.output
+    sdk.red_team.deployment_terraform.assert_not_called()
+
+
+def test_campaign_delete_aborts_without_yes():
+    result, sdk = _invoke('red-team', 'campaign', 'delete', '--key', 'k1',
+                          stdin='n\n')
+    assert result.exit_code != 0
+    assert 'Delete this campaign?' in result.output
+    sdk.red_team.campaign_delete.assert_not_called()
+
+
+def test_authorize_aborts_without_yes():
+    result, sdk = _invoke('red-team', 'campaign', 'authorize', '--id', 'c1',
+                          stdin='n\n')
+    assert result.exit_code != 0
+    assert 'sends live phishing email to real recipients' in result.output
+    sdk.red_team.campaign_authorize.assert_not_called()
+
+
+def test_dns_delete_aborts_without_yes():
+    result, sdk = _invoke('red-team', 'domain', 'dns-delete',
+                          '--domain', 'evil.com', '--record-id', 'r1',
+                          stdin='n\n')
+    assert result.exit_code != 0
+    assert 'Delete this DNS record?' in result.output
+    sdk.red_team.dns_delete.assert_not_called()
+
+
+# --- JSON body from a file ---
+
+def test_plan_reads_body_from_file(tmp_path):
+    body_file = tmp_path / 'builder.json'
+    body_file.write_text('{"globals":{},"nodes":[]}')
+    result, sdk = _invoke('red-team', 'deployment', 'plan', '--file', str(body_file))
+    assert result.exit_code == 0
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {
+        'globals': {}, 'nodes': []}
+
+
+def test_apply_reads_body_from_file_and_prompts_on_stdin(tmp_path):
+    body_file = tmp_path / 'builder.json'
+    body_file.write_text('{"globals":{},"nodes":[]}')
+    result, sdk = _invoke('red-team', 'deployment', 'apply',
+                          '--file', str(body_file), stdin='y\n')
+    assert result.exit_code == 0
+    assert 'Apply the Terraform deployment?' in result.output
+    assert sdk.red_team.deployment_terraform.call_args[0][0] == 'apply'
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {
+        'globals': {}, 'nodes': []}
+
+
+def test_load_json_body_missing_file():
+    result, sdk = _invoke('red-team', 'campaign', 'create',
+                          '--file', '/nonexistent/builder.json')
+    assert result.exit_code != 0
+    assert 'Cannot read JSON body from' in result.output
+    sdk.red_team.campaign_create.assert_not_called()
+
+
+def test_file_dash_reads_stdin():
+    result, sdk = _invoke('red-team', 'campaign', 'create', '--file', '-',
+                          stdin='{"name":"test"}')
+    assert result.exit_code == 0
+    sdk.red_team.campaign_create.assert_called_once_with({'name': 'test'})
+
+
+# --- Secret material off argv ---
+
+def test_configure_reads_params_from_file(tmp_path):
+    params_file = tmp_path / 'params.json'
+    params_file.write_text('{"client_id":"abc"}')
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'configure', '--node', 'n1',
+        '--domain', 'evil.com', '--phishlet', 'o365',
+        '--params-file', str(params_file))
+    assert result.exit_code == 0
+    sdk.red_team.evilginx_configure.assert_called_once_with(
+        'n1', 'evil.com', 'o365',
+        phishlet_params={'client_id': 'abc'}, unauth_url=None)
+
+
+def test_configure_params_and_params_file_are_mutually_exclusive():
+    result, sdk = _invoke(
+        'red-team', 'evilginx', 'configure', '--node', 'n1',
+        '--domain', 'evil.com', '--phishlet', 'o365',
+        '--params', '{"a":1}', '--params-file', 'params.json')
+    assert result.exit_code != 0
+    assert '--params and --params-file are mutually exclusive' in result.output
+    sdk.red_team.evilginx_configure.assert_not_called()
+
+
+def test_payload_generate_reads_variables_from_file(tmp_path):
+    vars_file = tmp_path / 'vars.json'
+    vars_file.write_text('{"dll_filename":"update.dll"}')
+    result, sdk = _invoke(
+        'red-team', 'payload-generate', '--shellcode', 'beacon.bin',
+        '--variables-file', str(vars_file))
+    assert result.exit_code == 0
+    sdk.red_team.payload_generate.assert_called_once_with(
+        'beacon.bin', variables={'dll_filename': 'update.dll'})
+
+
+def test_payload_generate_variables_and_file_are_mutually_exclusive():
+    result, sdk = _invoke(
+        'red-team', 'payload-generate', '--shellcode', 'beacon.bin',
+        '--variables', '{"a":1}', '--variables-file', 'vars.json')
+    assert result.exit_code != 0
+    assert '--variables and --variables-file are mutually exclusive' in result.output
+    sdk.red_team.payload_generate.assert_not_called()
+
+
+# --- Input validation exit codes ---
+
+def test_targets_bad_shape_is_a_usage_error():
+    result, sdk = _invoke('red-team', 'campaign', 'targets', '--id', 'c1',
+                          stdin='"just a string"')
+    assert result.exit_code == 2
+    assert "Expected JSON array or object with 'targets' key" in result.output
+    sdk.red_team.campaign_targets.assert_not_called()
+
+
+def test_targets_missing_key_is_a_usage_error():
+    result, sdk = _invoke('red-team', 'campaign', 'targets', '--id', 'c1',
+                          stdin='{"nope":[]}')
+    assert result.exit_code == 2
+    assert "Expected JSON with 'targets' key" in result.output
+    sdk.red_team.campaign_targets.assert_not_called()

--- a/praetorian_cli/sdk/test/test_red_team_cli.py
+++ b/praetorian_cli/sdk/test/test_red_team_cli.py
@@ -1,5 +1,9 @@
+import contextlib
+import io
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 import praetorian_cli.handlers.red_team  # noqa: F401
@@ -8,8 +12,7 @@ from praetorian_cli.handlers.chariot import chariot
 OK = {'status': 'ok'}
 
 
-def _invoke(*args, stdin=None):
-    runner = CliRunner()
+def _mock_sdk():
     mock_sdk = MagicMock()
     mock_sdk.is_praetorian_user.return_value = True
     mock_sdk.red_team.deployment_launch.return_value = {'project_id': 'p1'}
@@ -45,6 +48,12 @@ def _invoke(*args, stdin=None):
     mock_sdk.red_team.evilginx_status.return_value = {'status': 'ready'}
     mock_sdk.red_team.payload_generate.return_value = {'job_id': 'j4'}
     mock_sdk.red_team.phishkit_nodes.return_value = [{'name': 'node-1'}]
+    return mock_sdk
+
+
+def _invoke(*args, stdin=None):
+    runner = CliRunner()
+    mock_sdk = _mock_sdk()
     with patch('praetorian_cli.sdk.chariot.Chariot', return_value=mock_sdk), \
          patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
         result = runner.invoke(
@@ -547,6 +556,43 @@ def test_apply_prompts_and_aborts_without_yes():
     sdk.red_team.deployment_terraform.assert_not_called()
 
 
+def test_apply_with_a_bare_piped_body_fails_closed():
+    result, sdk = _invoke('red-team', 'deployment', 'apply', stdin='{"a": 1}')
+    assert result.exit_code == 1
+    assert 'Apply the Terraform deployment?' in result.output
+    sdk.red_team.deployment_terraform.assert_not_called()
+
+
+# Security: a payload cannot answer its own confirmation prompt. The prompt is an
+# eager Click parameter callback, so it consumes the body's first line before the
+# body is ever read, and Click accepts only y/yes/n/no -- a truthy-looking token
+# is rejected and the command aborts. No JSON document can begin with a line that
+# is exactly `y` or `yes`, so no real payload can self-confirm.
+@pytest.mark.parametrize('body', [
+    'true\n{"a": 1}',
+    '1\n{"a": 1}',
+    'on\n{"a": 1}',
+])
+def test_apply_payload_cannot_self_confirm_the_prompt(body):
+    result, sdk = _invoke('red-team', 'deployment', 'apply', stdin=body)
+    assert result.exit_code == 1
+    sdk.red_team.deployment_terraform.assert_not_called()
+
+
+def test_apply_accepts_an_explicit_y_line_before_the_piped_body():
+    result, sdk = _invoke('red-team', 'deployment', 'apply', stdin='y\n{"a": 1}')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_terraform.assert_called_once()
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {'a': 1}
+
+
+def test_apply_accepts_a_spelled_out_yes_line_before_the_piped_body():
+    result, sdk = _invoke('red-team', 'deployment', 'apply', stdin='yes\n{"a": 1}')
+    assert result.exit_code == 0
+    sdk.red_team.deployment_terraform.assert_called_once()
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {'a': 1}
+
+
 def test_campaign_delete_aborts_without_yes():
     result, sdk = _invoke('red-team', 'campaign', 'delete', '--key', 'k1',
                           stdin='n\n')
@@ -671,3 +717,115 @@ def test_targets_missing_key_is_a_usage_error():
     assert result.exit_code == 2
     assert "Expected JSON with 'targets' key" in result.output
     sdk.red_team.campaign_targets.assert_not_called()
+
+
+# --- Piped stdin is decoded as UTF-8 before anything reads it ---
+
+# Real locale decoding is unreachable from a test: CliRunner's stdin is a BytesIO
+# wrapper it decodes itself, and the process locale is fixed at interpreter start.
+# What IS testable is the mechanism -- that the reconfigure happens at all, that a
+# tty is left alone, and that it lands before the first read of the stream.
+class _StdinStub:
+    """A stdin that records reconfigure() and read calls, in order."""
+
+    def __init__(self, payload='', tty=False, reconfigure_error=None):
+        self._buffer = io.StringIO(payload)
+        self._tty = tty
+        self._reconfigure_error = reconfigure_error
+        self.events = []
+        self.reconfigure_calls = []
+
+    def isatty(self):
+        return self._tty
+
+    def reconfigure(self, **kwargs):
+        self.events.append('reconfigure')
+        self.reconfigure_calls.append(kwargs)
+        if self._reconfigure_error is not None:
+            raise self._reconfigure_error
+
+    def readline(self, *args):
+        self.events.append('readline')
+        return self._buffer.readline(*args)
+
+    def read(self, *args):
+        self.events.append('read')
+        return self._buffer.read(*args)
+
+
+def _invoke_with_stdin(stub, *args):
+    """Drive the real CLI with `stub` installed as sys.stdin.
+
+    CliRunner cannot carry a stub: isolation() overwrites sys.stdin with its own
+    BytesIO wrapper, and hands the confirmation prompt that wrapper directly
+    rather than going through sys.stdin -- so neither the reconfigure nor the
+    prompt's read would land on the stub. main() leaves sys.stdin alone, and
+    click's real prompt reads it through the builtin input().
+    """
+    mock_sdk = _mock_sdk()
+    output = io.StringIO()
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=mock_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f), \
+         patch.object(sys, 'stdin', stub), \
+         contextlib.redirect_stdout(output), \
+         contextlib.redirect_stderr(output):
+        try:
+            chariot.main(list(args), obj={'keychain': MagicMock(), 'proxy': ''},
+                         standalone_mode=True)
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code if e.code is not None else 0
+    return exit_code, output.getvalue(), mock_sdk
+
+
+def test_piped_stdin_is_reconfigured_to_utf8():
+    # `details` takes no JSON body, so the group callback is the only thing that
+    # can reconfigure here -- _load_json_body's own attempt never runs.
+    stub = _StdinStub()
+    exit_code, _, sdk = _invoke_with_stdin(stub, 'red-team', 'deployment', 'details')
+    assert exit_code == 0
+    assert stub.reconfigure_calls == [{'encoding': 'utf-8'}]
+    sdk.red_team.deployment_details.assert_called_once()
+
+
+def test_tty_stdin_is_not_reconfigured():
+    # A tty never carries a JSON body, and its encoding is the terminal's.
+    stub = _StdinStub(tty=True)
+    exit_code, _, sdk = _invoke_with_stdin(stub, 'red-team', 'deployment', 'details')
+    assert exit_code == 0
+    assert stub.reconfigure_calls == [], stub.events
+    sdk.red_team.deployment_details.assert_called_once()
+
+
+def test_reconfigure_precedes_the_eager_confirmation_prompts_read():
+    # The ordering IS the fix. reconfigure() is refused after the stream's first
+    # read, and @click.confirmation_option is eager -- its prompt reads a line
+    # before the command body runs. Anything that moves the call into a command
+    # body arrives after this read and silently restores the locale decoder.
+    stub = _StdinStub('y\n{"a": 1}')
+    exit_code, output, sdk = _invoke_with_stdin(
+        stub, 'red-team', 'deployment', 'apply')
+    assert exit_code == 0
+    assert 'Apply the Terraform deployment?' in output
+    assert stub.events[0] == 'reconfigure', stub.events
+    assert 'readline' in stub.events, stub.events
+    assert sdk.red_team.deployment_terraform.call_args[0][1] == {'a': 1}
+
+
+def test_a_stdin_without_reconfigure_is_tolerated():
+    # sys.stdin is not always a TextIOWrapper; the helper must not raise.
+    exit_code, _, sdk = _invoke_with_stdin(
+        io.StringIO('{"name":"t"}'), 'red-team', 'campaign', 'create')
+    assert exit_code == 0
+    sdk.red_team.campaign_create.assert_called_once_with({'name': 't'})
+
+
+def test_an_already_read_stdin_is_tolerated():
+    # reconfigure() is refused once the stream has been read. The stream's own
+    # decoder then stands and the command still runs.
+    stub = _StdinStub('{"name":"t"}',
+                      reconfigure_error=io.UnsupportedOperation('already read'))
+    exit_code, _, sdk = _invoke_with_stdin(stub, 'red-team', 'campaign', 'create')
+    assert exit_code == 0
+    assert stub.reconfigure_calls, stub.events
+    sdk.red_team.campaign_create.assert_called_once_with({'name': 't'})

--- a/praetorian_cli/sdk/test/test_red_team_entity.py
+++ b/praetorian_cli/sdk/test/test_red_team_entity.py
@@ -1,0 +1,579 @@
+"""Unit tests for the RedTeam SDK entity layer.
+
+test_red_team_cli.py exercises the CLI with sdk.red_team fully mocked, so it
+never reaches the entity. These tests drive the entity directly against a
+recording stub `api`, covering the `_segment` path-traversal guard, the
+terraform action allowlist, and the URL/body/params each method builds.
+
+The stub's method signatures mirror praetorian_cli/sdk/chariot.py:186-201
+exactly (post/put/get/delete), so a call-shape drift in the entity surfaces
+here as a TypeError rather than passing silently.
+"""
+
+import pytest
+
+from praetorian_cli.sdk.entities.red_team import RedTeam, TERRAFORM_ACTIONS, _segment
+
+SENTINEL = {'stub': 'response'}
+
+
+class RecordingApi:
+    """Stub `api` that records every call instead of performing it."""
+
+    def __init__(self, is_praetorian=True):
+        self.calls = []
+        self._is_praetorian = is_praetorian
+
+    def is_praetorian_user(self):
+        return self._is_praetorian
+
+    def post(self, type: str, body: dict, params: dict | None = None) -> dict:
+        self.calls.append(('post', type, body, params))
+        return SENTINEL
+
+    def put(self, type: str, body: dict, params: dict | None = None) -> dict:
+        self.calls.append(('put', type, body, params))
+        return SENTINEL
+
+    def get(self, type: str, params: dict | None = None) -> dict:
+        self.calls.append(('get', type, params))
+        return SENTINEL
+
+    def delete(self, type: str, body: dict, params: dict) -> dict:
+        self.calls.append(('delete', type, body, params))
+        return SENTINEL
+
+
+@pytest.fixture
+def api():
+    return RecordingApi()
+
+
+@pytest.fixture
+def red_team(api):
+    return RedTeam(api)
+
+
+# --------------------------------------------------------------------------
+# _segment: the path-traversal guard
+#
+# Verified contract (praetorian_cli/sdk/entities/red_team.py:9-19): the guard
+# REJECTS only the exact strings '', '.' and '..' after str() coercion. Every
+# other value is ACCEPTED and percent-encoded with safe='', which is what
+# defeats embedded traversal: '/' becomes '%2F', so the value can never split
+# into extra path segments for `requests` to normalize away.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('rejected', ['.', '..', ''])
+def test_segment_rejects_dot_segments_and_empty(rejected):
+    with pytest.raises(ValueError) as excinfo:
+        _segment(rejected)
+    assert str(excinfo.value) == f'invalid URL path segment: {rejected!r}'
+
+
+def test_segment_encodes_embedded_traversal_rather_than_rejecting_it():
+    result = _segment('a/../b')
+    assert result == 'a%2F..%2Fb'
+    # Anchored negative: the exact-equality above proves the anchor, so a
+    # loosened guard that let a literal separator through changes both lines.
+    assert '/' not in result
+
+
+def test_segment_encodes_leading_separator_traversal():
+    result = _segment('/..')
+    assert result == '%2F..'
+    assert '/' not in result
+
+
+def test_segment_encodes_trailing_separator_traversal():
+    result = _segment('../')
+    assert result == '..%2F'
+    assert '/' not in result
+
+
+def test_segment_encodes_dot_with_trailing_separator():
+    assert _segment('./') == '.%2F'
+
+
+def test_segment_double_encodes_percent_encoded_traversal():
+    # '..%2f' must not survive as a decodable separator downstream: the '%'
+    # itself is encoded, so the server sees the literal text, not a slash.
+    result = _segment('..%2f')
+    assert result == '..%252f'
+    assert '%2f' not in result.lower().replace('%252f', '')
+
+
+def test_segment_double_encodes_percent_encoded_dots():
+    assert _segment('%2e%2e') == '%252e%252e'
+
+
+def test_segment_encodes_backslash_traversal():
+    result = _segment('..\\')
+    assert result == '..%5C'
+    assert '\\' not in result
+
+
+def test_segment_accepts_triple_dot_verbatim():
+    # The guard is exact-match, not a dot-prefix check: '...' is not a
+    # dot-segment and is a legal path component, so it passes through unchanged.
+    assert _segment('...') == '...'
+
+
+def test_segment_does_not_strip_whitespace_around_dot_segments():
+    # ' .. ' is not the exact string '..', so it is accepted; the spaces are
+    # encoded, which keeps it distinct from a real dot-segment on the wire.
+    assert _segment(' .. ') == '%20..%20'
+
+
+def test_segment_passes_ordinary_value_through_unchanged():
+    assert _segment('campaign-1') == 'campaign-1'
+
+
+def test_segment_percent_encodes_non_ascii():
+    assert _segment('café') == 'caf%C3%A9'
+
+
+def test_segment_percent_encodes_unicode_beyond_latin1():
+    assert _segment('テスト') == '%E3%83%86%E3%82%B9%E3%83%88'
+
+
+@pytest.mark.parametrize('raw,encoded', [
+    ('a b', 'a%20b'),
+    ('a#b', 'a%23b'),
+    ('foo?bar=1', 'foo%3Fbar%3D1'),
+    ('x/y', 'x%2Fy'),
+    ('#campaign#my-camp', '%23campaign%23my-camp'),
+])
+def test_segment_percent_encodes_reserved_characters(raw, encoded):
+    assert _segment(raw) == encoded
+
+
+@pytest.mark.parametrize('value,expected', [
+    (0, '0'),
+    (1, '1'),
+    (None, 'None'),
+])
+def test_segment_coerces_non_strings_before_validating(value, expected):
+    # The emptiness check runs on str(value), not on value, so 0 and None are
+    # accepted as their textual forms rather than rejected as falsy.
+    assert _segment(value) == expected
+
+
+# --------------------------------------------------------------------------
+# deployment_terraform: the plan/apply allowlist
+# --------------------------------------------------------------------------
+
+def test_deployment_terraform_plan_posts_builder_state_to_plan_path(red_team, api):
+    state = {'globals': {'region': 'us-east-1'}}
+    assert red_team.deployment_terraform('plan', state) is SENTINEL
+    assert api.calls == [
+        ('post', 'red-team/deployment/terraform/plan', state, {}),
+    ]
+
+
+def test_deployment_terraform_apply_posts_builder_state_to_apply_path(red_team, api):
+    state = {'nodes': [{'type': 'phishkit'}]}
+    red_team.deployment_terraform('apply', state)
+    assert api.calls == [
+        ('post', 'red-team/deployment/terraform/apply', state, {}),
+    ]
+
+
+def test_deployment_terraform_passes_tag_and_sha_as_query_params(red_team, api):
+    red_team.deployment_terraform('plan', {}, tag='v1.1', sha='abc123')
+    assert api.calls == [
+        ('post', 'red-team/deployment/terraform/plan', {},
+         {'tag': 'v1.1', 'sha': 'abc123'}),
+    ]
+
+
+def test_deployment_terraform_omits_unset_tag_and_sha(red_team, api):
+    red_team.deployment_terraform('apply', {}, tag=None, sha='')
+    assert api.calls == [
+        ('post', 'red-team/deployment/terraform/apply', {}, {}),
+    ]
+
+
+@pytest.mark.parametrize('backend_only', ['generate', 'outputs', 'tag'])
+def test_deployment_terraform_refuses_backend_only_actions(red_team, api, backend_only):
+    # Anchor the negative assertion: prove the recorder captures an accepted
+    # call first, so "no second call" is evidence rather than a drifted no-op.
+    red_team.deployment_terraform('plan', {})
+    assert len(api.calls) == 1
+
+    with pytest.raises(ValueError) as excinfo:
+        red_team.deployment_terraform(backend_only, {'nodes': []})
+    assert str(excinfo.value) == (
+        f'invalid terraform action: {backend_only!r}; '
+        f"expected one of 'plan', 'apply'"
+    )
+    assert len(api.calls) == 1
+
+
+@pytest.mark.parametrize('hostile', ['..', '.', '', '../generate', 'PLAN', 'plan/apply'])
+def test_deployment_terraform_refuses_actions_outside_the_allowlist(red_team, api, hostile):
+    red_team.deployment_terraform('plan', {})
+    assert len(api.calls) == 1
+
+    with pytest.raises(ValueError):
+        red_team.deployment_terraform(hostile, {})
+    assert len(api.calls) == 1
+
+
+def test_terraform_allowlist_error_enumerates_only_reachable_actions(red_team):
+    with pytest.raises(ValueError) as excinfo:
+        red_team.deployment_terraform('generate', {})
+    message = str(excinfo.value)
+    assert message.endswith("expected one of 'plan', 'apply'")
+    for backend_only in ('generate', 'outputs'):
+        assert f"'{backend_only}'" not in message.split('expected one of')[1]
+
+
+def test_terraform_actions_constant_gates_exactly_plan_and_apply():
+    # Not a constant-identity test: this pins the reachable surface, so adding
+    # a backend-only sub-step to the tuple reddens here and in the CLI suite.
+    assert TERRAFORM_ACTIONS == ('plan', 'apply')
+
+
+# --------------------------------------------------------------------------
+# URL / body / params construction
+# --------------------------------------------------------------------------
+
+def test_deployment_launch_posts_empty_body_when_no_id_requested(red_team, api):
+    red_team.deployment_launch()
+    assert api.calls == [('post', 'red-team/deployment/launch', {}, None)]
+
+
+def test_deployment_launch_includes_requested_deployment_id(red_team, api):
+    red_team.deployment_launch('my-dep')
+    assert api.calls == [
+        ('post', 'red-team/deployment/launch', {'desired_id': 'my-dep'}, None),
+    ]
+
+
+def test_deployment_delete_sends_force_param_as_string_true(red_team, api):
+    red_team.deployment_delete(force=True)
+    assert api.calls == [
+        ('delete', 'red-team/deployment/delete', {}, {'force': 'true'}),
+    ]
+
+
+def test_deployment_delete_omits_force_param_by_default(red_team, api):
+    red_team.deployment_delete()
+    assert api.calls == [('delete', 'red-team/deployment/delete', {}, {})]
+
+
+@pytest.mark.parametrize('method,path', [
+    ('deployment_details', 'red-team/deployment/details'),
+    ('deployment_history', 'red-team/deployment/history'),
+    ('deployment_last_inputs', 'red-team/deployment/last-inputs'),
+    ('deployment_tags', 'red-team/deployment/tags'),
+])
+def test_parameterless_deployment_reads_get_their_own_path(red_team, api, method, path):
+    getattr(red_team, method)()
+    assert api.calls == [('get', path, None)]
+
+
+def test_deployment_node_schema_passes_tag_param(red_team, api):
+    red_team.deployment_node_schema('v1.1')
+    assert api.calls == [
+        ('get', 'red-team/deployment/node-schema', {'tag': 'v1.1'}),
+    ]
+
+
+def test_deployment_node_schema_omits_tag_param_when_unset(red_team, api):
+    red_team.deployment_node_schema()
+    assert api.calls == [('get', 'red-team/deployment/node-schema', {})]
+
+
+def test_deployment_collaborators_wraps_list_in_body(red_team, api):
+    red_team.deployment_collaborators(['a@co.com', 'b@co.com'])
+    assert api.calls == [
+        ('post', 'red-team/deployment/collaborators',
+         {'collaborators': ['a@co.com', 'b@co.com']}, None),
+    ]
+
+
+def test_campaign_create_puts_document_to_campaigns_collection(red_team, api):
+    campaign = {'name': 'q3-phish', 'template': 'invoice'}
+    red_team.campaign_create(campaign)
+    assert api.calls == [('put', 'red-team/campaigns', campaign, None)]
+
+
+def test_campaign_delete_sends_key_in_body_not_in_path(red_team, api):
+    red_team.campaign_delete('#campaign#my-camp')
+    assert api.calls == [
+        ('delete', 'red-team/campaigns', {'key': '#campaign#my-camp'}, {}),
+    ]
+
+
+def test_campaign_authorize_quotes_the_campaign_id_in_the_path(red_team, api):
+    red_team.campaign_authorize('camp/../admin')
+    assert api.calls == [
+        ('post', 'red-team/campaigns/camp%2F..%2Fadmin/authorize', {}, None),
+    ]
+
+
+def test_campaign_authorize_refuses_a_dot_segment_campaign_id(red_team, api):
+    red_team.campaign_authorize('camp-1')
+    assert len(api.calls) == 1
+
+    with pytest.raises(ValueError):
+        red_team.campaign_authorize('..')
+    assert len(api.calls) == 1
+
+
+def test_campaign_targets_builds_path_and_roster_body(red_team, api):
+    targets = [{'email': 'a@co.com'}]
+    red_team.campaign_targets('camp-1', targets)
+    assert api.calls == [
+        ('post', 'red-team/campaigns/camp-1/targets', {'targets': targets}, None),
+    ]
+
+
+def test_campaign_targets_includes_segment_when_supplied(red_team, api):
+    targets = [{'email': 'a@co.com'}]
+    red_team.campaign_targets('camp-1', targets, segment='finance')
+    assert api.calls == [
+        ('post', 'red-team/campaigns/camp-1/targets',
+         {'targets': targets, 'segment': 'finance'}, None),
+    ]
+
+
+def test_campaign_funnel_gets_the_funnel_subpath(red_team, api):
+    red_team.campaign_funnel('café-camp')
+    assert api.calls == [('get', 'red-team/campaigns/caf%C3%A9-camp/funnel', None)]
+
+
+def test_campaign_activity_stringifies_the_limit_param(red_team, api):
+    red_team.campaign_activity('camp-1', limit=25)
+    assert api.calls == [
+        ('get', 'red-team/campaigns/camp-1/activity', {'limit': '25'}),
+    ]
+
+
+def test_campaign_activity_omits_limit_param_when_unset(red_team, api):
+    red_team.campaign_activity('camp-1')
+    assert api.calls == [('get', 'red-team/campaigns/camp-1/activity', {})]
+
+
+def test_domain_update_puts_document_to_domain_parking(red_team, api):
+    domain_data = {'domain': 'evil.example', 'engagement': 'e1'}
+    red_team.domain_update(domain_data)
+    assert api.calls == [('put', 'red-team/domain-parking', domain_data, None)]
+
+
+def test_dns_list_quotes_the_domain_in_the_path(red_team, api):
+    red_team.dns_list('evil.example')
+    assert api.calls == [
+        ('get', 'red-team/domain-parking/dns/evil.example', None),
+    ]
+
+
+def test_dns_create_posts_the_record_body(red_team, api):
+    red_team.dns_create('evil.example', 'A', 'www', '10.0.0.1')
+    assert api.calls == [
+        ('post', 'red-team/domain-parking/dns/evil.example',
+         {'type': 'A', 'name': 'www', 'content': '10.0.0.1', 'ttl': 1}, None),
+    ]
+
+
+def test_dns_update_puts_the_record_body_to_a_two_segment_path(red_team, api):
+    red_team.dns_update('evil.example', 'rec-1', 'CNAME', 'mail',
+                        'target.example', ttl=300)
+    assert api.calls == [
+        ('put', 'red-team/domain-parking/dns/evil.example/rec-1',
+         {'type': 'CNAME', 'name': 'mail', 'content': 'target.example',
+          'ttl': 300}, None),
+    ]
+
+
+def test_dns_delete_quotes_both_path_segments(red_team, api):
+    red_team.dns_delete('evil.example', 'rec-1')
+    assert api.calls == [
+        ('delete', 'red-team/domain-parking/dns/evil.example/rec-1', {}, {}),
+    ]
+
+
+def test_dns_delete_encodes_traversal_in_both_segments(red_team, api):
+    red_team.dns_delete('a/../b', 'x/../y')
+    verb, path, body, params = api.calls[0]
+    assert path == 'red-team/domain-parking/dns/a%2F..%2Fb/x%2F..%2Fy'
+    # The literal path has exactly the four separators the route itself
+    # contributes; neither caller value added one.
+    assert path.count('/') == 4
+    assert (verb, body, params) == ('delete', {}, {})
+
+
+@pytest.mark.parametrize('domain,record_id', [
+    ('..', 'rec-1'),
+    ('.', 'rec-1'),
+    ('evil.example', '..'),
+    ('evil.example', ''),
+])
+def test_dns_delete_refuses_dot_segments_in_either_position(red_team, api,
+                                                            domain, record_id):
+    red_team.dns_delete('evil.example', 'rec-1')
+    assert len(api.calls) == 1
+
+    with pytest.raises(ValueError):
+        red_team.dns_delete(domain, record_id)
+    assert len(api.calls) == 1
+
+
+def test_mailgun_domain_status_gets_the_mailgun_domain_path(red_team, api):
+    red_team.mailgun_domain_status('evil.example')
+    assert api.calls == [
+        ('get', 'red-team/domain-parking/mailgun/domain/evil.example', None),
+    ]
+
+
+def test_mailgun_domain_provision_posts_an_empty_body(red_team, api):
+    red_team.mailgun_domain_provision('evil.example')
+    assert api.calls == [
+        ('post', 'red-team/domain-parking/mailgun/domain/evil.example', {}, None),
+    ]
+
+
+def test_mailgun_domain_delete_sends_empty_body_and_params(red_team, api):
+    red_team.mailgun_domain_delete('evil.example')
+    assert api.calls == [
+        ('delete', 'red-team/domain-parking/mailgun/domain/evil.example', {}, {}),
+    ]
+
+
+def test_mailgun_user_create_sends_username_and_domain_in_body(red_team, api):
+    red_team.mailgun_user_create('phish', 'evil.example')
+    assert api.calls == [
+        ('post', 'red-team/domain-parking/mailgun/user',
+         {'username': 'phish', 'domain': 'evil.example'}, None),
+    ]
+
+
+def test_mailgun_user_delete_sends_username_and_domain_in_body(red_team, api):
+    red_team.mailgun_user_delete('phish', 'evil.example')
+    assert api.calls == [
+        ('delete', 'red-team/domain-parking/mailgun/user',
+         {'username': 'phish', 'domain': 'evil.example'}, {}),
+    ]
+
+
+def test_evilginx_phishlets_passes_node_as_a_query_param(red_team, api):
+    red_team.evilginx_phishlets('node-1')
+    assert api.calls == [
+        ('get', 'red-team/evilginx/phishlets', {'node': 'node-1'}),
+    ]
+
+
+def test_evilginx_phishlet_params_quotes_the_name_and_keeps_node_a_param(red_team, api):
+    red_team.evilginx_phishlet_params('node-1', 'o365')
+    assert api.calls == [
+        ('get', 'red-team/evilginx/phishlets/o365/params', {'node': 'node-1'}),
+    ]
+
+
+def test_evilginx_phishlet_params_refuses_a_dot_segment_name(red_team, api):
+    red_team.evilginx_phishlet_params('node-1', 'o365')
+    assert len(api.calls) == 1
+
+    with pytest.raises(ValueError):
+        red_team.evilginx_phishlet_params('node-1', '..')
+    assert len(api.calls) == 1
+
+
+def test_evilginx_create_lure_posts_node_ref_and_path(red_team, api):
+    red_team.evilginx_create_lure('node-1', '/login')
+    assert api.calls == [
+        ('post', 'red-team/evilginx/lures',
+         {'node_ref': 'node-1', 'lure_path': '/login'}, None),
+    ]
+
+
+def test_evilginx_configure_posts_only_the_supplied_optional_fields(red_team, api):
+    red_team.evilginx_configure('node-1', 'evil.example', 'o365')
+    assert api.calls == [
+        ('post', 'red-team/evilginx/configure',
+         {'node_ref': 'node-1', 'domain': 'evil.example', 'phishlet': 'o365'},
+         None),
+    ]
+
+
+def test_evilginx_configure_includes_phishlet_params_and_unauth_url(red_team, api):
+    red_team.evilginx_configure('node-1', 'evil.example', 'o365',
+                                phishlet_params={'tenant': 'acme'},
+                                unauth_url='https://example.com')
+    assert api.calls == [
+        ('post', 'red-team/evilginx/configure',
+         {'node_ref': 'node-1', 'domain': 'evil.example', 'phishlet': 'o365',
+          'phishlet_params': {'tenant': 'acme'},
+          'unauth_url': 'https://example.com'}, None),
+    ]
+
+
+def test_evilginx_configure_keeps_an_explicitly_empty_phishlet_params(red_team, api):
+    # `is not None` rather than truthiness: {} must reach the backend as an
+    # explicit "no parameters" rather than being dropped.
+    red_team.evilginx_configure('node-1', 'evil.example', 'o365',
+                                phishlet_params={})
+    assert api.calls == [
+        ('post', 'red-team/evilginx/configure',
+         {'node_ref': 'node-1', 'domain': 'evil.example', 'phishlet': 'o365',
+          'phishlet_params': {}}, None),
+    ]
+
+
+def test_payload_generate_maps_filename_to_the_s3_body_field(red_team, api):
+    red_team.payload_generate('shell.bin')
+    assert api.calls == [
+        ('post', 'red-team/payload/generate',
+         {'shellcode_s3_filename': 'shell.bin'}, None),
+    ]
+
+
+def test_payload_generate_keeps_an_explicitly_empty_variables_map(red_team, api):
+    red_team.payload_generate('shell.bin', variables={})
+    assert api.calls == [
+        ('post', 'red-team/payload/generate',
+         {'shellcode_s3_filename': 'shell.bin', 'variables': {}}, None),
+    ]
+
+
+def test_phishkit_nodes_passes_status_filter(red_team, api):
+    red_team.phishkit_nodes('running')
+    assert api.calls == [
+        ('get', 'red-team/phishkit-nodes', {'status': 'running'}),
+    ]
+
+
+def test_phishkit_nodes_omits_status_filter_when_unset(red_team, api):
+    red_team.phishkit_nodes()
+    assert api.calls == [('get', 'red-team/phishkit-nodes', {})]
+
+
+# --------------------------------------------------------------------------
+# The Praetorian-only gate
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('method,args', [
+    ('deployment_launch', ()),
+    ('deployment_delete', ()),
+    ('deployment_details', ()),
+    ('deployment_terraform', ('apply', {})),
+    ('campaign_authorize', ('camp-1',)),
+    ('campaign_delete', ('#campaign#c',)),
+    ('dns_delete', ('evil.example', 'rec-1')),
+    ('mailgun_domain_delete', ('evil.example',)),
+    ('payload_generate', ('shell.bin',)),
+])
+def test_non_praetorian_user_is_refused_before_any_api_call(method, args):
+    # Anchor: the same call on a Praetorian api reaches the stub, so the
+    # empty call list below is the gate firing, not an unexercised path.
+    allowed = RecordingApi(is_praetorian=True)
+    getattr(RedTeam(allowed), method)(*args)
+    assert len(allowed.calls) == 1
+
+    refused = RecordingApi(is_praetorian=False)
+    with pytest.raises(RuntimeError) as excinfo:
+        getattr(RedTeam(refused), method)(*args)
+    assert 'limited to Praetorian engineers only' in str(excinfo.value)
+    assert refused.calls == []

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -2,14 +2,15 @@ import pytest
 
 from praetorian_cli.sdk.model.globals import Risk, Kind
 from praetorian_cli.sdk.entities.risks import get_note_entries
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestRisk:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_risk(self):

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -1,0 +1,537 @@
+"""The SDK's raising contract: the library raises, only the CLI exits.
+
+`praetorian_cli/sdk/**` used to report failures by calling
+`praetorian_cli.handlers.utils.error()`, whose body is `click.secho(...)` +
+`exit(1)`. That made library code do two things a library must not do:
+
+* **terminate the host process.** `exit(1)` raises `SystemExit`, a
+  `BaseException` -- so it is invisible to every `except Exception` an embedder
+  writes. Measured: the `except Exception` in `praetorian_cli/sdk/mcp_server.py`
+  and all 95 of them under `praetorian_cli/ui/` were bypassed, and a bad
+  keychain killed the MCP server process outright.
+* **depend on the presentation layer.** `praetorian_cli/sdk/*` imported
+  `praetorian_cli/handlers/*`, inverting the intended one-way dependency.
+
+These tests pin the replacement: the eight remaining exiting call sites raise
+`praetorian_cli.sdk.exceptions` types, and the `@cli_handler` boundary
+(`praetorian_cli/handlers/cli_decorators.py`) is the only thing that exits.
+
+Scope note: this file's subject is the SDK's *raising* contract. The decorator
+boundary's own contract is pinned separately in `test_cli_errors.py`, which
+stays untouched -- `handlers.utils.error()` remains the handlers layer's helper
+and has seven in-file callers plus every handler module.
+
+Offline only: the child-process tests arm `requests.get` to `os._exit(97)`, so a
+stray network call fails the return-code assertion instead of going out.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import praetorian_cli
+import praetorian_cli.sdk
+import praetorian_cli.sdk.keychain as keychain_module
+
+# Imported, never transcribed -- same reason as test_cli_errors.py: these tests
+# pin that the hint is *appended*, not what its wording is.
+from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+from praetorian_cli.sdk.entities.preseeds import Preseeds
+from praetorian_cli.sdk.entities.seeds import Seeds
+from praetorian_cli.sdk.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    GuardError,
+    NotFoundError,
+)
+from praetorian_cli.sdk.keychain import Keychain
+
+REPO_ROOT = Path(praetorian_cli.__file__).resolve().parent.parent
+SDK_ROOT = Path(praetorian_cli.sdk.__file__).resolve().parent
+
+TRACEBACK_HEADER = "Traceback (most recent call last)"
+
+# A profile name no keychain file will ever hold, so the "profile not found"
+# site is the one reached -- never a real profile of whoever runs the suite.
+MISSING_PROFILE = "__no_such_profile__"
+
+MISSING_SEED_KEY = "#asset#no-such-seed.example.com#no-such-seed.example.com"
+MISSING_PRESEED_KEY = "#preseed#whois+company#No Such Company#no such company"
+
+# A keychain whose single profile is complete, so `load()` reaches whichever
+# later site a test is aiming at instead of failing early.
+VALID_KEYCHAIN = """[United States]
+api = https://api.invalid
+client_id = test-client-id
+"""
+
+# Same, plus API-key credentials, so `has_api_key()` is genuinely true and
+# `token()` takes the API-key branch rather than the Cognito one.
+API_KEY_KEYCHAIN = """[United States]
+api = https://api.invalid
+client_id = test-client-id
+api_key_id = test-key-id
+api_key_secret = test-key-secret
+"""
+
+REJECTION_BODY = '{"message":"api key revoked"}'
+
+SDK_ERROR_CLASSES = (GuardError, ConfigurationError, AuthenticationError, NotFoundError)
+
+
+@pytest.fixture(autouse=True)
+def _no_keychain_env_overrides(monkeypatch):
+    """Strip `PRAETORIAN_*` from the environment for every test in this module.
+
+    `Keychain.load_env` lets an environment variable override the keychain file,
+    so a developer with `PRAETORIAN_CLI_API` exported would silently satisfy the
+    "incomplete profile" site and turn that test green for the wrong reason.
+    """
+    for name in list(os.environ):
+        if name.startswith("PRAETORIAN_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def isolated_home(tmp_path):
+    """A `$HOME` holding a controlled keychain, for the child-process CLI tests.
+
+    `DEFAULT_KEYCHAIN_FILEPATH` is `join(Path.home(), '.praetorian',
+    'keychain.ini')` resolved at import time, so a child process with `HOME`
+    redirected here reads this file -- and one without it reads the developer's
+    real keychain. The file has to *exist* and be valid, too: with no keychain at
+    all `load()` falls back to built-in defaults and a bogus `--profile` would
+    hit the "corrupted file" site instead of the "profile not found" one, making
+    the assertion depend on whose machine ran it.
+    """
+    home = tmp_path / "home"
+    (home / ".praetorian").mkdir(parents=True)
+    (home / ".praetorian" / "keychain.ini").write_text(VALID_KEYCHAIN)
+    return home
+
+
+# Guard against the measurement trap that this repo makes easy: a second,
+# pip-installed `praetorian_cli` is importable, and which one a child gets
+# depends on how it was launched (`-c` prepends the cwd; a script file prepends
+# the script's directory). Measured: launching the same probe as a file in a
+# scratch directory imported a stale third checkout instead of this worktree.
+# The child asserts its own package path and exits 98 rather than reporting a
+# plausible number about code nobody is editing.
+_PACKAGE_GUARD = """
+import os, sys
+import praetorian_cli
+if not praetorian_cli.__file__.startswith(os.environ["PRAETORIAN_TEST_PACKAGE_ROOT"]):
+    sys.stderr.write("imported the wrong praetorian_cli: %s\\n" % praetorian_cli.__file__)
+    os._exit(98)
+"""
+
+# `upgrade_check`'s bare `except:` swallows anything raisable, so only an
+# uncatchable exit makes a stray advisory request visible. Same device as
+# `test_cli_errors.py`'s `_NETWORK_TRIPWIRE`, kept local so this module stands
+# alone.
+_CLI_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.handlers.cli_decorators as decorators
+decorators.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+# The SDK-only counterpart, for the plain-script test: that script must not
+# import the handlers layer at all, since not needing it is half the point.
+# `Keychain.token()` is the only network call in `keychain.py`.
+_SDK_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.sdk.keychain as _keychain
+_keychain.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+
+def _run_child(script, tripwire, env=None):
+    child_env = {k: v for k, v in os.environ.items() if not k.startswith("PRAETORIAN_")}
+    child_env["PRAETORIAN_TEST_PACKAGE_ROOT"] = str(REPO_ROOT)
+    if env:
+        child_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-c", _PACKAGE_GUARD + tripwire + script],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+        env=child_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The hierarchy itself
+# ---------------------------------------------------------------------------
+
+
+def test_every_sdk_error_is_a_guard_error():
+    """`except GuardError` is the blanket arm an embedder gets to rely on.
+
+    Without this, the three concrete classes could each derive straight from
+    `Exception` -- every message and per-site test below would still pass, and
+    the one promise the base class exists to make would be silently broken.
+    """
+    for cls in (ConfigurationError, AuthenticationError, NotFoundError):
+        assert cls is not GuardError
+        assert issubclass(cls, GuardError), f"{cls.__name__} must subclass GuardError"
+
+        caught = None
+        try:
+            raise cls("boom")
+        except GuardError as exc:
+            caught = exc
+        assert isinstance(caught, cls)
+
+
+def test_sdk_errors_are_not_base_exceptions():
+    """This is the bug being fixed, stated as an assertion.
+
+    Measured on the old code: `error('boom')` was catchable *only* as
+    `SystemExit`, because `exit(1)` raises a `BaseException`. A class that
+    accidentally derived from `SystemExit` would reintroduce exactly that,
+    while every message-text test in this file still passed.
+    """
+    for cls in SDK_ERROR_CLASSES:
+        assert issubclass(cls, Exception), f"{cls.__name__} must be an Exception"
+        assert not issubclass(cls, SystemExit), f"{cls.__name__} must not exit the host"
+
+        caught = None
+        try:
+            raise cls("boom")
+        except Exception as exc:  # noqa: BLE001 - the blanket arm IS the contract
+            caught = exc
+        assert isinstance(caught, cls)
+        assert str(caught) == "boom"
+
+
+# ---------------------------------------------------------------------------
+# The eight converted call sites
+# ---------------------------------------------------------------------------
+
+
+def test_corrupted_keychain_file_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- no parseable profile sections at all."""
+    path = tmp_path / "keychain.ini"
+    # Comments only: a file that parses cleanly to *zero* sections. Arbitrary
+    # bytes would not reach this site -- ConfigParser raises
+    # MissingSectionHeaderError first, which is a different failure.
+    path.write_text("# a keychain file with no profile sections\n")
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(filepath=str(path)).load()
+
+    assert "Keychain file is corrupted" in str(raised.value)
+    assert str(path) in str(raised.value)
+
+
+def test_failed_load_is_not_cached_so_a_repaired_keychain_is_reread(tmp_path):
+    """keychain.py `load()` -- a raise must not poison the instance for good.
+
+    This is the half of the raising contract that only exists *because* the host
+    now survives. While these sites called `exit(1)` no process lived long
+    enough to hold stale state; now one does, and `load()`'s early return has to
+    key on a load that finished rather than on `self.config` being set. Measured:
+    `bool(ConfigParser())` is `True` and `len()` is 1 -- the DEFAULT section
+    always counts, even with `sections() == []` -- so the parser assigned before
+    validation is already truthy when the raise happens.
+
+    The sequence is the operator's: a long-lived SDK or MCP host hits a corrupt
+    keychain, catches `ConfigurationError`, the operator repairs the file, and
+    the next call has to see the repair. Measured on the unfixed code the second
+    `load()` returned the stale sectionless parser and every `get_option` read
+    `None` -- `ConfigParser.get`'s `fallback=` swallows the missing section as
+    well as a missing option, so the host went on silently seeing an unconfigured
+    profile, with no second error, until it was restarted.
+    """
+    path = tmp_path / "keychain.ini"
+    path.write_text("# no profile sections\n")
+
+    keychain = Keychain(filepath=str(path))
+
+    with pytest.raises(ConfigurationError):
+        keychain.load()
+
+    # The operator fixes the file the message pointed them at, in place.
+    path.write_text(VALID_KEYCHAIN)
+
+    assert keychain.load() is keychain
+    assert keychain.get_option("api") == "https://api.invalid"
+    assert keychain.get_option("client_id") == "test-client-id"
+
+
+def test_rejected_required_option_is_not_cached_so_a_repaired_keychain_is_reread(
+    tmp_path, monkeypatch
+):
+    """keychain.py `load_env()` -- its raise must invalidate the cached load too.
+
+    The message at this site tells the operator to run `praetorian configure` or
+    export the variable, so the instance has to be able to *see* that repair.
+    Measured on the unfixed code, against a keychain that loads cleanly but
+    carries no `username`: `load()` succeeded and set the cached-load flag, the
+    direct `load_env('username', ...)` raised `ConfigurationError` while the flag
+    stayed `True`, and after the operator added the line the second `load()`
+    returned early without rereading -- `get_option('username')` read `None`
+    indefinitely, while a fresh instance read `'fixed@example.com'`.
+
+    Not a regression from the cached-load flag: the pre-existing `if self.config:`
+    guard returned early here for exactly the same reason. The flag only made a
+    long-standing memoization gap visible, so this test pins the raise path that
+    the earlier one does not cover -- `load_env`'s, reached only by a direct call.
+    """
+    path = tmp_path / "keychain.ini"
+    # Valid, and deliberately without `username` -- that is what VALID_KEYCHAIN
+    # is: `api` and `client_id` only.
+    path.write_text(VALID_KEYCHAIN)
+
+    keychain = Keychain(filepath=str(path))
+    assert keychain.load() is keychain
+
+    # Before the call, not after: the environment branch takes precedence over
+    # the file and would satisfy the option without ever reaching the raise.
+    monkeypatch.delenv("PRAETORIAN_CLI_USERNAME", raising=False)
+
+    with pytest.raises(ConfigurationError):
+        keychain.load_env("username", "PRAETORIAN_CLI_USERNAME")
+
+    # The operator does what the message said, in the profile the load used.
+    with path.open("a") as keychain_file:
+        keychain_file.write("username = fixed@example.com\n")
+
+    assert keychain.load() is keychain
+    assert keychain.get_option("username") == "fixed@example.com"
+
+
+def test_missing_profile_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- the requested profile is not in the file."""
+    path = tmp_path / "keychain.ini"
+    path.write_text(VALID_KEYCHAIN)
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(profile=MISSING_PROFILE, filepath=str(path)).load()
+
+    assert MISSING_PROFILE in str(raised.value)
+    assert str(path) in str(raised.value)
+
+
+def test_incomplete_profile_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- profile exists but lacks `api`/`client_id`."""
+    path = tmp_path / "keychain.ini"
+    path.write_text("[United States]\nusername = someone@example.invalid\n")
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(filepath=str(path)).load()
+
+    assert "corrupted or incomplete" in str(raised.value)
+
+
+def test_required_env_option_missing_raises_configuration_error():
+    """keychain.py `load_env()` -- required option in neither file nor env.
+
+    Reached only through a direct call: all six `load_env` calls inside `load()`
+    pass `required=False`, so this site is unreachable from the CLI. It is a
+    public method whose `required` parameter defaults to `True`, so it is
+    converted with the rest and exercised here rather than through the CLI.
+    """
+    keychain = Keychain(data=VALID_KEYCHAIN).load()
+
+    with pytest.raises(ConfigurationError) as raised:
+        keychain.load_env("username", "PRAETORIAN_CLI_USERNAME", required=True)
+
+    assert "PRAETORIAN_CLI_USERNAME" in str(raised.value)
+
+
+def test_rejected_api_key_raises_authentication_error(monkeypatch):
+    """keychain.py `token()` -- the backend rejected the credentials.
+
+    `AuthenticationError`, not `ConfigurationError`: the local configuration is
+    fine and the server said no, so the caller's move is to rotate or retry,
+    not to re-run `configure`.
+    """
+    keychain = Keychain(data=API_KEY_KEYCHAIN)
+    monkeypatch.setattr(
+        keychain_module.requests,
+        "get",
+        Mock(return_value=Mock(status_code=401, text=REJECTION_BODY)),
+    )
+
+    with pytest.raises(AuthenticationError) as raised:
+        keychain.token()
+
+    # The response body is the only actionable detail the caller gets; the
+    # boundary surfaces the message verbatim, so it has to survive to here.
+    assert REJECTION_BODY in str(raised.value)
+
+
+def _seeds_finding_nothing():
+    """A `Seeds` whose backing search returns no results, so `get()` is None."""
+    api = Mock()
+    api.search.by_query.return_value = None
+    return Seeds(api)
+
+
+def test_seeds_update_missing_key_raises_not_found_error():
+    """seeds.py `update()` -- `NotFoundError` is ordinary control flow.
+
+    A caller iterating keys wants `except NotFoundError: continue`, which the
+    old `exit(1)` made impossible.
+    """
+    with pytest.raises(NotFoundError) as raised:
+        _seeds_finding_nothing().update(MISSING_SEED_KEY, "A")
+
+    assert MISSING_SEED_KEY in str(raised.value)
+
+
+def test_seeds_delete_missing_key_raises_not_found_error():
+    """seeds.py `delete()`."""
+    with pytest.raises(NotFoundError) as raised:
+        _seeds_finding_nothing().delete(MISSING_SEED_KEY)
+
+    assert MISSING_SEED_KEY in str(raised.value)
+
+
+def test_preseeds_update_missing_key_raises_not_found_error():
+    """preseeds.py `update()`."""
+    api = Mock()
+    api.search.by_exact_key.return_value = None
+
+    with pytest.raises(NotFoundError) as raised:
+        Preseeds(api).update(MISSING_PRESEED_KEY, "A")
+
+    assert MISSING_PRESEED_KEY in str(raised.value)
+
+
+# ---------------------------------------------------------------------------
+# An embedding host survives (the whole point of the change)
+# ---------------------------------------------------------------------------
+
+
+_PLAIN_SCRIPT_CATCHING_CONFIGURATION_ERROR = """
+import sys
+from praetorian_cli.sdk.exceptions import ConfigurationError
+from praetorian_cli.sdk.keychain import Keychain
+
+try:
+    Keychain(profile={profile!r}, filepath={path!r}).load()
+except ConfigurationError as exc:
+    print("CAUGHT", type(exc).__name__)
+    sys.exit(0)
+
+print("NOT RAISED")
+sys.exit(3)
+"""
+
+
+def test_plain_script_catches_configuration_error_and_survives(tmp_path):
+    """A child process is load-bearing here, not ceremony.
+
+    The claim is that the *host process survives*, and an in-process
+    `pytest.raises` cannot show that: under the old code `exit(1)` raised
+    `SystemExit`, so this script's `except ConfigurationError` never ran and the
+    process died with status 1 and `ERROR:` on stderr. Only a real process can
+    distinguish "caught and continued" from "was killed".
+    """
+    path = tmp_path / "keychain.ini"
+    path.write_text(VALID_KEYCHAIN)
+
+    result = _run_child(
+        _PLAIN_SCRIPT_CATCHING_CONFIGURATION_ERROR.format(
+            profile=MISSING_PROFILE, path=str(path)
+        ),
+        tripwire=_SDK_NETWORK_TRIPWIRE,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "CAUGHT ConfigurationError" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# No user-facing regression at either console script
+# ---------------------------------------------------------------------------
+
+
+_CLI_SCRIPT = """
+from praetorian_cli.main import {entry}
+{entry}({argv!r})
+"""
+
+
+def _cli_child(entry, argv, home):
+    return _run_child(
+        _CLI_SCRIPT.format(entry=entry, argv=argv),
+        tripwire=_CLI_NETWORK_TRIPWIRE,
+        env={"HOME": str(home)},
+    )
+
+
+def _assert_handled_cli_failure(result):
+    combined = result.stdout + result.stderr
+    # `== 1`, never `!= 0`: an argument-parsing mistake exits 2 without ever
+    # reading the keychain, and a stray network call exits 97 -- both would
+    # satisfy a loose assertion while measuring nothing about this change.
+    assert result.returncode == 1, f"exit={result.returncode} output={combined!r}"
+    assert MISSING_PROFILE in result.stderr, combined
+    assert DEBUG_HINT in result.stderr, combined
+    assert TRACEBACK_HEADER not in combined, combined
+
+
+def test_guard_entry_point_missing_profile_is_a_handled_failure(isolated_home):
+    """`guard --profile ... list assets`: exit 1, own message, no traceback."""
+    result = _cli_child(
+        "guard_main", ["--profile", MISSING_PROFILE, "list", "assets"], isolated_home
+    )
+    _assert_handled_cli_failure(result)
+
+
+def test_praetorian_entry_point_missing_profile_is_a_handled_failure(isolated_home):
+    """`praetorian --profile ... chariot list assets`, same contract.
+
+    The two console scripts carry *different* command sets (`praetorian` ->
+    `main`, `guard` -> `guard_main`), so measuring one is not evidence about the
+    other. The `chariot` segment is required: measured, dropping it exits 2 with
+    `Error: No such command 'list'.` and never reaches the keychain.
+    """
+    result = _cli_child(
+        "main",
+        ["--profile", MISSING_PROFILE, "chariot", "list", "assets"],
+        isolated_home,
+    )
+    _assert_handled_cli_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# The dependency direction, as a test rather than a grep
+# ---------------------------------------------------------------------------
+
+
+# WHY THE TEST TREE IS EXCLUDED -- read this before "fixing" a red result here.
+# The CLI's own tests deliberately live under the SDK's test tree and import the
+# CLI layer *in order to test it*: `test_cli_errors.py` alone carries nine such
+# imports. Measured on 556e63a: 18 matches under praetorian_cli/sdk/, 13 of them
+# in this directory. So the rule being enforced is about SHIPPING SDK code.
+# Reading it as "no such import anywhere under sdk/" would mean deleting working
+# tests to quiet a grep -- do NOT resolve a failure here by touching
+# praetorian_cli/sdk/test/.
+SDK_TEST_TREE = SDK_ROOT / "test"
+
+_HANDLERS_IMPORT = re.compile(r"\s*(?:from|import)\s+praetorian_cli\.handlers\b")
+
+
+def test_sdk_does_not_import_the_handlers_layer():
+    """A walk, not a hardcoded file list, so a *new* SDK module cannot slip one in."""
+    offenders = []
+    for module in sorted(SDK_ROOT.rglob("*.py")):
+        if SDK_TEST_TREE in module.parents:
+            continue
+        for lineno, line in enumerate(module.read_text().splitlines(), start=1):
+            if _HANDLERS_IMPORT.match(line):
+                offenders.append(f"{module.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert offenders == [], (
+        "SDK code must not import the CLI handlers layer:\n" + "\n".join(offenders)
+    )

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -130,8 +130,8 @@ if not praetorian_cli.__file__.startswith(os.environ["PRAETORIAN_TEST_PACKAGE_RO
     os._exit(98)
 """
 
-# `upgrade_check`'s bare `except:` swallows anything raisable, so only an
-# uncatchable exit makes a stray advisory request visible. Same device as
+# `_check_for_update`'s `except Exception: pass` arm swallows every ordinary
+# exception, so only an uncatchable exit makes a stray advisory request visible. Same device as
 # `test_cli_errors.py`'s `_NETWORK_TRIPWIRE`, kept local so this module stands
 # alone.
 _CLI_NETWORK_TRIPWIRE = """
@@ -462,10 +462,37 @@ from praetorian_cli.main import {entry}
 
 
 def _cli_child(entry, argv, home):
+    """Spawn a console-script child under the fake `$HOME`, deps still importable.
+
+    The `HOME` override is load-bearing -- `DEFAULT_KEYCHAIN_FILEPATH` derives
+    from it -- but it also relocates the *user* site-packages, whose location is
+    `$HOME`-relative. That is where `pip install --user` puts this package's own
+    dependencies, so overriding `HOME` alone takes them with it: measured on a
+    stock developer machine, the child died on `ModuleNotFoundError: No module
+    named 'click'` inside `cli_decorators` before reaching any behaviour under
+    test, and both tests below failed for that reason rather than on their own
+    assertions. The suite only passed where the deps happened to live outside
+    `$HOME`, i.e. in a virtualenv -- an unstated assumption about how the package
+    was installed.
+
+    Exporting the parent's own `sys.path` fixes it without weakening the
+    isolation (`Path.home()` in the child still resolves to the fake home), and
+    is correct under a venv too, where hardcoding the user-site path would not
+    be. `cwd` is `REPO_ROOT` and `-c` puts the cwd ahead of `PYTHONPATH`, so this
+    cannot shift which `praetorian_cli` the child imports -- `_PACKAGE_GUARD`
+    keeps measuring that.
+
+    The `if p` filter is load-bearing: `sys.path` carries an empty entry meaning
+    "the current directory", and an empty `PYTHONPATH` component would put the
+    child's cwd on its import path implicitly rather than by the `cwd` argument.
+    """
     return _run_child(
         _CLI_SCRIPT.format(entry=entry, argv=argv),
         tripwire=_CLI_NETWORK_TRIPWIRE,
-        env={"HOME": str(home)},
+        env={
+            "HOME": str(home),
+            "PYTHONPATH": os.pathsep.join(p for p in sys.path if p),
+        },
     )
 
 

--- a/praetorian_cli/sdk/test/test_search.py
+++ b/praetorian_cli/sdk/test/test_search.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind, Risk
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSearch:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.sdk.assets.add(self.asset_dns, self.asset_name)
         self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, self.comment)

--- a/praetorian_cli/sdk/test/test_seed.py
+++ b/praetorian_cli/sdk/test/test_seed.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Seed, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSeed:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_asset_seed(self):

--- a/praetorian_cli/sdk/test/test_setting.py
+++ b/praetorian_cli/sdk/test/test_setting.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSettings:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_setting(self):

--- a/praetorian_cli/sdk/test/test_test_handler.py
+++ b/praetorian_cli/sdk/test/test_test_handler.py
@@ -1,0 +1,560 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.cli_decorators as cli_decorators
+import praetorian_cli.handlers.script as script_handler
+import praetorian_cli.handlers.test as test_handler
+import praetorian_cli.main as cli_main
+from praetorian_cli.sdk.keychain import Keychain as SdkKeychain
+
+
+PROFILE = "United States"
+ACCOUNT = "account-123"
+
+# handlers.test._test_target() emits this (err=True) when a non-TestTarget context
+# reaches it, and _explicit_target() emits REFUSAL the same way.
+#
+# Stream note, measured on click 8.3.0 (the version pinned here) -- do not "fix" the
+# assertions below to .stdout. click 8.2 removed mix_stderr; Result.output became its
+# OWN stream interleaving stdout and stderr in write order, so err=True text lands in
+# .output as well as .stderr, while .stdout holds only real stdout. Asserting stderr
+# text against .stdout would therefore pass unconditionally. .output is used here
+# because it is the union of both streams: the strongest home for a "never appears"
+# assertion.
+FALLBACK_WARNING = "no explicit test target"
+REFUSAL = "an explicit, unambiguous profile is required"
+
+CREDENTIAL_ENV = (
+    "PRAETORIAN_CLI_USERNAME",
+    "PRAETORIAN_CLI_PASSWORD",
+    "PRAETORIAN_CLI_API_KEY_ID",
+    "PRAETORIAN_CLI_API_KEY_SECRET",
+    "PRAETORIAN_CLI_API",
+    "PRAETORIAN_CLI_CLIENT_ID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+)
+CREDENTIAL_FILE_ENV = (
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def guard_preconsent_sentinels():
+    with (
+        patch.object(
+            cli_main,
+            "Keychain",
+            side_effect=AssertionError("Keychain constructed before consent"),
+        ) as keychain,
+        patch(
+            "praetorian_cli.sdk.chariot.Chariot",
+            side_effect=AssertionError("Chariot constructed before consent"),
+        ) as chariot,
+        patch.object(
+            script_handler,
+            "load_dynamic_commands",
+            side_effect=AssertionError("dynamic commands loaded before consent"),
+        ) as loader,
+        patch.object(
+            cli_decorators.requests,
+            "get",
+            side_effect=AssertionError("network used before consent"),
+        ) as network,
+        patch.object(
+            SdkKeychain,
+            "load",
+            side_effect=AssertionError("Keychain loaded before consent"),
+        ) as keychain_load,
+        patch.object(
+            SdkKeychain,
+            "token",
+            side_effect=AssertionError("token requested before consent"),
+        ) as token,
+    ):
+        yield SimpleNamespace(
+            keychain=keychain,
+            chariot=chariot,
+            loader=loader,
+            network=network,
+            keychain_load=keychain_load,
+            token=token,
+        )
+
+
+def _target(profile=PROFILE, account=ACCOUNT):
+    """The context an explicit target actually arrives as.
+
+    A TestTarget is the only carrier of an explicit target, and main.py's _supplied()
+    is the only thing that fills one. Any other shape reaching the handler is a
+    context-wiring regression -- see _sdk_context() for that case.
+    """
+    return test_handler.TestTarget(profile=profile, account=account, proxy="http://localhost:8080")
+
+
+def _sdk_context(profile=PROFILE, account=ACCOUNT):
+    """An SDK-shaped context: what the non-test routes put on click_context.obj.
+
+    Deliberately NOT a TestTarget, so it drives handlers.test._test_target()'s
+    refusal branch. Its keychain carries the declared --profile default, which is
+    exactly the value that must never be inferred as a target.
+    """
+    return SimpleNamespace(
+        keychain=SimpleNamespace(profile=profile, account=account),
+        proxy="http://localhost:8080",
+    )
+
+
+def _invoke(runner, argv, *, target=None, input=None, returncode=0, env=None):
+    completed = SimpleNamespace(returncode=returncode)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            test_handler.test,
+            argv,
+            obj=target or _target(),
+            input=input,
+            env=env,
+        )
+    return result, run
+
+
+def _guard_test_args(suite):
+    return ["--profile", PROFILE, "--account", ACCOUNT, "test", "--suite", suite]
+
+
+def _public_test_args(entry_point, suite, *, include_account=True):
+    args = ["--profile", PROFILE]
+    if include_account:
+        args.extend(["--account", ACCOUNT])
+    if entry_point is cli_main.main:
+        args.append("chariot")
+    return [*args, "test", "--suite", suite]
+
+
+@pytest.mark.parametrize("entry_point", [cli_main.guard_main, cli_main.main])
+@pytest.mark.parametrize(
+    ("include_account", "input"),
+    [(False, "y\n"), (True, "n\n"), (True, "")],
+    ids=["missing-target", "refusal", "eof"],
+)
+def test_every_public_live_path_is_inert_before_consent(
+    runner,
+    guard_preconsent_sentinels,
+    monkeypatch,
+    tmp_path,
+    entry_point,
+    include_account,
+    input,
+):
+    imported = tmp_path / "imported"
+    (tmp_path / "sentinel.py").write_text(
+        f"from pathlib import Path\nPath({str(imported)!r}).write_text('imported')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PRAETORIAN_SCRIPTS_PATH", str(tmp_path))
+
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started before consent"),
+    ) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, "coherence", include_account=include_account),
+            input=input,
+        )
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+    assert not imported.exists()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+@pytest.mark.parametrize("entry_point", [cli_main.guard_main, cli_main.main])
+def test_every_public_live_path_propagates_confirmed_target_and_status(
+    runner,
+    guard_preconsent_sentinels,
+    entry_point,
+):
+    completed = SimpleNamespace(returncode=5)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, "coherence"),
+            input="y\n",
+        )
+
+    assert result.exit_code == 5
+    assert result.output.count("[y/N]") == 1
+    assert result.output.count(f"Profile: {PROFILE}") == 1
+    assert result.output.count(f"Account: {ACCOUNT}") == 1
+    environment = run.call_args.kwargs["env"]
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_refusal_has_no_preconsent_side_effects(runner, guard_preconsent_sentinels):
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started before consent"),
+    ) as run:
+        result = runner.invoke(cli_main.guard_main, _guard_test_args("coherence"), input="n\n")
+
+    assert result.exit_code != 0
+    assert "coherence" in result.output
+    assert PROFILE in result.output
+    assert ACCOUNT in result.output
+    run.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_missing_target_has_no_preconsent_side_effects(runner, guard_preconsent_sentinels):
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started without a target"),
+    ) as run:
+        result = runner.invoke(
+            cli_main.guard_main,
+            ["--profile", PROFILE, "test", "--suite", "coherence"],
+            input="y\n",
+        )
+
+    assert result.exit_code != 0
+    assert "account" in result.output.lower()
+    run.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_acceptance_propagates_pytest_status_without_root_initialization(
+    runner,
+    guard_preconsent_sentinels,
+):
+    completed = SimpleNamespace(returncode=5)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(cli_main.guard_main, _guard_test_args("coherence"), input="y\n")
+
+    assert result.exit_code == 5
+    run.assert_called_once()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_safe_suite_skips_root_initialization_and_remains_noninteractive(
+    runner,
+    guard_preconsent_sentinels,
+):
+    completed = SimpleNamespace(returncode=0)
+    with (
+        patch.object(test_handler.subprocess, "run", return_value=completed) as run,
+        patch.object(test_handler.click, "confirm", side_effect=AssertionError("unexpected prompt")) as confirm,
+    ):
+        result = runner.invoke(cli_main.guard_main, ["test"])
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    confirm.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_non_test_command_preserves_normal_initialization(runner):
+    keychain_value = object()
+    chariot_value = object()
+    with (
+        patch.object(cli_main, "Keychain", return_value=keychain_value) as keychain,
+        patch("praetorian_cli.sdk.chariot.Chariot", return_value=chariot_value) as chariot,
+        patch.object(script_handler, "load_dynamic_commands") as loader,
+    ):
+        result = runner.invoke(cli_main.guard_main, ["list", "--help"])
+
+    assert result.exit_code == 0
+    keychain.assert_called_once_with("United States", None)
+    chariot.assert_called_once_with(keychain_value, proxy="")
+    loader.assert_called_once_with()
+
+
+def test_legacy_non_test_command_preserves_normal_initialization(runner):
+    keychain_value = object()
+    chariot_value = object()
+    with (
+        patch.object(cli_main, "Keychain", return_value=keychain_value) as keychain,
+        patch("praetorian_cli.sdk.chariot.Chariot", return_value=chariot_value) as chariot,
+        patch.object(script_handler, "load_dynamic_commands") as loader,
+    ):
+        result = runner.invoke(cli_main.main, ["chariot", "list", "--help"])
+
+    assert result.exit_code == 0
+    keychain.assert_called_once_with("United States", None)
+    chariot.assert_called_once_with(keychain=keychain_value, proxy="")
+    loader.assert_called_once_with()
+
+
+def test_live_confirmation_discloses_target_and_mutation(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "coherence" in result.output
+    assert PROFILE in result.output
+    assert ACCOUNT in result.output
+    assert "mutating" in result.output.lower()
+    assert result.output.count("[y/N]") == 1
+    run.assert_called_once()
+
+
+def test_live_suite_propagates_exact_disclosed_target(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n")
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+    assert environment["CHARIOT_PROXY"] == "http://localhost:8080"
+
+
+@pytest.mark.parametrize(("profile", "account"), [(PROFILE, None), (None, ACCOUNT), ("", ACCOUNT), (PROFILE, "")])
+def test_missing_target_fails_before_subprocess(runner, profile, account):
+    result, run = _invoke(
+        runner,
+        ["--suite", "coherence"],
+        target=_target(profile=profile, account=account),
+        input="y\n",
+    )
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_live_refusal_is_a_nonzero_noop(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="n\n")
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_live_confirmation_eof_is_a_nonzero_noop(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="")
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_safe_suite_is_noninteractive_and_keyless(runner):
+    with patch.object(test_handler.click, "confirm", side_effect=AssertionError("unexpected prompt")) as confirm:
+        result, run = _invoke(runner, [])
+
+    assert result.exit_code == 0
+    confirm.assert_not_called()
+    command = run.call_args.args[0]
+    assert command[-2:] == ["-m", "not coherence and not cli and not tui"]
+    environment = run.call_args.kwargs["env"]
+    assert "CHARIOT_TEST_PROFILE" not in environment
+    assert "CHARIOT_TEST_ACCOUNT" not in environment
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_non_live_suite_scrubs_inherited_credentials(runner, suite):
+    inherited = {name: f"sentinel-{index}" for index, name in enumerate(CREDENTIAL_ENV)}
+
+    result, run = _invoke(runner, ["--suite", suite], env=inherited)
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert all(
+        name not in environment
+        for name in CREDENTIAL_ENV
+        if name not in CREDENTIAL_FILE_ENV
+    )
+    assert all(environment.get(name) != inherited[name] for name in CREDENTIAL_FILE_ENV)
+    assert environment["AWS_EC2_METADATA_DISABLED"] == "true"
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_non_live_suite_isolates_default_credential_stores(runner, tmp_path, suite):
+    ambient_home = tmp_path / "ambient-home"
+    sentinel_paths = (
+        ambient_home / ".praetorian" / "keychain.ini",
+        ambient_home / ".aws" / "credentials",
+        ambient_home / ".aws" / "config",
+    )
+    for path in sentinel_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("credential-sentinel", encoding="utf-8")
+
+    observed = {}
+
+    def inspect_environment(_args, *, env):
+        isolated_home = Path(env["HOME"])
+        observed.update(
+            isolated_home=isolated_home,
+            home_was_dir=isolated_home.is_dir(),
+            userprofile=env.get("USERPROFILE"),
+            shared_credentials_file=env.get("AWS_SHARED_CREDENTIALS_FILE"),
+            aws_config_file=env.get("AWS_CONFIG_FILE"),
+            boto_config=env.get("BOTO_CONFIG"),
+            keychain_exists=(isolated_home / ".praetorian" / "keychain.ini").exists(),
+        )
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(test_handler.subprocess, "run", side_effect=inspect_environment) as run:
+        result = runner.invoke(
+            test_handler.test,
+            ["--suite", suite],
+            obj=_target(),
+            env={"HOME": str(ambient_home), "USERPROFILE": str(ambient_home)},
+        )
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    isolated_home = observed["isolated_home"]
+    assert observed["home_was_dir"]
+    assert isolated_home != ambient_home
+    assert observed["userprofile"] == str(isolated_home)
+    assert observed["shared_credentials_file"] == str(isolated_home / ".aws" / "credentials")
+    assert observed["aws_config_file"] == str(isolated_home / ".aws" / "config")
+    assert observed["boto_config"] == str(isolated_home / ".boto")
+    assert observed["keychain_exists"] is False
+
+
+def test_live_suite_retains_inherited_auth_environment(runner):
+    inherited = {name: f"sentinel-{index}" for index, name in enumerate(CREDENTIAL_ENV)}
+
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n", env=inherited)
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert all(environment[name] == value for name, value in inherited.items())
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+
+
+@pytest.mark.parametrize(
+    ("suite", "selector", "input"),
+    [
+        ("safe", "not coherence and not cli and not tui", None),
+        ("coherence", "coherence", "y\n"),
+        ("cli", "cli", "y\n"),
+        ("tui", "tui", None),
+    ],
+)
+def test_every_suite_uses_its_explicit_selector(runner, suite, selector, input):
+    result, run = _invoke(runner, ["--suite", suite], input=input)
+
+    assert result.exit_code == 0
+    command = run.call_args.args[0]
+    marker_index = max(index for index, argument in enumerate(command) if argument == "-m")
+    assert command[marker_index + 1] == selector
+
+
+def test_pytest_exit_status_is_propagated(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n", returncode=5)
+
+    assert result.exit_code == 5
+    run.assert_called_once()
+
+
+@pytest.mark.parametrize("suite", ["coherence", "cli"])
+def test_sdk_context_refuses_live_suite_without_inferring_a_target(runner, suite):
+    # run.assert_not_called() below is the guard. The side_effect is only a perturbation:
+    # cli_decorators.handle_error catches Exception and then touches chariot.is_debug,
+    # which is unset when the command is invoked directly, so this AssertionError would
+    # surface as exit 1 rather than propagating. Do not trust it as a tripwire.
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started without an explicit target"),
+    ) as run:
+        result = runner.invoke(
+            test_handler.test,
+            ["--suite", suite],
+            obj=_sdk_context(),
+            input="y\n",
+        )
+
+    # "y" is supplied so a refusal here can only be the gate, never an operator declining.
+    assert result.exit_code == 2
+    assert FALLBACK_WARNING in result.output
+    assert REFUSAL in result.output
+    # click.confirm is deliberately left UNPATCHED: the prompt's own marker is the
+    # witness that consent was never reached, and leaving it real is what makes the
+    # two disclosure assertions below able to fail -- a keychain-inferring regression
+    # prints "Profile: <profile>" here, which a confirm mock would have swallowed.
+    assert "[y/N]" not in result.output
+    assert PROFILE not in result.output
+    assert ACCOUNT not in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_sdk_context_runs_non_live_suite_without_exporting_a_target(runner, suite):
+    completed = SimpleNamespace(returncode=0)
+    with (
+        patch.object(test_handler.subprocess, "run", return_value=completed) as run,
+        patch.object(
+            test_handler.click,
+            "confirm",
+            side_effect=AssertionError("unexpected prompt"),
+        ) as confirm,
+    ):
+        result = runner.invoke(test_handler.test, ["--suite", suite], obj=_sdk_context())
+
+    assert result.exit_code == 0
+    # Proves the refusal branch was taken -- without this the launch below could be
+    # passing because the context was accepted as a target.
+    assert FALLBACK_WARNING in result.output
+    assert REFUSAL not in result.output
+    run.assert_called_once()
+    confirm.assert_not_called()
+    environment = run.call_args.kwargs["env"]
+    assert "CHARIOT_TEST_PROFILE" not in environment
+    assert "CHARIOT_TEST_ACCOUNT" not in environment
+
+
+@pytest.mark.parametrize(
+    "entry_point", [cli_main.guard_main, cli_main.main], ids=["guard_main", "main"]
+)
+# Non-live only, deliberately. A live suite cannot exercise the assertion this test
+# exists for: any regression that emits FALLBACK_WARNING also refuses the live suite, so
+# exit_code fails first and the sentinel line is never reached -- measured, and it merely
+# duplicated test_every_public_live_path_propagates_confirmed_target_and_status. Do not
+# add "coherence" back.
+@pytest.mark.parametrize("suite", ["safe"])
+def test_public_routes_never_reach_the_target_inference_fallback(runner, entry_point, suite):
+    completed = SimpleNamespace(returncode=0)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, suite),
+            input="y\n",
+        )
+
+    # Reaching the launch is what makes the absence below load-bearing: the route ran
+    # end to end rather than dying before _test_target() could have warned.
+    assert result.exit_code == 0
+    run.assert_called_once()
+    assert FALLBACK_WARNING not in result.output

--- a/praetorian_cli/sdk/test/test_test_target.py
+++ b/praetorian_cli/sdk/test/test_test_target.py
@@ -1,0 +1,369 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from click.core import ParameterSource
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.test as test_handler
+import praetorian_cli.main as cli_main
+from praetorian_cli.sdk.test import utils
+
+
+@pytest.mark.parametrize(
+    ("profile", "account"),
+    [
+        (None, "account-123"),
+        ("", "account-123"),
+        ("United States", None),
+        ("United States", ""),
+    ],
+)
+def test_setup_chariot_requires_explicit_account(profile, account):
+    with patch.object(utils, "Keychain") as keychain, patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(ValueError, match="profile and account"):
+            utils.setup_chariot(profile, account)
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+
+
+def test_setup_chariot_requires_both_explicit_arguments():
+    with patch.object(utils, "Keychain") as keychain, patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(TypeError):
+            utils.setup_chariot()
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+
+
+def test_setup_chariot_propagates_selected_account_without_environment_fallback(monkeypatch):
+    selected_keychain = SimpleNamespace(profile="United States", account="account-123")
+    selected_chariot = object()
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "other-profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "other-account")
+
+    with patch.object(utils, "Keychain", return_value=selected_keychain) as keychain, \
+         patch.object(utils, "Chariot", return_value=selected_chariot) as chariot:
+        result = utils.setup_chariot("United States", "account-123")
+
+    assert result is selected_chariot
+    keychain.assert_called_once_with(profile="United States", account="account-123")
+    chariot.assert_called_once_with(selected_keychain)
+
+
+def test_setup_chariot_rejects_mismatched_target_before_sdk_construction():
+    mismatched_keychain = SimpleNamespace(profile="United States", account="other-account")
+
+    with patch.object(utils, "Keychain", return_value=mismatched_keychain), \
+         patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(ValueError, match="does not match"):
+            utils.setup_chariot("United States", "account-123")
+
+    chariot.assert_not_called()
+
+
+def test_selected_test_target_reads_exact_handler_environment(monkeypatch):
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "Selected Profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "selected-account")
+
+    assert utils.selected_test_target() == ("Selected Profile", "selected-account")
+
+
+@pytest.mark.parametrize(
+    ("profile", "account"),
+    [
+        (None, None),
+        ("Selected Profile", None),
+        (None, "selected-account"),
+        (" ", "selected-account"),
+        ("Selected Profile", " selected-account"),
+    ],
+)
+def test_selected_test_target_rejects_missing_partial_or_malformed_before_sdk(
+    monkeypatch,
+    profile,
+    account,
+):
+    for name, value in (
+        ("CHARIOT_TEST_PROFILE", profile),
+        ("CHARIOT_TEST_ACCOUNT", account),
+    ):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    with patch.object(utils, "Keychain") as keychain, \
+         patch.object(utils, "Chariot") as chariot, \
+         patch("praetorian_cli.sdk.keychain.requests.get") as network:
+        with pytest.raises(ValueError, match="profile and account"):
+            utils.selected_test_target()
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+    network.assert_not_called()
+
+
+def test_existing_setup_class_reaches_keychain_with_selected_target(monkeypatch):
+    from praetorian_cli.sdk.test.test_seed import TestSeed
+
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "Selected Profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "selected-account")
+    selected_keychain = SimpleNamespace(profile="Selected Profile", account="selected-account")
+    selected_chariot = object()
+
+    with patch.object(utils, "Keychain", return_value=selected_keychain) as keychain, \
+         patch.object(utils, "Chariot", return_value=selected_chariot) as chariot:
+        instance = TestSeed()
+        instance.setup_class()
+
+    assert instance.sdk is selected_chariot
+    keychain.assert_called_once_with(profile="Selected Profile", account="selected-account")
+    chariot.assert_called_once_with(selected_keychain)
+
+
+def test_z_cli_helpers_forward_confirmed_target_as_inert_argv(monkeypatch):
+    from praetorian_cli.sdk.test import test_z_cli
+
+    confirmed_profile = "Selected Profile; $(profile-command)"
+    confirmed_account = "selected+account;$(account-command)@example.com"
+    configured_default = "configured-default@example.com"
+    monkeypatch.setenv(utils.TEST_PROFILE_ENV, confirmed_profile)
+    monkeypatch.setenv(utils.TEST_ACCOUNT_ENV, confirmed_account)
+    sdk = SimpleNamespace(
+        keychain=SimpleNamespace(
+            profile=confirmed_profile,
+            account=configured_default,
+        )
+    )
+    child = Mock(
+        side_effect=[
+            SimpleNamespace(returncode=0, stdout='{"items": []}', stderr=""),
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ]
+    )
+
+    with patch.object(test_z_cli, "setup_chariot", return_value=sdk), patch.object(
+        test_z_cli, "run", child
+    ):
+        test_case = test_z_cli.TestZCli()
+        test_case.setup_class()
+        assert test_case.run_json('list assets -f "#asset#alpha beta"') == {"items": []}
+        test_case.verify('delete asset "#asset#alpha beta"')
+
+    expected_prefix = [
+        "guard",
+        "--profile",
+        confirmed_profile,
+        "--account",
+        confirmed_account,
+    ]
+    assert child.call_args_list[0].args[0] == expected_prefix + [
+        "list",
+        "assets",
+        "-f",
+        "#asset#alpha beta",
+    ]
+    assert child.call_args_list[1].args[0] == expected_prefix + [
+        "delete",
+        "asset",
+        "#asset#alpha beta",
+    ]
+    for call in child.call_args_list:
+        assert call.kwargs.get("shell", False) is False
+
+
+@pytest.mark.parametrize(
+    ("method", "command"),
+    [
+        ("run_json", "list assets"),
+        ("verify", "delete asset target"),
+    ],
+)
+def test_z_cli_helpers_fail_closed_without_confirmed_target(method, command):
+    from praetorian_cli.sdk.test import test_z_cli
+
+    child = Mock()
+    test_case = test_z_cli.TestZCli()
+    test_case.sdk = SimpleNamespace(
+        keychain=SimpleNamespace(profile="profile-default", account="account-default")
+    )
+
+    with patch.object(test_z_cli, "run", child):
+        with pytest.raises(ValueError, match="confirmed profile and account"):
+            getattr(test_case, method)(command)
+
+    child.assert_not_called()
+
+
+def test_test_handler_callback_stays_below_review_limit():
+    callback = inspect.unwrap(test_handler.test.callback)
+
+    assert len(inspect.getsourcelines(callback)[0]) < 50
+
+
+def test_suite_risk_is_explicit_for_every_suite():
+    expected = {
+        "safe": (True, False, False, False, False),
+        "coherence": (False, True, True, False, True),
+        "cli": (False, True, True, False, True),
+        "tui": (False, False, False, True, False),
+    }
+
+    assert set(test_handler.TEST_SUITES) == set(expected)
+    for name, risk in expected.items():
+        suite = test_handler.TEST_SUITES[name]
+        assert suite.name == name
+        assert (
+            suite.local_safe,
+            suite.live,
+            suite.mutating,
+            suite.tui,
+            suite.requires_target,
+        ) == risk
+        assert suite.pytest_selector
+
+
+def test_safe_suite_uses_an_explicit_keyless_selector():
+    suite = test_handler.TEST_SUITES["safe"]
+
+    assert suite.pytest_selector == ("-m", "not coherence and not cli and not tui")
+    assert suite.local_safe is True
+    assert suite.requires_target is False
+
+
+# The Click layer is where the --profile default is injected, so the explicit-target
+# gate can only be exercised through the public entry points. `guard` is the shipped
+# console script (setup.cfg: guard = praetorian_cli.main:guard_main); under the legacy
+# `praetorian` entry point the same command sits under the `chariot` group.
+ENTRY_POINTS = [(cli_main.guard_main, []), (cli_main.main, ['chariot'])]
+ENTRY_POINT_IDS = ['guard_main', 'main']
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _coherence_argv(command_path, *root_options):
+    return [*root_options, *command_path, 'test', '--suite', 'coherence']
+
+
+def _invoke_gated(runner, entry_point, argv):
+    """Drive the public CLI with the live-suite launcher armed to fail loudly.
+
+    `--suite coherence` creates, mutates and deletes real entities in a real Guard
+    account. Nothing here may reach subprocess.run, and the confirmation prompt --
+    if the gate ever lets execution get that far -- is answered with a refusal.
+    """
+    with patch.object(
+        test_handler.subprocess,
+        'run',
+        side_effect=AssertionError('a live, mutating suite was launched'),
+    ) as run:
+        result = runner.invoke(entry_point, argv, input='n\n')
+    return result, run
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_defaulted_profile(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(command_path, '--account', 'someone@example.com'),
+    )
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous profile is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_accepts_explicitly_passed_default_profile(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(
+            command_path,
+            '--profile',
+            'United States',
+            '--account',
+            'someone@example.com',
+        ),
+    )
+
+    assert 'Suite: coherence' in result.output
+    assert 'Profile: United States' in result.output
+    assert 'MUTATING' in result.output
+    assert result.exit_code == 1
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_missing_target_entirely(runner, entry_point, command_path):
+    result, run = _invoke_gated(runner, entry_point, _coherence_argv(command_path))
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous profile is required' in result.output
+    assert 'unambiguous account' not in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_defaulted_account(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(command_path, '--profile', 'Canada'),
+    )
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous account is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ('profile', 'account', 'label'),
+    [
+        ('', 'a@b.c', 'profile'),
+        (' United States ', 'a@b.c', 'profile'),
+        ('United States', '', 'account'),
+    ],
+    ids=['empty-profile', 'untrimmed-profile', 'empty-account'],
+)
+def test_coherence_suite_rejects_blank_or_untrimmed_explicit_values(runner, profile, account, label):
+    result, run = _invoke_gated(
+        runner,
+        cli_main.guard_main,
+        _coherence_argv([], '--profile', profile, '--account', account),
+    )
+
+    assert result.exit_code == 2
+    assert f'an explicit, unambiguous {label} is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'argv',
+    [['test'], ['test', '--suite', 'safe']],
+    ids=['implicit-default', 'explicit-safe'],
+)
+def test_safe_suite_needs_no_explicit_target(runner, argv):
+    with patch.object(test_handler.subprocess, 'run', return_value=Mock(returncode=0)) as run:
+        result = runner.invoke(cli_main.guard_main, argv, input='n\n')
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    assert 'explicit, unambiguous' not in result.output
+
+
+def test_supplied_only_honours_commandline_and_environment_sources():
+    assert cli_main.SUPPLIED_PARAMETER_SOURCES == (
+        ParameterSource.COMMANDLINE,
+        ParameterSource.ENVIRONMENT,
+    )
+    assert ParameterSource.DEFAULT not in cli_main.SUPPLIED_PARAMETER_SOURCES
+    assert ParameterSource.DEFAULT_MAP not in cli_main.SUPPLIED_PARAMETER_SOURCES
+    assert ParameterSource.PROMPT not in cli_main.SUPPLIED_PARAMETER_SOURCES

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -1,0 +1,2063 @@
+"""Contract for the best-effort update advisory in `@cli_handler`.
+
+Offline only: every test redirects `XDG_CACHE_HOME` at `tmp_path` and replaces
+`requests.get`, so no test reaches pypi.org or the real user cache directory.
+
+Three properties carry most of the weight here, because each of them was a real
+defect that reached a release:
+
+* the advisory is *throttled by the record of the attempt*, not by the record of
+  a success -- so the count of `requests.get` calls, not the presence of a cache
+  file, is what these tests assert,
+* the interactivity gate reads BOTH stdout and stderr, so `guard ... | jq` (a
+  piped stdout with stderr still a tty) is skipped,
+* a group callback that is merely delegating to a subcommand does not advise --
+  otherwise the advisory prints before the work the user asked for, and prints
+  twice when that subcommand succeeds.
+"""
+
+import json
+import os
+import stat
+import threading
+from collections import namedtuple
+from concurrent.futures import CancelledError
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.cli_decorators import (
+    UPDATE_CHECK_CACHE_MAX_BYTES,
+    UPDATE_CHECK_CACHE_TTL_SECONDS,
+    UPDATE_CHECK_DEADLINE_SECONDS,
+    UPDATE_CHECK_RESPONSE_MAX_BYTES,
+)
+
+
+UPDATE_URL = "https://pypi.org/pypi/praetorian-cli/json"
+DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
+CHECKED_AT = 1_700_000_000.0
+LOCAL_VERSION = "1.0.0"
+
+# The three lines the advisory prints when pypi is ahead of the local install.
+ADVISORY_FRAGMENTS = (
+    "A new version of praetorian-cli is available",
+    "You are currently running",
+    'pip install --upgrade praetorian-cli',
+)
+# The one fragment that appears exactly once per advisory, so counting it counts
+# advisories.
+ADVISORY_LEAD = ADVISORY_FRAGMENTS[0]
+
+# The exact call `_fetch_latest_version` makes. Asserted in full rather than as
+# "the URL, with some timeout", because three of these four arguments are
+# load-bearing and each was added for a measured reason: `stream=True` is what
+# leaves the body unread until the size cap has been applied to it, and
+# `Accept-Encoding: identity` is what makes a cap on RAW bytes a cap on the bytes
+# that actually get parsed -- a compressed body is capped on the wire and then
+# expanded without any bound at all, which a gzip bomb walks straight through
+# (measured: 55 KiB of wire peaking 131x past the 1 MiB ceiling). A call
+# assertion naming only the URL and the timeout would let any of them be dropped
+# again in silence.
+FETCH_ARGS = (UPDATE_URL,)
+FETCH_KWARGS = {
+    "timeout": 2,
+    "stream": True,
+    "headers": {"Accept-Encoding": "identity"},
+}
+
+
+def _assert_fetched_once(request):
+    """Exactly one fetch, made with the whole documented request shape."""
+    assert request.call_count == 1
+    assert request.call_args.args == FETCH_ARGS
+    assert request.call_args.kwargs == FETCH_KWARGS
+
+# The 0700/0600 guarantees are POSIX mode bits. Windows has no equivalent, and
+# `Path.chmod` there is close to a no-op -- so these are skipped rather than
+# deleted, which would drop the guarantee on the platforms that do enforce it.
+posix_modes_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX mode bits are not enforced on this platform"
+)
+
+# Creating a *directory* symlink needs a privilege or developer mode off POSIX, so
+# the symlink cases are skipped there rather than deleted -- the rejection they
+# pin is what keeps a hostile pre-created cache directory from being written to.
+symlinks_only = pytest.mark.skipif(
+    os.name != "posix", reason="creating a directory symlink is not unprivileged off POSIX"
+)
+
+# `/dev/fd` is how this process's open descriptors are counted. Linux and macOS
+# both have it; elsewhere there is nothing to count, so the leak test is skipped.
+fd_counting_only = pytest.mark.skipif(
+    not os.path.isdir("/dev/fd"), reason="descriptor counting needs /dev/fd"
+)
+
+# The cache write has two arms, chosen by `_cache_dir_descriptor_supported()`: a
+# directory-descriptor arm, and a path fallback for the platforms without the
+# descriptor primitives. The fallback is always reachable -- deleting `os.fchmod`
+# simulates it -- but the descriptor arm cannot be simulated where the primitives
+# do not exist, so cases specific to it are skipped there.
+descriptor_writes_only = pytest.mark.skipif(
+    not (hasattr(os, "O_NOFOLLOW") and hasattr(os, "fchmod")),
+    reason="the directory-descriptor arm needs os.O_NOFOLLOW and os.fchmod",
+)
+
+# A planted FIFO at the cache path is the availability vector that has no
+# exception to catch: it parks `open()` in the kernel until a writer arrives.
+fifos_only = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="planting a FIFO needs os.mkfifo"
+)
+
+# `os.mknod` is not available unprivileged, so the device vector is reached with a
+# symlink to a device that already exists. `/dev/zero` is the worst case on
+# purpose: an unbounded read of it returns bytes forever.
+DEVICE_PATH = "/dev/zero"
+
+
+def _is_character_device(path: str) -> bool:
+    try:
+        return stat.S_ISCHR(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+
+character_devices_only = pytest.mark.skipif(
+    not _is_character_device(DEVICE_PATH),
+    reason=f"{DEVICE_PATH} is not a character device on this platform",
+)
+
+
+def _cache_path(cache_root: Path) -> Path:
+    return cache_root / "praetorian-cli" / "update-check.json"
+
+
+def _write_cache_record(cache_path: Path, checked_at, latest_version) -> None:
+    """Leave the cache record a previous invocation -- or a peer -- would have left."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps({"checked_at": checked_at, "latest_version": latest_version}),
+        encoding="utf-8",
+    )
+
+
+def _victim_directory(tmp_path: Path) -> Path:
+    """A directory this user owns, world-readable and non-empty.
+
+    Owned and writable ON PURPOSE: nothing but the module's own refusal stands
+    between a refresh and writing in here, so a missing refusal shows up as a
+    changed mode or a changed file rather than as an `OSError` the fail-open arm
+    would have swallowed. The mode is set explicitly, not left to umask, because
+    it is asserted afterwards.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keepme").write_bytes(b"not ours")
+    (victim / "keepme").chmod(0o644)
+    victim.chmod(0o755)
+    return victim
+
+
+def _symlinked_leaf_cache(tmp_path: Path):
+    """A cache root whose `praetorian-cli` leaf is a pre-created symlink.
+
+    Returns `(cache_root, victim)`. The target is a directory this user owns and
+    can write, so nothing but the leaf-symlink rejection stands between the
+    refresh and writing into it -- and it is world-readable and non-empty, so both
+    its mode and its contents are observable afterwards.
+    """
+    victim = _victim_directory(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    _cache_path(cache_root).parent.symlink_to(victim, target_is_directory=True)
+    return cache_root, victim
+
+
+class _RawBody:
+    """`response.raw`: the byte source `_fetch_latest_version` reads under a cap.
+
+    Every read is recorded, so a test can assert the body is read ONCE, bounded at
+    one byte PAST the ceiling -- which is the only way "over the ceiling" is
+    detectable at all -- and with decoding switched off.
+    """
+
+    def __init__(self, body: bytes):
+        self._remaining = body
+        self.reads = []
+
+    def read(self, amt=None, decode_content=None):
+        self.reads.append((amt, decode_content))
+        if amt is None:
+            chunk, self._remaining = self._remaining, b""
+        else:
+            chunk, self._remaining = self._remaining[:amt], self._remaining[amt:]
+        return chunk
+
+
+class _FakeResponse:
+    """The part of `requests.Response` that `_fetch_latest_version` actually uses.
+
+    Hand-written rather than a `Mock`, and that is the point of it: the fetch uses
+    the response as a CONTEXT MANAGER and reads BYTES off `.raw`, and a mock fakes
+    both shapes without holding them to anything -- `MagicMock.__enter__` hands
+    back another mock, and `raw.read(...)` hands back a mock whose `len()` raises
+    `TypeError` from inside the fail-open arm. So a mock turns "the fetch no
+    longer calls `.json()`" into either a vacuous pass or an unrelated failure,
+    while this fake turns it into a `TypeError` on the first shape that does not
+    match. `closed` is recorded because `stream=True` holds the connection open
+    until the response is closed, which makes leaking one a real defect rather
+    than a detail of the fake.
+    """
+
+    def __init__(self, body: bytes, status_error=None):
+        self.body = body
+        self.raw = _RawBody(body)
+        self.status_error = status_error
+        self.closed = False
+        self.entered = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, *_exception):
+        self.close()
+        return False
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        if self.status_error is not None:
+            raise self.status_error
+
+    def json(self):
+        raise AssertionError(
+            "the fetch must not call response.json(): it reads and decodes the "
+            "whole body, which is exactly what the size cap exists to prevent"
+        )
+
+
+def _payload(latest: str, releases=None) -> dict:
+    """A PyPI payload whose `releases` block is a decoy for `info.version`.
+
+    The default decoy carries a prerelease that outranks `info.version` and a key
+    `packaging` cannot parse at all, so an implementation that ranks release keys
+    instead of reading `info.version` either advertises the prerelease or raises
+    `InvalidVersion` into the fail-open arm -- and every test that uses this
+    fixture notices, not just the one that names the behaviour.
+    """
+    if releases is None:
+        releases = ["0.9.0", latest, "9.9.9rc1", "not-a-version"]
+    return {
+        "info": {"version": latest},
+        "releases": {key: [] for key in releases},
+    }
+
+
+def _response(latest: str = "1.1.0", releases=None, padded_to=None) -> _FakeResponse:
+    """The successful response for `latest`, as a real streamed-body response.
+
+    `padded_to` pads the encoded body out to exactly that many bytes with JSON
+    whitespace, which is how the size-cap boundary cases differ from an ordinary
+    payload in byte count and in nothing else.
+    """
+    body = json.dumps(_payload(latest, releases)).encode()
+    if padded_to is not None:
+        assert len(body) <= padded_to, "payload already exceeds the requested size"
+        body += b" " * (padded_to - len(body))
+        assert len(body) == padded_to
+    return _FakeResponse(body)
+
+
+def _response_without_info() -> _FakeResponse:
+    """The payload shape that raises `KeyError` inside `_fetch_latest_version`."""
+    return _FakeResponse(json.dumps({"releases": {"9.9.9": []}}).encode())
+
+
+def _error_response() -> _FakeResponse:
+    """A 500 from pypi.org: a body that parses fine, behind a failing status.
+
+    The body deliberately carries a plausible-looking version, so a
+    `_fetch_latest_version` that skipped `raise_for_status()` would advertise an
+    error page's contents as the latest release.
+    """
+    return _FakeResponse(
+        json.dumps({"info": {"version": "9.9.9"}, "releases": {}}).encode(),
+        status_error=RuntimeError("500 Server Error"),
+    )
+
+
+def _configure_inputs(monkeypatch, cache_root: Path):
+    """Pin every input except the interactivity gate: cache root, opt-out, clock, version.
+
+    The environment variables the gate itself reads are cleared here too, so an
+    ambient `CI=true` on a developer's shell cannot silently turn a positive
+    assertion below into a vacuous one.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
+    monkeypatch.delenv(DISABLE_ENV, raising=False)
+    for name in ("CI", "GITHUB_ACTIONS", "TERM"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(decorators, "version", lambda _package: LOCAL_VERSION)
+    monkeypatch.setattr(decorators.time, "time", lambda: CHECKED_AT)
+    return decorators
+
+
+def _configure_update_check(monkeypatch, cache_root: Path, interactive: bool = True):
+    """`_configure_inputs`, plus a forced answer for the interactivity gate.
+
+    The gate force is the load-bearing part, and it belongs in this shared helper
+    rather than in each test. `_session_is_interactive()` requires BOTH
+    `sys.stdout.isatty()` and `sys.stderr.isatty()`, and `CliRunner` replaces both
+    with non-tty buffers -- so inside *any* `CliRunner.invoke` the real gate is
+    closed and the advisory returns before it does anything. A helper that forced
+    only one of the two streams would leave it closed and every positive assertion
+    below would pass vacuously, including the ones asserting that a request is
+    *not* made, which would then prove nothing at all. Replacing the whole
+    predicate also means a future third condition cannot silently reopen that
+    hole.
+
+    The real predicate is not left untested by this: it has its own tests, which
+    deliberately do not use this helper -- see
+    `test_update_check_requires_both_streams_to_be_a_terminal` and
+    `test_update_check_skipped_by_non_interactive_environment`.
+    """
+    decorators = _configure_inputs(monkeypatch, cache_root)
+    monkeypatch.setattr(decorators, "_session_is_interactive", lambda: interactive)
+    return decorators
+
+
+def _successful_command(events=None):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        if events is not None:
+            events.append("command")
+        return "done"
+
+    return command
+
+
+def _group_with_leaf(events, leaf_fails=False):
+    """A real Click group in the shape production uses, plus one subcommand.
+
+    Mirrors `praetorian_cli/handlers/aegis.py`: `invoke_without_command=True` so
+    the bare group runs an interactive default, `@cli_handler` on the group
+    callback *and* on the leaf, and `@click.pass_context` so the callback can read
+    `ctx.invoked_subcommand`. That decorator stack is what puts two
+    `upgrade_check` wrappers on the path of a single `guard aegis list`.
+    """
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.group(invoke_without_command=True)
+    @cli_handler
+    @click.pass_context
+    def group(ctx, _sdk):
+        events.append("group")
+        if ctx.invoked_subcommand is None:
+            events.append("group-default")
+
+    @group.command("leaf")
+    @cli_handler
+    def leaf(_sdk):
+        events.append("leaf")
+        if leaf_fails:
+            raise click.ClickException("leaf failed")
+
+    return group
+
+
+class _Stream:
+    """The one method `_session_is_interactive` calls on `sys.stdout`/`sys.stderr`."""
+
+    def __init__(self, tty):
+        self._tty = tty
+
+    def isatty(self):
+        if self._tty == "raise":
+            raise ValueError("detached stream")
+        return self._tty
+
+
+class _SysShim:
+    """Stands in for the `sys` module so a tty can be simulated in-process.
+
+    `CliRunner` owns the real `sys.stdout`/`sys.stderr` for the duration of an
+    `invoke`, and there is no way to make its buffers report `isatty() is True`.
+    `_session_is_interactive` reads both streams off the module-global `sys`, so
+    replacing that global is how the tty cases become reachable at all -- and it
+    is what makes the *positive* case of these tests (a request IS made) real
+    rather than an artefact of a closed gate.
+    """
+
+    def __init__(self, stdout_tty, stderr_tty):
+        self.stdout = _Stream(stdout_tty)
+        self.stderr = _Stream(stderr_tty)
+
+
+def test_update_check_runs_after_success(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    events = []
+    request = Mock(
+        side_effect=lambda *args, **kwargs: (
+            events.append("request"),
+            _response(),
+        )[1]
+    )
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(events), obj=object())
+
+    assert result.exit_code == 0
+    assert events == ["command", "request"]
+
+
+def test_update_check_skips_unsuccessful_command(monkeypatch, tmp_path):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=AssertionError("update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        raise click.ClickException("command failed")
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 1
+    assert "command failed" in result.output
+    request.assert_not_called()
+
+
+def test_update_check_disabled_by_explicit_environment_switch(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, "1")
+    request = Mock(side_effect=AssertionError("disabled update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "TRUE", " yes ", "on"],
+    ids=["one", "true", "upper-true", "padded-yes", "on"],
+)
+def test_update_check_opt_out_accepts_conventional_truthy_values(
+    monkeypatch, tmp_path, value
+):
+    """This is a privacy opt-out, so it accepts what a user would plausibly export.
+
+    A user who exports `=true` and still gets network requests has been silently
+    overruled by a parsing detail. Case and surrounding whitespace are normalized
+    for the same reason.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, value)
+    request = Mock(side_effect=AssertionError("opted-out update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_not_called()
+    # Opting out is not merely quiet: nothing is written under the cache root
+    # either, because the check returns before the cache path is computed.
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    "value", ["0", "false", ""], ids=["zero", "false", "empty"]
+)
+def test_update_check_opt_out_ignores_values_that_do_not_mean_yes(
+    monkeypatch, tmp_path, value
+):
+    """The complement of the case above: a falsy value must not disable anything.
+
+    Without this, `="0"` reading as "set, therefore disabled" would silently
+    switch the advisory off for every user who wrote the value out explicitly.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, value)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+
+
+def test_update_check_uses_fresh_cached_result_without_network(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    request = Mock(side_effect=AssertionError("fresh cache must avoid network"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+    request.assert_not_called()
+
+
+def test_update_check_refreshes_stale_cached_result_once_with_short_timeout(
+    monkeypatch, tmp_path
+):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    request = Mock(return_value=_response("1.3.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["latest_version"] == "1.3.0"
+
+
+def test_update_check_reads_info_version_and_ignores_release_keys(monkeypatch, tmp_path):
+    """`info.version` is PyPI's latest STABLE release; the `releases` keys are not.
+
+    `max(Version(k) for k in releases)` ranks `2.0.0rc1` above `1.1.0`, so it would
+    nag every user to "upgrade" to a release candidate; and one unparseable key
+    (PyPI has them) raises `InvalidVersion` into the fail-open arm and silences the
+    advisory entirely. This payload contains both hazards, and the assertion is
+    that neither one is what gets advertised.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(
+        return_value=_response(
+            "1.1.0", releases=["1.1.0", "2.0.0rc1", "3.0.0.dev1", "not-a-version"]
+        )
+    )
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "A new version of praetorian-cli is available: 1.1.0" in result.output
+    assert "2.0.0rc1" not in result.output
+    assert "3.0.0.dev1" not in result.output
+    # The prerelease is not merely unadvertised, it is not cached either -- a
+    # cached prerelease would be served on every subsequent invocation for a day.
+    assert (
+        json.loads(_cache_path(tmp_path).read_text(encoding="utf-8"))["latest_version"]
+        == "1.1.0"
+    )
+
+
+def test_update_check_timeout_failure_is_fail_open(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=TimeoutError("version service unavailable"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    _assert_fetched_once(request)
+
+
+def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_path):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response())
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    @click.command()
+    @click.argument("target")
+    @click.option("--profile")
+    @click.option("--account")
+    @cli_handler
+    def command(_sdk, target, profile, account):
+        return target, profile, account
+
+    sentinels = ["SECRET_TARGET", "SECRET_PROFILE", "SECRET_ACCOUNT"]
+    result = CliRunner().invoke(
+        command,
+        [sentinels[0], "--profile", sentinels[1], "--account", sentinels[2]],
+        obj=object(),
+    )
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    request_repr = repr(request.call_args)
+    assert all(sentinel not in request_repr for sentinel in sentinels)
+
+
+_Replacement = namedtuple(
+    "_Replacement",
+    "mechanism raw_source raw_destination source_name destination_name "
+    "source_directory destination_directory",
+)
+
+
+def _directory_identity(entry) -> tuple:
+    """`(device, inode)` for a path or an open descriptor, or None for neither."""
+    if entry is None:
+        return None
+    info = os.stat(entry)
+    return (info.st_dev, info.st_ino)
+
+
+def _record_atomic_cache_replacements(monkeypatch):
+    """Record every atomic replacement a cache write performs, on either arm.
+
+    The two arms replace the record by different primitives -- `os.rename`
+    against a directory descriptor, and `os.replace` against full paths -- so
+    both are patched and each call is normalised to one shape. `source_directory`
+    and `destination_directory` are `(device, inode)` identities rather than path
+    strings, because "the same directory, so the rename is atomic" is a statement
+    about the directory the entry name is resolved against, which on the
+    descriptor arm is a descriptor and has no path at all.
+
+    The primitive actually used is recorded too, so a test can pin which arm ran
+    rather than merely that *something* replaced the file.
+    """
+    replacements = []
+    real_rename = os.rename
+    real_replace = os.replace
+
+    def record_rename(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        replacements.append(
+            _Replacement(
+                "os.rename",
+                str(source),
+                str(destination),
+                Path(source).name,
+                Path(destination).name,
+                _directory_identity(src_dir_fd),
+                _directory_identity(dst_dir_fd),
+            )
+        )
+        real_rename(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+
+    def record_replace(source, destination):
+        replacements.append(
+            _Replacement(
+                "os.replace",
+                str(source),
+                str(destination),
+                Path(source).name,
+                Path(destination).name,
+                _directory_identity(Path(source).parent),
+                _directory_identity(Path(destination).parent),
+            )
+        )
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "rename", record_rename)
+    monkeypatch.setattr(os, "replace", record_replace)
+    return replacements
+
+
+@pytest.mark.parametrize(
+    "descriptor_support",
+    [
+        pytest.param(True, marks=descriptor_writes_only, id="directory-descriptor"),
+        pytest.param(False, id="path-fallback"),
+    ],
+)
+def test_update_check_cached_payload_is_atomically_replaced_twice(
+    monkeypatch, tmp_path, descriptor_support
+):
+    """A refresh replaces the cache file TWICE, and every replace is atomic.
+
+    Two by design, not by accident: the first records the attempt *before* the
+    request goes out (which is what throttles a failing refresh), the second
+    records its result. Each one writes a temporary entry beside the destination
+    and then renames it over the destination in a single same-directory
+    operation, so a reader never sees a partially written file and neither leaves
+    the temp entry behind.
+
+    Both write arms are exercised, because the property is the atomicity and not
+    the call. Where the directory-descriptor primitives exist, the temporary is
+    created and renamed *relative to an open descriptor on the cache directory*
+    (`os.rename` with `src_dir_fd`/`dst_dir_fd`, which takes bare entry names and
+    never resolves the path a second time -- that second resolution is the TOCTOU
+    window). Where they do not -- Windows -- the fallback keeps `tempfile.mkstemp`
+    plus `os.replace` on full paths. Windows is simulated rather than skipped, for
+    the reason spelled out in
+    `test_update_check_survives_a_platform_without_os_fchmod`.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    if not descriptor_support:
+        monkeypatch.delattr(os, "fchmod", raising=False)
+    assert decorators._cache_dir_descriptor_supported() == descriptor_support
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text("malformed", encoding="utf-8")
+    cache_directory = _directory_identity(cache_path.parent)
+    request = Mock(return_value=_response("1.4.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    replacements = _record_atomic_cache_replacements(monkeypatch)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert len(replacements) == 2
+    for replacement in replacements:
+        assert replacement.mechanism == ("os.rename" if descriptor_support else "os.replace")
+        assert replacement.destination_name == cache_path.name
+        assert replacement.source_name != replacement.destination_name
+        assert replacement.source_directory == cache_directory
+        assert replacement.destination_directory == cache_directory
+        assert not (cache_path.parent / replacement.source_name).exists()
+        if descriptor_support:
+            # A descriptor-relative rename takes BARE entry names; a full path
+            # here would be resolved against the process cwd, not the descriptor.
+            assert replacement.raw_source == replacement.source_name
+            assert replacement.raw_destination == cache_path.name
+        else:
+            assert Path(replacement.raw_destination) == cache_path
+            assert Path(replacement.raw_source).parent == cache_path.parent
+    # No debris of any kind left beside the destination.
+    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert set(payload) == {"checked_at", "latest_version"}
+    assert isinstance(payload["checked_at"], (int, float))
+    assert payload["latest_version"] == "1.4.0"
+
+
+@posix_modes_only
+def test_update_check_cache_is_private_to_the_user(monkeypatch, tmp_path):
+    """0700 directory, 0600 file -- and the directory mode is *repaired*, not assumed.
+
+    The directory is pre-created world-readable, which is what a `mkdir` whose mode
+    was masked by the user's umask leaves behind. The explicit `chmod` after the
+    `mkdir` is the only thing that closes it, so this asserts the end state rather
+    than the call.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(mode=0o755)
+    request = Mock(return_value=_response("1.4.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert cache_path.exists()
+    assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_update_check_records_the_attempt_before_making_the_request(
+    monkeypatch, tmp_path
+):
+    """The throttle record is on disk *before* `requests.get` is entered.
+
+    Asserted from inside the mocked `get`, because the ordering is the whole
+    mechanism: a record written only after a successful response cannot throttle
+    the failures -- a timeout, an HTTP error, an unparseable payload, or a cache
+    directory that cannot be written -- which is how this reached pypi.org on
+    every single invocation. The previous known version rides along in that first
+    record, so a refresh that then fails keeps advertising what was already known.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    snapshots = []
+
+    def snapshot_then_respond(*_args, **_kwargs):
+        snapshots.append(json.loads(cache_path.read_text(encoding="utf-8")))
+        return _response("1.4.0")
+
+    request = Mock(side_effect=snapshot_then_respond)
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    assert snapshots == [{"checked_at": CHECKED_AT, "latest_version": "1.2.0"}]
+    # And the second record lands afterwards, carrying the fetched answer.
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": "1.4.0",
+    }
+
+
+def test_update_check_network_failure_is_throttled_across_invocations(
+    monkeypatch, tmp_path
+):
+    """An unreachable index is probed ONCE per TTL, not once per invocation.
+
+    The assertion is the request count across three separate invocations, not the
+    existence of a cache file: a cache written only on success leaves a file
+    behind on the *next* success while still probing on every failure, which is
+    exactly the defect this pins.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=OSError("name or service not known"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert ADVISORY_LEAD not in result.output
+
+    assert request.call_count == 1
+    assert json.loads(_cache_path(tmp_path).read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": None,
+    }
+
+
+@posix_modes_only
+@pytest.mark.skipif(
+    getattr(os, "geteuid", lambda: 1)() == 0, reason="root ignores directory permissions"
+)
+def test_update_check_unwritable_cache_directory_stays_off_the_network(
+    monkeypatch, tmp_path
+):
+    """Where the cache cannot be created at all, ZERO requests are made -- ever.
+
+    Not one per invocation, and not one-then-stop: an environment whose probe rate
+    cannot be limited is one that must not be probed. The read-only parent is a
+    read-only `$XDG_CACHE_HOME`, an immutable container image layer, or a cache
+    directory owned by another user.
+    """
+    read_only_root = tmp_path / "read-only"
+    read_only_root.mkdir(mode=0o500)
+    decorators = _configure_update_check(monkeypatch, read_only_root)
+    request = Mock(side_effect=AssertionError("unthrottleable environment must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    try:
+        for _ in range(3):
+            result = CliRunner().invoke(_successful_command(), obj=object())
+            assert result.exit_code == 0
+            assert result.exception is None
+
+        request.assert_not_called()
+        assert not _cache_path(read_only_root).parent.exists()
+    finally:
+        # Restore write permission so pytest's tmp_path cleanup can remove it.
+        read_only_root.chmod(0o700)
+
+
+def test_update_check_unwritable_cache_makes_no_request(monkeypatch, tmp_path):
+    """A cache write that fails mid-way stops the refresh AND leaves no debris.
+
+    Zero requests, not one: the write is the throttle, so a write that cannot
+    complete is the signal to stay off the network. The `finally:
+    temp_path.unlink(missing_ok=True)` is what keeps the failure from
+    accumulating a `mkstemp` leftover in the user's cache directory on every
+    invocation, and the previous cache file is left byte-for-byte intact because
+    `os.replace` was never reached.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    # Stale, so the refresh branch is the one taken and a write is attempted.
+    original_bytes = json.dumps({"checked_at": 0, "latest_version": "1.0.0"}).encode()
+    cache_path.write_bytes(original_bytes)
+    request = Mock(return_value=_response("1.6.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def failing_dump(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(decorators.json, "dump", failing_dump)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    # Fail open: the write failure never reaches the user or the exit status.
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
+    assert cache_path.read_bytes() == original_bytes
+
+
+def test_update_check_survives_a_platform_without_os_fchmod(monkeypatch, tmp_path):
+    """`os.fchmod` is POSIX-only, and the advisory must not depend on it.
+
+    Windows is simulated rather than skipped, because a skip is what let this
+    ship: an `os.fchmod` after `mkstemp` raised `AttributeError` there, the
+    fail-open arm swallowed it, the cache was therefore never written, and the
+    advisory hit pypi.org on every invocation while printing nothing at all.
+    `mkstemp` already creates its file 0600 regardless of umask, so nothing is
+    lost by not calling it.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    assert not hasattr(os, "fchmod")
+    request = Mock(return_value=_response("1.7.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    advisories = 0
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        advisories += result.output.count(ADVISORY_LEAD)
+
+    # Every invocation advises (the first from the network, the rest from the
+    # cache it wrote), and only the first one reaches the network.
+    assert advisories == 3
+    assert request.call_count == 1
+    assert (
+        json.loads(_cache_path(tmp_path).read_text(encoding="utf-8"))["latest_version"]
+        == "1.7.0"
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["os-error", "runtime-error", "http-error", "payload-without-info"],
+)
+def test_update_check_failed_refresh_retains_the_previous_version(
+    monkeypatch, tmp_path, failure
+):
+    """A refresh that fails keeps advertising the version already known.
+
+    Every failure shape must behave identically, and each is a different arm of
+    the fetch: an `OSError` and a `RuntimeError` out of the request itself, a
+    non-2xx response (`raise_for_status`), and a payload whose `info` key is
+    missing (a `KeyError` from inside `_fetch_latest_version`). In each case the
+    exception is swallowed -- the command still succeeds and says nothing about it
+    -- the stale `1.2.0` is retained rather than dropped (dropping it would
+    silence a real, still-valid advisory for a full TTL every time pypi.org
+    hiccuped), and `checked_at` still advances, so the failure is throttled just
+    like a success.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    if failure == "os-error":
+        request = Mock(side_effect=OSError("connection reset by peer"))
+    elif failure == "runtime-error":
+        request = Mock(side_effect=RuntimeError("connection pool exhausted"))
+    elif failure == "http-error":
+        request = Mock(return_value=_error_response())
+    else:
+        request = Mock(return_value=_response_without_info())
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    _assert_fetched_once(request)
+    assert result.output.count(ADVISORY_LEAD) == 1
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+    # Nothing about the failure itself reaches the user.
+    assert "9.9.9" not in result.output
+    assert "Error" not in result.output
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": "1.2.0",
+    }
+
+
+def test_update_check_fresh_unparseable_entry_is_silent_until_the_ttl_expires(
+    monkeypatch, tmp_path
+):
+    """An unparseable cached version throttles like any other record, then recovers.
+
+    A record whose version cannot be parsed is still a record of an attempt, so it
+    must not be treated as "no cache" -- that would probe on every invocation for
+    as long as the bad entry survived. It costs one TTL of silence, and no more:
+    once the entry ages out the refresh runs and the advisory returns.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": "not-a-version"}),
+        encoding="utf-8",
+    )
+    request = Mock(return_value=_response("1.8.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    inside_ttl = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert inside_ttl.exit_code == 0
+    assert inside_ttl.exception is None
+    assert inside_ttl.output == ""
+    request.assert_not_called()
+
+    # Age the entry past its TTL: the refresh now runs and the advisory recovers.
+    expired = CHECKED_AT + UPDATE_CHECK_CACHE_TTL_SECONDS + 1
+    monkeypatch.setattr(decorators.time, "time", lambda: expired)
+
+    after_ttl = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert after_ttl.exit_code == 0
+    _assert_fetched_once(request)
+    assert "A new version of praetorian-cli is available: 1.8.0" in after_ttl.output
+
+
+def test_update_check_fresh_null_version_entry_throttles(monkeypatch, tmp_path):
+    """`"latest_version": null` is a valid throttle record, not a corrupt one.
+
+    It is exactly what a failed refresh with nothing previously known writes, so
+    reading it as "unusable, refresh now" would turn every such failure into an
+    unthrottled probe on the very next invocation.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": None}),
+        encoding="utf-8",
+    )
+    request = Mock(side_effect=AssertionError("a null-version record still throttles"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+    request.assert_not_called()
+
+
+def test_update_check_skipped_when_session_is_not_interactive(monkeypatch, tmp_path):
+    """The advisory never runs for a session that is not a terminal.
+
+    ENG-6643's "never runs where it is inappropriate" criterion: a piped or
+    redirected session (a script, a cron job, a `2>` capture) must get no network
+    call and no cache file -- the advisory is for humans at a terminal only.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path, interactive=False)
+    request = Mock(side_effect=AssertionError("non-interactive session must not check"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    # Not merely no *fresh* cache: the check returns before the cache path is
+    # even computed, so nothing under XDG_CACHE_HOME is created or read.
+    assert not _cache_path(tmp_path).exists()
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("stdout_tty", "stderr_tty", "expect_request"),
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+        ("raise", True, False),
+    ],
+    ids=[
+        "both-tty",
+        "stdout-piped",
+        "stderr-redirected",
+        "neither-tty",
+        "isatty-raises",
+    ],
+)
+def test_update_check_requires_both_streams_to_be_a_terminal(
+    monkeypatch, tmp_path, stdout_tty, stderr_tty, expect_request
+):
+    """BOTH streams must be a terminal -- an stderr-only gate does not hold.
+
+    `guard list assets | jq` redirects stdout and leaves stderr a tty, which is
+    the piped, scripted, high-volume case whose cadence the gate exists to stop
+    leaking. This test deliberately does NOT use the shared gate force: it drives
+    the real `_session_is_interactive` through a substituted `sys`, so the
+    `both-tty` row is a genuine positive (a request IS made) and the other rows
+    are genuine negatives.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "sys", _SysShim(stdout_tty, stderr_tty))
+    request = Mock(return_value=_response("1.9.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    if expect_request:
+        _assert_fetched_once(request)
+        assert "A new version of praetorian-cli is available: 1.9.0" in result.output
+    else:
+        request.assert_not_called()
+        assert result.output == ""
+        assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [("CI", "1"), ("CI", "true"), ("GITHUB_ACTIONS", "1"), ("TERM", "dumb")],
+    ids=["ci-one", "ci-true", "github-actions", "term-dumb"],
+)
+def test_update_check_skipped_by_non_interactive_environment(
+    monkeypatch, tmp_path, name, value
+):
+    """A runner that allocates a pty is still not a human at a terminal.
+
+    Both streams are forced to report a tty here, so the tty gate is open and each
+    environment variable is the *only* thing that can close it -- which is what
+    makes each row independent rather than incidentally passing on the tty check.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "sys", _SysShim(True, True))
+    monkeypatch.setenv(name, value)
+    request = Mock(side_effect=AssertionError("CI session must not check for updates"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    assert result.output == ""
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+def test_update_check_future_timestamp_is_treated_as_stale(monkeypatch, tmp_path):
+    """A `checked_at` in the future is stale, so a bad clock cannot pin an answer.
+
+    One hour ahead is the mutant-killing value: it is *inside* the TTL window in
+    absolute terms, so a freshness test written as `age < TTL` without the
+    `0 <= age` lower bound would read this entry as fresh and serve it forever.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT + 3600, "latest_version": "9.9.9"}),
+        encoding="utf-8",
+    )
+    assert 3600 < UPDATE_CHECK_CACHE_TTL_SECONDS
+    request = Mock(return_value=_response("1.5.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    # The future-dated entry was neither served to the user nor left in place.
+    assert "9.9.9" not in result.output
+    assert "1.5.0" in result.output
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload == {"checked_at": CHECKED_AT, "latest_version": "1.5.0"}
+
+
+def test_update_check_skipped_when_group_delegates_to_a_failing_subcommand(
+    monkeypatch, tmp_path
+):
+    """A group callback delegating to a subcommand advises NOT AT ALL.
+
+    Click runs a group callback BEFORE its subcommand, so without this gate
+    `guard aegis list` printed the advisory ahead of the work the user asked for
+    -- and still printed it when that work then failed, which is the one moment a
+    user least wants an unrelated nag. Measured on the ungated code: the advisory
+    appeared before the leaf ran and the request went out even though the command
+    exited non-zero.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
+
+    result = CliRunner().invoke(_group_with_leaf(events, leaf_fails=True), ["leaf"], obj=object())
+
+    assert result.exit_code == 1
+    assert "leaf failed" in result.output
+    assert events == ["group", "leaf"]
+    request.assert_not_called()
+    for fragment in ADVISORY_FRAGMENTS:
+        assert fragment not in result.output
+
+
+def test_update_check_advises_exactly_once_for_a_succeeding_subcommand(
+    monkeypatch, tmp_path
+):
+    """Two `upgrade_check` wrappers on one invocation must still advise once.
+
+    `guard aegis list` runs the group callback's check and the leaf's check. The
+    group's is the one that is skipped, so the user gets exactly one advisory --
+    measured on the ungated code, the same invocation printed all three lines
+    twice.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
+
+    result = CliRunner().invoke(_group_with_leaf(events), ["leaf"], obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert events == ["group", "leaf"]
+    for fragment in ADVISORY_FRAGMENTS:
+        assert result.output.count(fragment) == 1
+    _assert_fetched_once(request)
+
+
+def test_update_check_advises_once_for_a_bare_group_invocation(monkeypatch, tmp_path):
+    """Skipping delegation does not silence the group's own default path.
+
+    `invoke_without_command=True` groups do real work when called bare (the TUI
+    entry points), so that invocation is a leaf as far as the advisory is
+    concerned. A gate keyed on "is a group" rather than "is delegating" would lose
+    it.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
+
+    result = CliRunner().invoke(_group_with_leaf(events), [], obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert events == ["group", "group-default"]
+    for fragment in ADVISORY_FRAGMENTS:
+        assert result.output.count(fragment) == 1
+    _assert_fetched_once(request)
+
+
+class _SentinelBaseException(BaseException):
+    """A `BaseException` that is nothing else: not process control, not `Exception`.
+
+    Its only job is to prove the fetch's guard is written against `BaseException`
+    and not against a list of known classes -- an `except Exception` there, or an
+    `except (Exception, KeyboardInterrupt, SystemExit)`, would let this one out.
+    """
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        RuntimeError("boom"),
+        OSError("offline"),
+        KeyboardInterrupt(),
+        SystemExit(73),
+        CancelledError("cancelled"),
+        _SentinelBaseException("stop"),
+    ],
+    ids=[
+        "runtime-error",
+        "os-error",
+        "keyboard-interrupt",
+        "system-exit",
+        "cancelled",
+        "base-exception",
+    ],
+)
+@pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")
+def test_update_check_abandons_a_fetch_that_raises_anything(monkeypatch, tmp_path, exception):
+    """Whatever class the fetch raises, the fetch is abandoned and the command is untouched.
+
+    This is the guarantee the fetch seam actually offers, and it is unconditional
+    in the exception's class. The fetch runs on a worker thread
+    (`_fetch_latest_version_within_deadline`) whose body is
+    `except BaseException: pass`, so an advisory that cannot answer simply does
+    not answer: no version, no advisory, and nothing raised into the command's
+    result. The alternative -- re-raising the worker's exception in the main
+    thread -- would let an unreachable PyPI turn every successful command into a
+    failure, which is the whole reason the advisory is fail-open.
+
+    The class list is the point rather than decoration. `RuntimeError` and
+    `OSError` are what a real fetch fails with; the next three are the classes the
+    suite used to assert *propagate* from here (they do not, and cannot: SIGINT is
+    delivered to the main thread only, `SystemExit` in a non-main thread ends that
+    thread alone, and there is no future or event loop in a raw `threading.Thread`
+    to inject a `CancelledError`); and `_SentinelBaseException` covers the rest of
+    the hierarchy, so narrowing the guard to any enumerated set fails here.
+
+    `result.output == ""` pins that nothing reached the user: no advisory, because
+    there is no version to advise about, and no error either.
+
+    The `filterwarnings` mark is the other half, and it is load-bearing rather
+    than hygiene. If the worker's guard were narrowed, the exception would escape
+    the thread instead of the command -- so every assertion above would still
+    hold, and the test would pass over the regression. What actually happens then
+    is `threading.excepthook`, which on the real CLI prints a bare traceback onto
+    the user's stderr after a command that succeeded (and for `SystemExit` prints
+    nothing at all, killing the fetch thread silently). Under pytest that hook is
+    replaced by the threadexception plugin, which turns an escaped thread
+    exception into a warning; promoting that warning to an error is what lets this
+    test see it. Measured: narrowing `except BaseException` to `except Exception`
+    reddens the `keyboard-interrupt`, `system-exit` and `base-exception` cases and
+    is silent without the mark.
+
+    Where each of these *is* still expected to surface is pinned separately: at
+    the main-thread cache read below, at the cache write after that, and at the
+    CLI boundary in test_cli_errors.py.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=exception)
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+    _assert_fetched_once(request)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [KeyboardInterrupt(), SystemExit(73), CancelledError("cancelled")],
+    ids=["keyboard-interrupt", "system-exit", "cancelled"],
+)
+def test_update_check_propagates_process_control_from_the_cache_read(
+    monkeypatch, tmp_path, exception
+):
+    """The fail-open arms swallow failures, not process control.
+
+    `_read_update_check_cache` narrows its arm to
+    `except (KeyError, OSError, TypeError, ValueError)`, and all three of these
+    fall outside it. Widening it to `except Exception` would swallow the
+    cancellation; a bare `except:` would swallow all three and report a cancelled
+    or exiting command as a clean success.
+
+    Anchored on the cache read because the read is a MAIN-THREAD step and the
+    fetch is not. This test used to inject at `requests.get`, which is now the
+    wrong seam twice over: the worker discards whatever it raises (see
+    `test_update_check_abandons_a_fetch_that_raises_anything`), and none of these
+    three can arise inside a worker blocked in a socket read in the first place.
+    The read is where a Ctrl-C, a `sys.exit()` from a signal handler, or a
+    cancellation of the surrounding task genuinely can land.
+
+    The record is seeded so the read has something to parse -- a missing file
+    returns before `json.loads` is reached. Seeding it STALE and arming the fetch
+    to fail loudly makes `request.assert_not_called()` a real guard: if the read
+    ever stopped raising, control would fall through to the refresh and the test
+    would fail at the fetch rather than passing vacuously.
+
+    Called directly rather than through `CliRunner`, because the claim is about
+    what leaves `_check_for_update`; Click's standalone mode would translate each
+    of these into an exit status and hide which one escaped. What the CLI then
+    does with each is a separate contract, pinned in test_cli_errors.py:
+    `SystemExit` and `CancelledError` become the exit status, while
+    `KeyboardInterrupt` is caught by `upgrade_check` so a command that already
+    succeeded still exits 0.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(
+        _cache_path(tmp_path), CHECKED_AT - UPDATE_CHECK_CACHE_TTL_SECONDS - 1, "1.1.0"
+    )
+    request = Mock(side_effect=AssertionError("must not be reached"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def raise_during_the_read(*_args, **_kwargs):
+        raise exception
+
+    monkeypatch.setattr(decorators.json, "loads", raise_during_the_read)
+
+    with pytest.raises(type(exception)) as raised:
+        decorators._check_for_update()
+
+    assert raised.value is exception
+    request.assert_not_called()
+
+
+def test_update_check_propagates_cancellation_from_the_cache_write(monkeypatch, tmp_path):
+    """Cancellation during the *write* propagates too, not just during the read.
+
+    The write has its own fail-open arm (it returns False rather than raising, so
+    the caller can treat a failed write as "stay off the network"), which is
+    exactly the shape that would turn a cancelled command into a silent success.
+
+    The write is the second main-thread step of the advisory, after the read
+    pinned above; the fetch is not one at all, so it is deliberately not the
+    comparison here.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cancelled = CancelledError("cancelled")
+    monkeypatch.setattr(
+        decorators.requests, "get", Mock(side_effect=AssertionError("must not be reached"))
+    )
+
+    def cancelling_dump(*_args, **_kwargs):
+        raise cancelled
+
+    monkeypatch.setattr(decorators.json, "dump", cancelling_dump)
+
+    with pytest.raises(CancelledError) as raised:
+        decorators._check_for_update()
+
+    assert raised.value is cancelled
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [PackageNotFoundError("praetorian-cli"), RuntimeError("boom"), OSError("offline")],
+    ids=["package-not-found", "runtime-error", "os-error"],
+)
+def test_update_check_failure_after_the_fetch_is_still_fail_open(
+    monkeypatch, tmp_path, exception
+):
+    """A failure raised OUTSIDE the fetch is swallowed too -- by the outer arm.
+
+    This is the complement of the propagation test above, and it needs a failure
+    that is not network-shaped: the fetch has its own guard, so every request-side
+    failure is caught before the outer arm is reachable, which would leave that
+    arm -- the one that decides whether the advisory can break a command at all --
+    with nothing pinning it.
+
+    Reading the local version is the realistic somewhere-else.
+    `importlib.metadata.version` raises `PackageNotFoundError` whenever the CLI
+    runs from a source tree with no installed distribution, which is the normal
+    state of a developer checkout; that must not turn a command the user already
+    completed into a failure.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators.requests, "get", Mock(return_value=_response("1.2.0")))
+
+    def failing_version(_package):
+        raise exception
+
+    monkeypatch.setattr(decorators, "version", failing_version)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+
+
+def test_update_check_unparseable_local_version_is_silent(monkeypatch, tmp_path):
+    """An unparseable *local* version is swallowed as well, not raised.
+
+    Editable installs and vendored builds produce version strings `packaging`
+    rejects, and the comparison against them is outside the fetch guard -- so
+    `InvalidVersion` would escape as a command failure without the outer arm.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "version", lambda _package: "not-a-version")
+    monkeypatch.setattr(decorators.requests, "get", Mock(return_value=_response("1.2.0")))
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+
+
+@pytest.mark.parametrize(
+    "remote_version",
+    ["1.0.0", "0.9.0"],
+    ids=["remote-equals-local", "remote-older-than-local"],
+)
+def test_update_check_advisory_is_silent_when_local_version_is_current(
+    monkeypatch, tmp_path, remote_version
+):
+    """No advisory unless pypi is strictly ahead: `>`, not `!=` and not `>=`.
+
+    The local version is pinned at 1.0.0, so an equal remote is the boundary case
+    a `>=` comparison would get wrong, and an older remote is what a `!=`
+    comparison would get wrong -- both would nag a user who is already current.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response(remote_version))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    # `output` is the interleaved stdout+stderr stream and the command itself
+    # prints nothing, so total emptiness is assertable -- a stronger claim than
+    # the absence of the three fragments alone.
+    assert result.output == ""
+    for fragment in ADVISORY_FRAGMENTS:
+        assert fragment not in result.output
+
+
+# --------------------------------------------------------------------------- #
+# `XDG_CACHE_HOME` that is not an absolute path.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "cache_home",
+    ["relative-cache", "./relative-cache", ""],
+    ids=["relative", "dot-relative", "empty"],
+)
+def test_update_check_non_absolute_xdg_cache_home_falls_back_to_the_home_cache(
+    monkeypatch, tmp_path, cache_home
+):
+    """A non-absolute `XDG_CACHE_HOME` is ignored, per the XDG base-directory spec.
+
+    Honouring it would resolve the cache against the *current working directory*,
+    so `guard` would scatter a cache directory into whatever tree the user happened
+    to be standing in -- and, worse, would read a throttle record written by
+    whoever else can write there. The empty value is the case that was already
+    correct and is easy to break, since it is falsey rather than non-absolute.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    working_dir = tmp_path / "cwd"
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("XDG_CACHE_HOME", cache_home)
+    request = Mock(return_value=_response("2.0.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    resolved = decorators._update_check_cache_path()
+
+    assert resolved.is_absolute()
+    assert resolved == fake_home / ".cache" / "praetorian-cli" / "update-check.json"
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    assert "A new version of praetorian-cli is available: 2.0.0" in result.output
+    assert json.loads(resolved.read_text(encoding="utf-8"))["latest_version"] == "2.0.0"
+    # Nothing was resolved against the working directory.
+    assert list(working_dir.iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
+# A cache directory that is a symlink.
+# --------------------------------------------------------------------------- #
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_directory_stays_off_the_network(
+    monkeypatch, tmp_path
+):
+    """A cache directory that is a symlink is refused, so ZERO requests are made.
+
+    This is the consequence that actually matters: the write is the throttle, so a
+    cache directory that cannot be written is an environment whose probe rate
+    cannot be limited -- and it must not be probed at all, not once per invocation.
+    Three invocations, because a rejection that failed to stop the fetch would show
+    up as a request every time rather than only on the first.
+    """
+    cache_root, _victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(side_effect=AssertionError("a symlinked cache directory must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert ADVISORY_LEAD not in result.output
+
+    request.assert_not_called()
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_directory_writes_nothing_into_the_target(
+    monkeypatch, tmp_path
+):
+    """Nothing is created inside the symlink target -- not the record, not a temp file.
+
+    A pre-created symlink is how an attacker who can write the cache path but not
+    the target aims a privileged write somewhere else; `mkstemp` plus `os.replace`
+    would follow the link and land both files in the target directory.
+    """
+    cache_root, victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(side_effect=AssertionError("a symlinked cache directory must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert sorted(p.name for p in victim.iterdir()) == ["keepme"]
+    assert (victim / "keepme").read_bytes() == b"not ours"
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+@symlinks_only
+@posix_modes_only
+def test_update_check_symlinked_cache_directory_keeps_the_targets_mode(
+    monkeypatch, tmp_path
+):
+    """The target's mode is unchanged: the 0700 repair does not follow the link.
+
+    The directory preparation deliberately *repairs* a too-permissive mode, which
+    is exactly why the symlink case has to be refused before it runs -- otherwise
+    the repair reaches through the link and re-modes a directory that is none of
+    its business.
+    """
+    cache_root, victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(return_value=_response("2.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    assert result.exit_code == 0
+
+
+@symlinks_only
+def test_update_check_write_to_a_symlinked_cache_directory_reports_failure(
+    monkeypatch, tmp_path
+):
+    """`_write_update_check_cache` reports the refusal, rather than claiming success.
+
+    The return value is what the caller reads to decide whether to fetch, so a
+    refusal reported as success would restore the unthrottled probe -- the network
+    assertion above is downstream of this one.
+    """
+    cache_root, _victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+
+    assert not decorators._write_update_check_cache(
+        _cache_path(cache_root), CHECKED_AT, "1.2.0"
+    )
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_ancestor_still_works(monkeypatch, tmp_path):
+    """The rejection is scoped to the leaf: a symlinked ANCESTOR still works.
+
+    A symlinked `~/.cache` is a normal dotfile-manager or shared-cache-volume
+    setup, and rejecting it would silently disable the advisory for those users.
+    The leaf is the component the module creates itself, so it is the only one it
+    can hold to having not been pre-created by somebody else.
+    """
+    real_cache = tmp_path / "real-cache"
+    real_cache.mkdir()
+    linked_cache = tmp_path / "linked-cache"
+    linked_cache.symlink_to(real_cache, target_is_directory=True)
+    decorators = _configure_update_check(monkeypatch, linked_cache)
+    request = Mock(return_value=_response("2.1.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    _assert_fetched_once(request)
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 2.1.0" in result.output
+    assert json.loads(
+        _cache_path(real_cache).read_text(encoding="utf-8")
+    )["latest_version"] == "2.1.0"
+
+
+# --------------------------------------------------------------------------- #
+# The leaf directory swapped for a symlink MID-FLIGHT.
+#
+# The section above plants the symlink before the run starts, which a check
+# ordered before the first write already catches. These two plant it in the
+# window the module opens itself: between creating the leaf and using it. Anything
+# that names the leaf BY PATH after that point resolves the attacker's link, so
+# what is asserted here is the VICTIM -- its mode and its bytes -- and not merely
+# the returned False, which one of the two windows already returned before the fix.
+# --------------------------------------------------------------------------- #
+
+
+def _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, leaf: Path, victim: Path):
+    """Hand the race to the attacker: swap `leaf` for a symlink as its `mkdir` returns.
+
+    `Path.mkdir` is the moment the leaf comes into existence and the last moment
+    before anything looks at it, so it is the window a racing attacker actually
+    gets. Returns the (single-element) record of the swap, so a test can prove the
+    race was RUN -- a swap that never fired would leave every assertion below
+    passing over an ordinary directory.
+
+    Fires once, deliberately: the module tolerates `FileExistsError` and retries
+    against whatever now sits at the path, and that second look must refuse it too.
+    """
+    real_mkdir = Path.mkdir
+    swapped = []
+
+    def mkdir(self, *args, **kwargs):
+        real_mkdir(self, *args, **kwargs)
+        if not swapped and self == leaf:
+            self.rmdir()
+            self.symlink_to(victim, target_is_directory=True)
+            swapped.append(str(self))
+
+    monkeypatch.setattr(Path, "mkdir", mkdir)
+    return swapped
+
+
+@symlinks_only
+@posix_modes_only
+@descriptor_writes_only
+def test_update_check_leaf_swapped_after_mkdir_leaves_the_targets_mode(
+    monkeypatch, tmp_path
+):
+    """Losing the race at `mkdir` refuses -- and does NOT re-mode the target.
+
+    The 0700 repair is the payload here. Validating the leaf by PATH and then
+    re-moding it by PATH resolves it twice, and the swap lands between the two: the
+    repair reaches through the link and locks a directory that is none of our
+    business down to 0700 (measured on the pre-fix code: 0o755 -> 0o700). Holding a
+    DESCRIPTOR across both steps is what closes it -- `os.fstat` and `os.fchmod`
+    address the inode that was vetted, and cannot be redirected by a later swap.
+
+    The mode is the assertion, not the return value: the return was already False
+    in this window before the fix, while the victim had already been re-moded.
+
+    Scoped to the descriptor arm because that is the only arm that CAN close this
+    window -- measured, forcing `_cache_dir_descriptor_supported()` false fails
+    both of these -- and every platform with POSIX mode bits has the primitives.
+    """
+    victim = _victim_directory(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    cache_path = _cache_path(cache_root)
+    swapped = _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, cache_path.parent, victim)
+
+    prepared = decorators._prepare_update_check_cache_dir(cache_path)
+
+    assert swapped, "the race never ran: the leaf mkdir was not reached"
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    assert sorted(p.name for p in victim.iterdir()) == ["keepme"]
+    assert not prepared
+
+
+@symlinks_only
+@posix_modes_only
+@descriptor_writes_only
+def test_update_check_leaf_swapped_after_mkdir_leaves_the_targets_file(
+    monkeypatch, tmp_path
+):
+    """The same swap through the WRITE: the target's own file survives it untouched.
+
+    A cache record the attacker has aimed elsewhere is not only a write in the
+    wrong directory -- it OVERWRITES whatever already answers to that name there,
+    with our bytes and our 0600 (measured on the pre-fix code: `b"not ours"` at
+    0o644 became our JSON at 0o600, destroying a file and closing it to its own
+    group). The write therefore re-validates on its own terms rather than trusting
+    its caller, and addresses the record by `dir_fd` so the directory it vetted is
+    the directory it writes in.
+    """
+    victim = _victim_directory(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    cache_path = _cache_path(cache_root)
+    # Same NAME the record would be written under, so an unvalidated write
+    # clobbers it rather than landing beside it.
+    planted = victim / cache_path.name
+    planted.write_bytes(b"not ours")
+    planted.chmod(0o644)
+    swapped = _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, cache_path.parent, victim)
+
+    written = decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+
+    assert swapped, "the race never ran: the leaf mkdir was not reached"
+    assert planted.read_bytes() == b"not ours"
+    assert stat.S_IMODE(planted.stat().st_mode) == 0o644
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    # No temporary left behind in the target either, which is where `mkstemp`
+    # would have put it.
+    assert sorted(p.name for p in victim.iterdir()) == sorted(["keepme", cache_path.name])
+    assert not written
+
+
+# --------------------------------------------------------------------------- #
+# A hostile cache RECORD.
+#
+# The cache path is a predictable name under `$XDG_CACHE_HOME`, so anything that
+# can create one entry there chooses what `_read_update_check_cache` opens. Three
+# distinct consequences, and they are not interchangeable: two are availability
+# (the read never returns) and one is integrity (the read returns an attacker's
+# answer). Every case below therefore asserts on the *return*, bounded by a
+# deadline -- not on which guard rejected it.
+# --------------------------------------------------------------------------- #
+
+
+def _read_cache_within(decorators, cache_path: Path, seconds: float = 5.0):
+    """`_read_update_check_cache(cache_path)`, on a thread, under a deadline.
+
+    The availability vectors here fail by BLOCKING rather than by raising: a
+    planted FIFO parks `open()` in the kernel with nothing raised, so neither the
+    read's own `except (KeyError, OSError, TypeError, ValueError)` nor the
+    advisory's outer fail-open arm can turn it into a skipped check. An
+    unhardened implementation must therefore fail this call rather than hang the
+    suite, which is what the deadline is for -- and the thread is a daemon so a
+    hung mutant cannot keep the interpreter alive at exit either.
+    """
+    outcome = []
+
+    def call():
+        try:
+            outcome.append(("returned", decorators._read_update_check_cache(cache_path)))
+        except BaseException as error:  # reported below, never swallowed
+            outcome.append(("raised", error))
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    worker.join(seconds)
+    assert not worker.is_alive(), f"the cache read did not return within {seconds}s"
+    kind, value = outcome[0]
+    assert kind == "returned", f"the cache read raised {value!r}"
+    return value
+
+
+@fifos_only
+def test_update_check_cache_record_that_is_a_fifo_is_refused_promptly(monkeypatch, tmp_path):
+    """A FIFO at the cache path returns None instead of blocking the CLI forever.
+
+    This is the one vector with no exception to catch: with a FIFO and no writer,
+    a blocking `open()` never returns and never raises, so `guard <anything>`
+    simply stops before running the user's command. The failure mode this pins is
+    a HANG, not a raise -- which is why the read is bounded by a deadline here
+    rather than merely asserted to be None.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    os.mkfifo(cache_path)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+@symlinks_only
+@character_devices_only
+def test_update_check_cache_record_symlinked_to_a_device_is_refused(monkeypatch, tmp_path):
+    """A cache path linked at a device returns None without reading the device.
+
+    `/dev/zero` yields bytes for as long as anything asks, so a reader that treats
+    whatever it opened as a small JSON file resolves the link and then allocates
+    until the process dies. The deadline is the assertion that matters: it fails
+    on an implementation that reads to completion, where a plain `is None` would
+    wait for the OOM killer.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.symlink_to(DEVICE_PATH)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+@symlinks_only
+def test_update_check_cache_record_symlinked_to_a_valid_record_is_refused(
+    monkeypatch, tmp_path
+):
+    """A symlinked record is refused even when the target parses -- the INTEGRITY vector.
+
+    Distinct from the availability cases above, and the reason the refusal cannot
+    be softened for targets that look harmless. An attacker who can create the
+    cache path but not write our directory plants a link to a record of their own,
+    stamped now and naming the installed version as the latest: the advisory is
+    then pinned off and the user is never told about a security release. The
+    consequence is asserted twice -- the record is not read, and the check
+    therefore is not fresh, so the refresh goes ahead and reaches the real index.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    planted = tmp_path / "planted-record.json"
+    _write_cache_record(planted, CHECKED_AT, LOCAL_VERSION)
+    cache_path.symlink_to(planted)
+    request = Mock(return_value=_response("1.9.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    assert _read_cache_within(decorators, cache_path) is None
+    assert not decorators._update_check_cache_is_fresh(
+        decorators._read_update_check_cache(cache_path), CHECKED_AT
+    )
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    _assert_fetched_once(request)
+    assert "A new version of praetorian-cli is available: 1.9.0" in result.output
+    # The record was replaced, not written *through* the link.
+    assert json.loads(planted.read_text(encoding="utf-8"))["latest_version"] == LOCAL_VERSION
+
+
+@pytest.mark.parametrize(
+    "padded_to, accepted",
+    [
+        pytest.param(None, True, id="an-ordinary-record"),
+        pytest.param(UPDATE_CHECK_CACHE_MAX_BYTES, True, id="exactly-at-the-size-cap"),
+        pytest.param(
+            UPDATE_CHECK_CACHE_MAX_BYTES + 1, False, id="one-byte-over-the-size-cap"
+        ),
+    ],
+)
+def test_update_check_cache_record_is_read_only_up_to_the_size_cap(
+    monkeypatch, tmp_path, padded_to, accepted
+):
+    """The cap is pinned from BOTH sides: at the cap parses, one byte over does not.
+
+    A cap asserted only from above is satisfied by refusing everything, which
+    would disable the cache and restore the unthrottled probe -- so the accepted
+    cases are as load-bearing as the refused one. Trailing whitespace is valid
+    JSON, so between the two boundary cases the only thing that differs is the
+    byte count.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    record = json.dumps({"checked_at": CHECKED_AT, "latest_version": "1.2.0"}).encode()
+    if padded_to is not None:
+        record += b" " * (padded_to - len(record))
+        assert len(record) == padded_to
+    cache_path.write_bytes(record)
+
+    cached = _read_cache_within(decorators, cache_path)
+
+    if accepted:
+        assert cached == (CHECKED_AT, decorators._parse_version("1.2.0"))
+    else:
+        assert cached is None
+
+
+@posix_modes_only
+def test_update_check_cache_record_owned_by_another_user_is_refused(monkeypatch, tmp_path):
+    """A record this user does not own is refused, rather than parsed.
+
+    Only root can actually chown a file to somebody else, so the *other* half of
+    the comparison is moved instead: the effective uid the read checks against is
+    replaced, which is indistinguishable from the record's point of view and needs
+    no privilege. A shared or pre-seeded `$XDG_CACHE_HOME` -- a container image
+    layer, a multi-user build agent -- is where a foreign-owned record comes from,
+    and it is the same integrity problem as the symlink above without the symlink.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    _write_cache_record(cache_path, CHECKED_AT, "1.2.0")
+    owner = os.stat(cache_path).st_uid
+    monkeypatch.setattr(decorators.os, "geteuid", lambda: owner + 1)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+# --------------------------------------------------------------------------- #
+# Descriptor accounting on the cache-write failure path.
+# --------------------------------------------------------------------------- #
+
+
+@fd_counting_only
+def test_update_check_leaks_no_descriptor_when_fdopen_raises(monkeypatch, tmp_path):
+    """`mkstemp` hands back a raw descriptor, and a failed `os.fdopen` must not orphan it.
+
+    Only `os.fdopen` succeeding transfers ownership of that descriptor to a file
+    object the `with` block can close; if it raises, nothing else will ever close
+    it. The count is taken across 200 induced failures because one leak is
+    invisible -- and a long-lived process on a `guard` install that hits this path
+    every invocation is exactly where it stops being invisible.
+
+    The path-only assertion is the one that missed this bug: the old code removed
+    the temp file and leaked its descriptor, so `iterdir()` looked spotless while
+    the process bled descriptors. Both are asserted here for that reason.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    request = Mock(side_effect=AssertionError("a cache that cannot be written must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def refuse_to_wrap(*_args, **_kwargs):
+        raise OSError("too many open files")
+
+    monkeypatch.setattr(decorators.os, "fdopen", refuse_to_wrap)
+
+    # One failing invocation before the baseline, so any one-time allocation on
+    # this path is counted as setup rather than as a leak.
+    warm_up = CliRunner().invoke(_successful_command(), obj=object())
+    assert warm_up.exit_code == 0
+    baseline = len(os.listdir("/dev/fd"))
+
+    for _ in range(200):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    assert len(os.listdir("/dev/fd")) == baseline
+    request.assert_not_called()
+    # No `mkstemp` leftover, and no cache record: the write never completed.
+    assert list(cache_path.parent.iterdir()) == []
+
+
+@fd_counting_only
+@descriptor_writes_only
+@pytest.mark.parametrize(
+    "operation",
+    ["prepare", "write", "failed-write"],
+    ids=["preparing-the-directory", "writing-the-record", "a-write-that-raises"],
+)
+def test_update_check_reclaims_the_cache_directory_descriptor(
+    monkeypatch, tmp_path, operation
+):
+    """The DIRECTORY descriptor is reclaimed too -- on success and on failure.
+
+    Validating the directory by descriptor rather than by path means there is now
+    a second long-lived descriptor per invocation, opened before the record is
+    written and useless afterwards. On a long-lived `guard` process this path runs
+    once per invocation, so a directory descriptor held one iteration too long is
+    a slow file-descriptor exhaustion that ends with the CLI unable to open
+    anything -- the advisory taking the whole tool down, which is the failure mode
+    this module exists to avoid.
+
+    All three arms count, because they close at three different places: the
+    preparation opens one only to answer a question and must drop it immediately,
+    the write must drop it after a successful record, and a write that RAISES must
+    drop it on the way out -- the arm a `try`/`finally` is there for.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+
+    if operation == "prepare":
+        def once():
+            assert decorators._prepare_update_check_cache_dir(cache_path)
+    elif operation == "write":
+        def once():
+            assert decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+    else:
+        def refuse_to_wrap(*_args, **_kwargs):
+            raise OSError("too many open files")
+
+        monkeypatch.setattr(decorators.os, "fdopen", refuse_to_wrap)
+
+        def once():
+            assert not decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+
+    # One call before the baseline, so a one-time allocation on this path is
+    # counted as setup rather than as a leak.
+    once()
+    baseline = len(os.listdir("/dev/fd"))
+
+    for _ in range(200):
+        once()
+
+    assert len(os.listdir("/dev/fd")) == baseline

--- a/praetorian_cli/sdk/test/test_webhook.py
+++ b/praetorian_cli/sdk/test/test_webhook.py
@@ -5,14 +5,15 @@ import requests
 
 from praetorian_cli.sdk.model.globals import Risk
 from praetorian_cli.sdk.model.utils import risk_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestWebhook:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_create_webhook(self):

--- a/praetorian_cli/sdk/test/test_webpage.py
+++ b/praetorian_cli/sdk/test/test_webpage.py
@@ -1,6 +1,6 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, setup_chariot
 
 
 @pytest.mark.coherence
@@ -8,7 +8,8 @@ class TestWebpage:
     """Test suite for the Webpage entity class."""
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_webpage(self):

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -1,19 +1,21 @@
 import os
 import json
+import shlex
 from subprocess import run
 
 import pytest
 
 from praetorian_cli.sdk.model.globals import AddRisk, Asset, Risk, Seed, Preseed
 from praetorian_cli.sdk.model.utils import configuration_key
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.cli
 class TestZCli:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        self._confirmed_profile, self._confirmed_account = selected_test_target()
+        self.sdk = setup_chariot(self._confirmed_profile, self._confirmed_account)
 
     def test_asset_cli(self):
         o = make_test_values(lambda: None)
@@ -452,15 +454,13 @@ class TestZCli:
 
     def run_json(self, command):
         """Run a CLI command and return parsed JSON output."""
-        result = run(f'guard --profile "{self.sdk.keychain.profile}" {command}', capture_output=True,
-                     text=True, shell=True)
+        result = run(self._guard_argv(command), capture_output=True, text=True)
         assert result.returncode == 0, f'CLI "{command}" failed with exit code {result.returncode}; stderr: {result.stderr}'
         assert len(result.stderr) == 0, f'CLI "{command}" should not have content in stderr; instead, got {result.stderr}'
         return json.loads(result.stdout)
 
     def verify(self, command, expected_stdout=[], expected_stderr=[], ignore_stdout=False):
-        result = run(f'guard --profile "{self.sdk.keychain.profile}" {command}', capture_output=True,
-                     text=True, shell=True)
+        result = run(self._guard_argv(command), capture_output=True, text=True)
         if expected_stdout:
             for out in expected_stdout:
                 assert out in result.stdout, f'CLI "{command}" does not contain {out} in stdout; instead, got {result.stdout}'
@@ -475,3 +475,17 @@ class TestZCli:
         else:
             assert len(result.stderr) == 0, \
                 f'CLI "{command}" should not have content in stderr; instead, got {result.stderr}'
+
+    def _guard_argv(self, command):
+        profile = getattr(self, '_confirmed_profile', None)
+        account = getattr(self, '_confirmed_account', None)
+        if (
+            not isinstance(profile, str)
+            or not profile
+            or profile != profile.strip()
+            or not isinstance(account, str)
+            or not account
+            or account != account.strip()
+        ):
+            raise ValueError('A confirmed profile and account are required for CLI tests.')
+        return ['guard', '--profile', profile, '--account', account, *shlex.split(command)]

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -1,11 +1,15 @@
-import os
 import time
+from os import environ
 from random import randint
 
 from praetorian_cli.sdk.chariot import Chariot
 from praetorian_cli.sdk.keychain import Keychain
 from praetorian_cli.sdk.model.globals import Risk, Preseed
 from praetorian_cli.sdk.model.utils import risk_key, asset_key, ad_domain_key, attribute_key, seed_asset_key, preseed_key, setting_key, configuration_key
+
+
+TEST_PROFILE_ENV = 'CHARIOT_TEST_PROFILE'
+TEST_ACCOUNT_ENV = 'CHARIOT_TEST_ACCOUNT'
 
 
 def epoch_micro():
@@ -84,8 +88,34 @@ def clean_test_entities(sdk, o):
     sdk.settings.delete(o.setting_key)
     sdk.configurations.delete(o.configuration_key)
 
-def setup_chariot():
-    return Chariot(Keychain(os.environ.get('CHARIOT_TEST_PROFILE')))
+def setup_chariot(profile, account):
+    if (
+        not isinstance(profile, str)
+        or not profile
+        or profile != profile.strip()
+        or not isinstance(account, str)
+        or not account
+        or account != account.strip()
+    ):
+        raise ValueError('An explicit profile and account are required for live tests.')
+
+    keychain = Keychain(profile=profile, account=account)
+    if keychain.profile != profile or keychain.account != account:
+        raise ValueError('Constructed test target does not match the selected profile and account.')
+    return Chariot(keychain)
+
+
+def selected_test_target():
+    profile = environ.get(TEST_PROFILE_ENV)
+    account = environ.get(TEST_ACCOUNT_ENV)
+    if (
+        not profile
+        or profile != profile.strip()
+        or not account
+        or account != account.strip()
+    ):
+        raise ValueError('An explicit profile and account are required for live tests.')
+    return profile, account
 
 
 def email_address():


### PR DESCRIPTION
> **PR Stack (5/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> 3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)
> 4. #268 Knossos, Aegis management (st7-st9)
> **5. #269 Red Team CLI (st5)** (this PR)
> 6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> 8. #272 share, leaderboard, misc, multipart (st18-st21)
> 9. #244 skills, risk-status, conversation UX
> 10. #243 Hannibal hunt CLI + TUI
> 11. #228 Marcus terminal hardening
> 12. #226 module management system


## Summary
Full Red Team CLI surface across five domains:
- **Deployment** (`guard red-team deployment launch|delete|details|history|last-inputs|node-schema|plan|apply|collaborators`) — full infra lifecycle with confirmation on destructive ops
- **Campaigns** (`guard red-team campaign create|delete|targets|authorize|funnel|activity`) — phishing campaign management
- **Domain parking** (`guard red-team domain update|dns-list|dns-create|dns-delete|mailgun-status|mailgun-provision|mailgun-user`) — domain and DNS management
- **Evilginx** (`guard red-team evilginx phishlets|phishlet-params|lures|create-lure|configure|status`) — phishing infrastructure
- **Payload/phishkit** (`guard red-team payload-generate|phishkit-nodes`) — payload generation and node discovery

All commands gated with `@praetorian_only`. Complex request bodies (deployment plan/apply, campaign create, domain update) accept JSON from stdin. 39 unit tests.

Covers [ENG-6612](https://linear.app/praetorianlabs/issue/ENG-6612) (ST-5).

## Test plan
- [x] 39 CLI unit tests pass across all 5 domains
- [x] Deployment `delete` and `apply` require confirmation (`--yes`)
- [x] Argument validation (missing required options, invalid DNS record types)
- [x] JSON stdin input for complex bodies (plan, apply, campaign create, targets, domain update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)