### PR TITLE
feat: nuclei, bifrost, engineer-vm, CSF CLI commands

### DIFF
--- a/docs/superpowers/plans/2026-05-28-marcus-terminal.md
+++ b/docs/superpowers/plans/2026-05-28-marcus-terminal.md
@@ -1,0 +1,487 @@
+# Marcus Terminal Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Marcus AI console mode correct (no sticky impersonation, no swallowed errors, clean Ctrl-C), efficient (paged polling with idle backoff), and pleasant (Rich `Live` streaming), with real test coverage.
+
+**Architecture:** Refactor `_send_to_marcus` into focused units — `_post_to_planner` (POST + 403 retry inside a `try/finally` impersonation guard + guarded JSON parse), `_poll_messages` (paged fetch + backoff, surfaces real errors), `_render_stream` (Rich `Live`). Public command surface (`ask`, `marcus`, `marcus read/ingest/do`, `research`) is unchanged.
+
+**Tech Stack:** Python 3.12, Rich (`Live`), prompt_toolkit, pytest. SDK: `sdk.chariot_request`, `sdk.search.by_key_prefix`, `sdk.accounts.login_principal`, `sdk.keychain.account`.
+
+**Branch:** `fix/marcus-terminal` (new, off `main`). Base spec: `docs/superpowers/specs/2026-05-28-marcus-terminal-design.md`.
+
+---
+
+## File Structure
+
+- Modify: `praetorian_cli/ui/console/commands/marcus.py` — split `_send_to_marcus`; add `_post_to_planner`, `_poll_messages`, `_render_stream`.
+- Test: `praetorian_cli/sdk/test/ui/test_console_marcus.py` (new).
+
+The Marcus parsing helpers (`_parse_tool_name`, `_parse_tool_result`, `_infer_tool_from_response`) stay as-is but become directly unit-tested.
+
+---
+
+## Task 1: Test harness + parsing coverage (characterization)
+
+**Files:**
+- Create: `praetorian_cli/sdk/test/ui/test_console_marcus.py`
+
+- [ ] **Step 1: Write characterization tests for the parsing helpers**
+
+```python
+# praetorian_cli/sdk/test/ui/test_console_marcus.py
+import json
+import types
+import pytest
+from praetorian_cli.ui.console.commands.marcus import MarcusCommands
+
+
+class _Host(MarcusCommands):
+    """Bare host exposing MarcusCommands methods for unit testing."""
+    def __init__(self):
+        pass
+
+
+@pytest.fixture
+def host():
+    return _Host()
+
+
+def test_parse_tool_name_from_structured_content(host):
+    content = json.dumps({'name': 'run_capability', 'input': {'capability': 'nuclei'}})
+    assert host._parse_tool_name(content, {}) == 'run_capability(nuclei)'
+
+def test_parse_tool_name_falls_back_to_tool(host):
+    assert host._parse_tool_name('not json', {}) == 'tool'
+
+def test_parse_tool_result_counts_list(host):
+    content = json.dumps({'assets': [1, 2, 3]})
+    assert host._parse_tool_result(content) == '3 assets'
+
+def test_infer_tool_from_response_status(host):
+    assert host._infer_tool_from_response(json.dumps({'status': 'JF'})) == 'status_check'
+```
+
+- [ ] **Step 2: Run tests to verify they pass (characterization — should already pass)**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -v`
+Expected: PASS. These pin current behavior before refactoring.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add praetorian_cli/sdk/test/ui/test_console_marcus.py
+git commit -m "test(marcus): characterization tests for tool-name/result parsing"
+```
+
+---
+
+## Task 2: Fix impersonation restore (try/finally)
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/commands/marcus.py:106-137`
+- Test: `praetorian_cli/sdk/test/ui/test_console_marcus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class _FakeResp:
+    def __init__(self, status, body='', payload=None, ok=None):
+        self.status_code = status
+        self.text = body
+        self._payload = payload if payload is not None else {}
+        self.ok = ok if ok is not None else (200 <= status < 300)
+    def json(self):
+        return self._payload
+
+
+def _make_host_for_post(first_resp, second_resp=None, login='analyst@praetorian.com'):
+    host = _Host()
+    calls = {'n': 0}
+    class _KC: account = 'client@acme.com'
+    class _Accounts:
+        def login_principal(self): return login
+    class _SDK:
+        keychain = _KC()
+        accounts = _Accounts()
+        def url(self, p): return 'https://x' + p
+        def chariot_request(self, method, url, json=None):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                if isinstance(first_resp, Exception):
+                    raise first_resp
+                return first_resp
+            return second_resp
+    host.sdk = _SDK()
+    host.context = types.SimpleNamespace(account='client@acme.com', mode='agent',
+                                         conversation_id=None)
+    class _Console:
+        def print(self, *a, **k): pass
+        def status(self, *a, **k):
+            import contextlib
+            return contextlib.nullcontext()
+    host.console = _Console()
+    host.colors = {'primary': 'red'}
+    return host, calls
+
+
+def test_impersonation_restored_after_exception(host):
+    h, calls = _make_host_for_post(RuntimeError('boom'))
+    with pytest.raises(RuntimeError):
+        h._post_to_planner('hello')
+    # keychain.account must be restored even though the call raised
+    assert h.sdk.keychain.account == 'client@acme.com'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k impersonation -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_post_to_planner'`.
+
+- [ ] **Step 3: Extract `_post_to_planner` with try/finally + guarded JSON**
+
+Add to `MarcusCommands` and replace the POST/403-retry/JSON-parse portion of `_send_to_marcus` (lines ~106-141) with a call to it:
+
+```python
+    def _post_to_planner(self, message: str):
+        """POST to /planner, handling the 403 retry-as-Praetorian path safely.
+
+        Returns the parsed JSON dict. Raises on network error; the keychain
+        account is always restored.
+        """
+        url = self.sdk.url('/planner')
+        payload = {'message': message, 'mode': self.context.mode}
+        if self.context.conversation_id:
+            payload['conversationId'] = self.context.conversation_id
+
+        with self.console.status('Sending...', spinner='dots',
+                                 spinner_style=self.colors['primary']):
+            response = self.sdk.chariot_request('POST', url, json=payload)
+
+        if response.status_code == 403 and self.context.account:
+            login_user = self.sdk.accounts.login_principal()
+            if login_user and login_user.endswith('@praetorian.com'):
+                self.console.print(
+                    f'[dim]AI not enabled on this account -- routing through {login_user}[/dim]')
+                saved_account = self.sdk.keychain.account
+                try:
+                    self.sdk.keychain.account = None
+                    if self.context.account not in message:
+                        message = f'[Context: querying data for account {self.context.account}] {message}'
+                    payload['message'] = message
+                    if self.context.conversation_id:
+                        payload.pop('conversationId', None)
+                        self.context.conversation_id = None
+                    with self.console.status('Sending via Praetorian account...', spinner='dots',
+                                             spinner_style=self.colors['primary']):
+                        response = self.sdk.chariot_request('POST', url, json=payload)
+                finally:
+                    self.sdk.keychain.account = saved_account
+
+        if not response.ok:
+            raise MarcusError(f'API error: {response.status_code} - {response.text}')
+
+        try:
+            return response.json()
+        except (ValueError, json.JSONDecodeError):
+            raise MarcusError(
+                f'Unexpected non-JSON response ({response.status_code}): {response.text[:200]}')
+```
+
+Add a small exception type near the top of the module:
+
+```python
+class MarcusError(Exception):
+    """Raised for recoverable Marcus terminal errors (shown to the user)."""
+```
+
+Update `_send_to_marcus` to call `_post_to_planner` and convert `MarcusError` into the existing user-facing error print + `return None`:
+
+```python
+        try:
+            result = self._post_to_planner(message)
+        except MarcusError as e:
+            self.console.print(f'[error]{e}[/error]')
+            return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k impersonation -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/marcus.py praetorian_cli/sdk/test/ui/test_console_marcus.py
+git commit -m "fix(marcus): restore impersonation in finally; guard non-JSON responses"
+```
+
+---
+
+## Task 3: Guarded JSON + 403 retry routing test
+
+**Files:**
+- Test: `praetorian_cli/sdk/test/ui/test_console_marcus.py`
+
+- [ ] **Step 1: Write the tests**
+
+```python
+def test_non_json_response_raises_marcus_error(host):
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+    bad = _FakeResp(500, body='<html>oops</html>')
+    def _json(): raise ValueError('no json')
+    bad.json = _json
+    h, _ = _make_host_for_post(bad)
+    with pytest.raises(MarcusError):
+        h._post_to_planner('hi')
+
+def test_403_retries_through_praetorian_account(host):
+    first = _FakeResp(403, body='forbidden')
+    second = _FakeResp(200, payload={'conversation': {'uuid': 'c1'}})
+    h, calls = _make_host_for_post(first, second)
+    out = h._post_to_planner('hi')
+    assert calls['n'] == 2
+    assert out['conversation']['uuid'] == 'c1'
+    assert h.sdk.keychain.account == 'client@acme.com'  # restored
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k "non_json or retries" -v`
+Expected: PASS (behavior implemented in Task 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add praetorian_cli/sdk/test/ui/test_console_marcus.py
+git commit -m "test(marcus): cover non-JSON and 403 retry routing"
+```
+
+---
+
+## Task 4: Paged polling with idle backoff + surfaced errors
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/commands/marcus.py` (the poll loop, lines ~143-230)
+- Test: `praetorian_cli/sdk/test/ui/test_console_marcus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_poll_messages_yields_only_new_and_stops_on_chariot(host):
+    msgs_round1 = [{'key': '#message#c1#001', 'role': 'tool call', 'content': '{}'},
+                   {'key': '#message#c1#002', 'role': 'tool response', 'content': '{"assets":[1]}'}]
+    msgs_round2 = msgs_round1 + [{'key': '#message#c1#003', 'role': 'chariot', 'content': 'final answer'}]
+    rounds = iter([msgs_round1, msgs_round2])
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            return (next(rounds), None)
+    host.sdk = types.SimpleNamespace(search=_Search())
+    host.context = types.SimpleNamespace(verbose=False)
+    collected = list(host._poll_messages('c1', after_key='', max_wait=5, sleep=lambda s: None))
+    roles = [m['role'] for m in collected]
+    assert roles[-1] == 'chariot'
+    assert collected[-1]['content'] == 'final answer'
+
+def test_poll_messages_surfaces_persistent_errors(host):
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            raise RuntimeError('search down')
+    host.sdk = types.SimpleNamespace(search=_Search())
+    host.context = types.SimpleNamespace(verbose=False)
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+    with pytest.raises(MarcusError):
+        list(host._poll_messages('c1', after_key='', max_wait=2, sleep=lambda s: None,
+                                 error_threshold=1))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k poll_messages -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_poll_messages'`.
+
+- [ ] **Step 3: Implement `_poll_messages` as a generator**
+
+Add to `MarcusCommands`:
+
+```python
+    def _poll_messages(self, conversation_id, after_key='', *, max_wait=180,
+                       sleep=time.sleep, error_threshold=5):
+        """Yield new conversation messages in key order until a 'chariot' reply.
+
+        Pages by after_key (client-side filter today; server-side if supported).
+        Backs off when idle. Raises MarcusError after `error_threshold`
+        consecutive fetch failures so problems surface instead of hanging.
+        """
+        start = time.time()
+        last_key = after_key
+        delay = 1.0
+        consecutive_errors = 0
+        prefix = f'#message#{conversation_id}#'
+        while time.time() - start < max_wait:
+            try:
+                messages, _ = self.sdk.search.by_key_prefix(prefix, user=True)
+                consecutive_errors = 0
+            except Exception as e:
+                consecutive_errors += 1
+                if consecutive_errors >= error_threshold:
+                    raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
+                sleep(delay)
+                continue
+            new = sorted((m for m in messages if m.get('key', '') > last_key),
+                         key=lambda x: x.get('key', ''))
+            if new:
+                delay = 1.0  # reset backoff on activity
+                for msg in new:
+                    last_key = msg.get('key', '')
+                    yield msg
+                    if msg.get('role', '') == 'chariot':
+                        return
+            else:
+                delay = min(delay + 1.0, 3.0)  # idle backoff
+            sleep(delay)
+        raise MarcusError('Timed out waiting for response')
+```
+
+Rewrite the poll section of `_send_to_marcus` to consume this generator (preserving the existing snapshot of `last_key` and the tool-log rendering), and convert a trailing-timeout `MarcusError` into the existing `[warning]Timed out…[/warning]` + `return None`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k poll_messages -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/marcus.py praetorian_cli/sdk/test/ui/test_console_marcus.py
+git commit -m "perf(marcus): paged polling generator with idle backoff and surfaced errors"
+```
+
+---
+
+## Task 5: Rich Live streaming + graceful Ctrl-C
+
+**Files:**
+- Modify: `praetorian_cli/ui/console/commands/marcus.py`
+- Test: `praetorian_cli/sdk/test/ui/test_console_marcus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_send_to_marcus_handles_ctrl_c(host, monkeypatch):
+    # _post_to_planner succeeds, but polling raises KeyboardInterrupt
+    host._post_to_planner = lambda m: {'conversation': {'uuid': 'c1'}}
+    def _boom(*a, **k):
+        raise KeyboardInterrupt()
+    host._poll_messages = _boom
+    class _Console:
+        printed = []
+        def print(self, *a, **k): _Console.printed.append(' '.join(str(x) for x in a))
+        def status(self, *a, **k):
+            import contextlib; return contextlib.nullcontext()
+    host.console = _Console()
+    host.colors = {'primary': 'red'}
+    host.context = types.SimpleNamespace(account=None, mode='agent', conversation_id=None,
+                                         verbose=False)
+    class _Search:
+        def by_key_prefix(self, prefix, user=False): return ([], None)
+    host.sdk = types.SimpleNamespace(search=_Search())
+    result = host._send_to_marcus('hi')
+    assert result is None
+    assert any('cancel' in p.lower() or 'interrupt' in p.lower() for p in _Console.printed)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -k ctrl_c -v`
+Expected: FAIL (KeyboardInterrupt propagates; no cancel message).
+
+- [ ] **Step 3: Wrap the poll consumption in try/except KeyboardInterrupt**
+
+In `_send_to_marcus`, surround the `_poll_messages` consumption with:
+
+```python
+        try:
+            for msg in self._poll_messages(self.context.conversation_id, after_key=last_key):
+                ...  # existing per-role rendering; return content on 'chariot'
+        except KeyboardInterrupt:
+            self.console.print('\n[warning]Cancelled — returned to console.[/warning]')
+            return None
+        except MarcusError as e:
+            self.console.print(f'\n[warning]{e}[/warning]')
+            return None
+```
+
+- [ ] **Step 4: Replace the `\r` rewrite with a Rich Live region**
+
+Within that loop, render tool activity and incremental assistant text through a `rich.live.Live` region instead of the carriage-return rewrite at the old line ~215. Keep the `tool_log`/`_last_tool_log` bookkeeping intact for the `show tools` command. Minimal shape:
+
+```python
+        from rich.live import Live
+        from rich.console import Group
+        lines = []
+        with Live(console=self.console, refresh_per_second=8, transient=False) as live:
+            for msg in self._poll_messages(...):
+                role = msg.get('role', '')
+                if role == 'tool call':
+                    name = self._parse_tool_name(msg.get('content', ''), msg)
+                    lines.append(f'  [dim]->[/dim] [accent]{name}[/accent] …')
+                elif role == 'tool response':
+                    summary = self._parse_tool_result(msg.get('content', ''))
+                    if lines:
+                        lines[-1] = lines[-1].replace(' …', f' [dim]-- {summary}[/dim] [success]done[/success]')
+                elif role == 'chariot':
+                    self._last_tool_log = tool_log
+                    return msg.get('content', '')
+                live.update(Group(*[__import__('rich').text.Text.from_markup(l) for l in lines]))
+```
+
+(Preserve verbose-mode expansion via the existing `_print_verbose_*` helpers when `self.context.verbose`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest praetorian_cli/sdk/test/ui/test_console_marcus.py -v`
+Expected: PASS (all Marcus tests).
+
+- [ ] **Step 6: Manual smoke (requires auth)**
+
+```bash
+guard            # launch console
+marcus           # enter conversation mode
+> what assets do I have?     # observe live tool activity + streamed answer; Ctrl-C mid-run returns cleanly
+/back
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add praetorian_cli/ui/console/commands/marcus.py praetorian_cli/sdk/test/ui/test_console_marcus.py
+git commit -m "feat(marcus): Rich Live streaming and graceful Ctrl-C handling"
+```
+
+---
+
+## Task 6: Full suite + regression check
+
+**Files:**
+- Test only.
+
+- [ ] **Step 1: Run the full UI suite**
+
+Run: `pytest praetorian_cli/sdk/test/ui/ -q`
+Expected: green. Fix any test coupled to the old `_send_to_marcus` internals.
+
+- [ ] **Step 2: Commit any fixups**
+
+```bash
+git add -A && git commit -m "test(marcus): align suite with refactored poll/stream"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** try/finally impersonation (Task 2), surfaced errors + guarded JSON (Tasks 2–4), Ctrl-C (Task 5), paged polling + backoff (Task 4), Rich Live streaming (Task 5), tests throughout (Tasks 1–6).
+- **Type consistency:** `MarcusError`, `_post_to_planner(message)->dict`, `_poll_messages(conversation_id, after_key, *, max_wait, sleep, error_threshold)->generator`, `_render`/Live usage are referenced consistently across tasks.
+- **Risk noted in spec:** if `by_key_prefix` later gains server-side after-key paging, `_poll_messages` is the single place to adopt it. Rich `Live` must coexist with the prompt_toolkit session; if it fights the prompt during manual smoke (Task 5 Step 6), fall back to incremental `console.print` while keeping the backoff/error-surfacing logic.

--- a/docs/superpowers/specs/2026-05-28-marcus-terminal-design.md
+++ b/docs/superpowers/specs/2026-05-28-marcus-terminal-design.md
@@ -1,0 +1,93 @@
+# Marcus Terminal — Correctness, Performance, Streaming UX
+
+**Date:** 2026-05-28
+**Branch:** `fix/marcus-terminal` (new, off `main`)
+**Status:** Design — pending implementation plan
+
+## Problem
+
+The Marcus AI console mode (`praetorian_cli/ui/console/commands/marcus.py`) POSTs
+to `/planner`, then **polls** `#message#<conversation_id>#` keys to stream tool
+calls and the final response. Review for "optimize + ensure no errors" surfaced
+correctness bugs, an inefficient poll loop, and a fragile rendering path.
+
+## Goals
+
+Harden and streamline the Marcus terminal across four dimensions (and anything
+else found during implementation):
+
+1. **Correctness / no errors**
+2. **Poll-loop performance**
+3. **Streaming UX**
+4. **Test coverage**
+
+## Findings → Fixes
+
+### 1. Correctness
+
+- **Impersonation not restored on error** (`marcus.py:122-133`):
+  `self.sdk.keychain.account` is cleared then restored *without* `try/finally`.
+  If `chariot_request` raises in between, impersonation stays disabled for the
+  rest of the session. → Wrap in `try/finally`; restore unconditionally.
+- **Silent `except Exception: pass`** (`151-152`, `223-224`): genuine API/parse
+  errors are swallowed, so failures look like hangs/timeouts. → Catch narrowly,
+  log/surface transient errors, and distinguish "still working" from "errored".
+- **`response.json()` unguarded** (`139`): a non-JSON error body throws. → Guard
+  with a clear error message including status code + body snippet.
+- **Ctrl-C mid-response** (`164-226`): not caught inside `_send_to_marcus`; only
+  the outer conversation loop handles it → traceback while "Thinking…". → Catch
+  `KeyboardInterrupt`, cancel cleanly, return to the prompt.
+
+### 2. Performance
+
+- **Full-conversation refetch every 1s** (`164-226`): `by_key_prefix` pulls the
+  entire conversation each second for up to 180s, filtered client-side by
+  `> last_key` — O(messages × polls). → Page by after/offset key if the search
+  API supports it; otherwise request only the tail. Add idle backoff (e.g.
+  1s → 2s → 3s, capped) that resets on new activity.
+
+### 3. Streaming UX
+
+- **Final-only render**: assistant text appears only at the end. → Use a Rich
+  `Live` region to render tool activity and incremental assistant text as they
+  arrive.
+- **`\r` line-rewrite hack** (`215`) for retroactive tool-name fixes is fragile
+  across terminal widths. → Replace with the `Live` region; prefer structured
+  tool-name fields over heuristic inference where the API provides them.
+
+### 4. Tests
+
+- New `test_console_marcus.py` covering:
+  - Tool-name parsing (`_parse_tool_name`) and result summary (`_parse_tool_result`)
+    across structured and unstructured payloads.
+  - Impersonation restore on both success and exception (the `try/finally` fix).
+  - Poll-loop termination on `chariot` message, timeout, and Ctrl-C.
+  - `response.json()` failure path.
+  - 403 retry-as-Praetorian routing.
+
+## Approach
+
+Refactor `_send_to_marcus` into focused, testable units:
+
+- `_post_to_planner(message)` — POST, handle 403 retry-as-Praetorian inside a
+  `try/finally` impersonation guard, guarded JSON parse.
+- `_poll_messages(conversation_id, after_key)` — paged fetch + backoff, yields
+  new messages; raises/annotates real errors instead of swallowing them.
+- `_render_stream(messages)` — Rich `Live` region rendering tool activity and
+  incremental text.
+
+Keep the public command surface (`ask`, `marcus`, `marcus read/ingest/do`,
+`research`/`critfinder`) unchanged.
+
+## Non-Goals
+
+- Changing the `/planner` backend contract.
+- Replacing polling with websockets/SSE (out of scope unless the API already
+  supports it; revisit separately).
+
+## Risks
+
+- The search API may not support after-key paging; if so, the tail-fetch
+  optimization degrades to "fetch all" but the correctness + UX fixes still land.
+- Rich `Live` inside the prompt-toolkit session must not fight the prompt; verify
+  interaction and fall back to incremental `print` if needed.

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -51,17 +51,17 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except click.ClickException:
+            raise
         except click.Abort:
             raise
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
-        except click.ClickException:
         except click.exceptions.Exit:
+            raise
         except CancelledError:
+            raise
         except Exception as exc:
             if _debug_enabled(ctx):
+                raise
             raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -211,10 +211,7 @@ class Keychain:
 
     def websocket_url(self):
         """ Get the optional WebSocket endpoint URL (profile 'websocket' option or PRAETORIAN_CLI_WS_URL env). Returns None if unset. """
-        try:
-            return self.get_option('websocket')
-        except Exception:
-            return None
+        return self.get_option('websocket')
 
     def username(self):
         """ Get the username field from the keychain profile """

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -138,6 +138,7 @@ class Keychain:
         self.load_env(API_KEY_SECRET, 'PRAETORIAN_CLI_API_KEY_SECRET', required=False)
         self.load_env('api', 'PRAETORIAN_CLI_API', required=False)
         self.load_env('client_id', 'PRAETORIAN_CLI_CLIENT_ID', required=False)
+        self.load_env('websocket', 'PRAETORIAN_CLI_WS_URL', required=False)
         
         if 'api' not in profile or 'client_id' not in profile:
             raise ConfigurationError(
@@ -207,6 +208,13 @@ class Keychain:
     def base_url(self):
         """ Get the base URL for the backend. It is the "api" field in the keychain file. """
         return _validated_backend_url(self.get_option('api'))
+
+    def websocket_url(self):
+        """ Get the optional WebSocket endpoint URL (profile 'websocket' option or PRAETORIAN_CLI_WS_URL env). Returns None if unset. """
+        try:
+            return self.get_option('websocket')
+        except Exception:
+            return None
 
     def username(self):
         """ Get the username field from the keychain profile """

--- a/praetorian_cli/sdk/test/test_keychain_ws.py
+++ b/praetorian_cli/sdk/test/test_keychain_ws.py
@@ -1,0 +1,56 @@
+"""Tests for the optional websocket_url() accessor on Keychain."""
+import pytest
+
+from praetorian_cli.sdk.keychain import DEFAULT_PROFILE, Keychain
+
+# Minimal keychain INI content with just the required fields (api + client_id)
+MINIMAL_PROFILE = f"""
+[{DEFAULT_PROFILE}]
+api = https://example.com/chariot
+client_id = test-client-id
+username = testuser
+password = testpassword
+"""
+
+PROFILE_WITH_WS = f"""
+[{DEFAULT_PROFILE}]
+api = https://example.com/chariot
+client_id = test-client-id
+username = testuser
+password = testpassword
+websocket = wss://example.com/ws
+"""
+
+
+class TestWebsocketUrl:
+
+    def _make_keychain(self, ini_data):
+        """Construct a Keychain using in-memory INI data so no real file is needed."""
+        return Keychain(profile=DEFAULT_PROFILE, data=ini_data)
+
+    def test_websocket_url_returns_none_when_unset(self, monkeypatch):
+        """websocket_url() should return None (or '') when neither profile option nor env var is set."""
+        monkeypatch.delenv('PRAETORIAN_CLI_WS_URL', raising=False)
+        kc = self._make_keychain(MINIMAL_PROFILE)
+        result = kc.websocket_url()
+        assert result is None or result == '', (
+            f"Expected None or '' when websocket is unset, got {result!r}"
+        )
+
+    def test_websocket_url_returns_env_var(self, monkeypatch):
+        """PRAETORIAN_CLI_WS_URL env var overrides the profile option."""
+        monkeypatch.setenv('PRAETORIAN_CLI_WS_URL', 'wss://env.example.com/ws')
+        kc = self._make_keychain(MINIMAL_PROFILE)
+        assert kc.websocket_url() == 'wss://env.example.com/ws'
+
+    def test_websocket_url_returns_profile_option(self, monkeypatch):
+        """websocket_url() returns the profile 'websocket' value when no env var override."""
+        monkeypatch.delenv('PRAETORIAN_CLI_WS_URL', raising=False)
+        kc = self._make_keychain(PROFILE_WITH_WS)
+        assert kc.websocket_url() == 'wss://example.com/ws'
+
+    def test_websocket_url_env_overrides_profile(self, monkeypatch):
+        """Env var takes precedence over the profile 'websocket' value."""
+        monkeypatch.setenv('PRAETORIAN_CLI_WS_URL', 'wss://override.example.com/ws')
+        kc = self._make_keychain(PROFILE_WITH_WS)
+        assert kc.websocket_url() == 'wss://override.example.com/ws'

--- a/praetorian_cli/sdk/test/test_keychain_ws.py
+++ b/praetorian_cli/sdk/test/test_keychain_ws.py
@@ -29,13 +29,11 @@ class TestWebsocketUrl:
         return Keychain(profile=DEFAULT_PROFILE, data=ini_data)
 
     def test_websocket_url_returns_none_when_unset(self, monkeypatch):
-        """websocket_url() should return None (or '') when neither profile option nor env var is set."""
+        """websocket_url() should return None when neither profile option nor env var is set."""
         monkeypatch.delenv('PRAETORIAN_CLI_WS_URL', raising=False)
         kc = self._make_keychain(MINIMAL_PROFILE)
         result = kc.websocket_url()
-        assert result is None or result == '', (
-            f"Expected None or '' when websocket is unset, got {result!r}"
-        )
+        assert result is None
 
     def test_websocket_url_returns_env_var(self, monkeypatch):
         """PRAETORIAN_CLI_WS_URL env var overrides the profile option."""

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -133,6 +133,74 @@ def test_post_to_planner_guards_non_json_on_200(host):
         h._post_to_planner('hi')
 
 
+# ── FIX 1: Ctrl-C during the initial POST ────────────────────────────────────
+
+def test_ctrl_c_during_initial_request_returns_none(host):
+    """KeyboardInterrupt during _post_to_planner must return None and print cancel msg."""
+    import contextlib
+
+    def _boom(m):
+        raise KeyboardInterrupt()
+
+    host._post_to_planner = _boom
+    printed = []
+
+    class _Console:
+        def print(self, *a, **k): printed.append(' '.join(str(x) for x in a))
+        def status(self, *a, **k): return contextlib.nullcontext()
+
+    host.console = _Console()
+    host.colors = {'primary': 'red'}
+    host.context = types.SimpleNamespace(account=None, mode='agent', conversation_id=None,
+                                         verbose=False)
+
+    class _Search:
+        def by_key_prefix(self, prefix, user=False): return ([], None)
+
+    host.sdk = types.SimpleNamespace(search=_Search())
+    result = host._send_to_marcus('hi')
+    assert result is None
+    assert any('cancel' in p.lower() or 'interrupt' in p.lower() for p in printed)
+
+
+# ── FIX 2: Network exceptions in _post_to_planner become MarcusError ─────────
+
+def test_post_to_planner_network_error_becomes_marcus_error(host):
+    """RequestException from chariot_request must be re-raised as MarcusError."""
+    from requests.exceptions import RequestException
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+
+    h, _ = _make_host_for_post(RequestException('boom'))
+    with pytest.raises(MarcusError):
+        h._post_to_planner('hi')
+
+
+# ── FIX 3 + 4: Guard result type and non-dict poll items ─────────────────────
+
+def test_poll_messages_skips_non_dict_items(host):
+    """Non-dict items in the message list must be silently skipped."""
+    msgs = [
+        {'key': '#message#c1#001', 'role': 'tool call', 'content': '{}'},
+        'garbage',
+        {'key': '#message#c1#002', 'role': 'chariot', 'content': 'done'},
+    ]
+    call_count = {'n': 0}
+
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            call_count['n'] += 1
+            return (msgs, None)
+
+    host.sdk = types.SimpleNamespace(search=_Search())
+    host.context = types.SimpleNamespace(verbose=False)
+    collected = list(host._poll_messages('c1', after_key='', max_wait=5, sleep=lambda s: None))
+    roles = [m['role'] for m in collected]
+    assert 'chariot' in roles
+    assert collected[-1]['content'] == 'done'
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
 def test_send_to_marcus_handles_ctrl_c(host):
     # _post_to_planner succeeds, but polling raises KeyboardInterrupt mid-stream
     host._post_to_planner = lambda m: {'conversation': {'uuid': 'c1'}}

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -28,3 +28,50 @@ def test_parse_tool_result_counts_list(host):
 
 def test_infer_tool_from_response_status(host):
     assert host._infer_tool_from_response(json.dumps({'status': 'JF'})) == 'status_check'
+
+
+class _FakeResp:
+    def __init__(self, status, body='', payload=None, ok=None):
+        self.status_code = status
+        self.text = body
+        self._payload = payload if payload is not None else {}
+        self.ok = ok if ok is not None else (200 <= status < 300)
+    def json(self):
+        return self._payload
+
+
+def _make_host_for_post(first_resp, second_resp=None, login='analyst@praetorian.com'):
+    host = _Host()
+    calls = {'n': 0}
+    class _KC: account = 'client@acme.com'
+    class _Accounts:
+        def login_principal(self): return login
+    class _SDK:
+        keychain = _KC()
+        accounts = _Accounts()
+        def url(self, p): return 'https://x' + p
+        def chariot_request(self, method, url, json=None):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                if isinstance(first_resp, Exception):
+                    raise first_resp
+                return first_resp
+            return second_resp
+    host.sdk = _SDK()
+    host.context = types.SimpleNamespace(account='client@acme.com', mode='agent',
+                                         conversation_id=None)
+    class _Console:
+        def print(self, *a, **k): pass
+        def status(self, *a, **k):
+            import contextlib
+            return contextlib.nullcontext()
+    host.console = _Console()
+    host.colors = {'primary': 'red'}
+    return host, calls
+
+
+def test_impersonation_restored_after_exception(host):
+    h, calls = _make_host_for_post(RuntimeError('boom'))
+    with pytest.raises(RuntimeError):
+        h._post_to_planner('hello')
+    assert h.sdk.keychain.account == 'client@acme.com'

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -1,0 +1,30 @@
+import json
+import types
+import pytest
+from praetorian_cli.ui.console.commands.marcus import MarcusCommands
+
+
+class _Host(MarcusCommands):
+    """Bare host exposing MarcusCommands methods for unit testing."""
+    def __init__(self):
+        pass
+
+
+@pytest.fixture
+def host():
+    return _Host()
+
+
+def test_parse_tool_name_from_structured_content(host):
+    content = json.dumps({'name': 'run_capability', 'input': {'capability': 'nuclei'}})
+    assert host._parse_tool_name(content, {}) == 'run_capability(nuclei)'
+
+def test_parse_tool_name_falls_back_to_tool(host):
+    assert host._parse_tool_name('not json', {}) == 'tool'
+
+def test_parse_tool_result_counts_list(host):
+    content = json.dumps({'assets': [1, 2, 3]})
+    assert host._parse_tool_result(content) == '3 assets'
+
+def test_infer_tool_from_response_status(host):
+    assert host._infer_tool_from_response(json.dumps({'status': 'JF'})) == 'status_check'

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -75,3 +75,22 @@ def test_impersonation_restored_after_exception(host):
     with pytest.raises(RuntimeError):
         h._post_to_planner('hello')
     assert h.sdk.keychain.account == 'client@acme.com'
+
+
+def test_non_json_response_raises_marcus_error(host):
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+    bad = _FakeResp(500, body='<html>oops</html>')
+    def _json(): raise ValueError('no json')
+    bad.json = _json
+    h, _ = _make_host_for_post(bad)
+    with pytest.raises(MarcusError):
+        h._post_to_planner('hi')
+
+def test_403_retries_through_praetorian_account(host):
+    first = _FakeResp(403, body='forbidden')
+    second = _FakeResp(200, payload={'conversation': {'uuid': 'c1'}})
+    h, calls = _make_host_for_post(first, second)
+    out = h._post_to_planner('hi')
+    assert calls['n'] == 2
+    assert out['conversation']['uuid'] == 'c1'
+    assert h.sdk.keychain.account == 'client@acme.com'  # restored

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -301,6 +301,45 @@ def test_ws_messages_yields_until_chariot(host):
     assert collected[-1]['content'] == 'final'
 
 
+def test_ws_messages_builds_url_and_subscribe_frame(host, monkeypatch):
+    import json as _json
+    captured = {}
+
+    class _Conn:
+        def send(self, payload): captured['sub'] = payload
+        def recv(self): return ''
+        def settimeout(self, t): pass
+        def close(self): pass
+
+    def _fake_create_connection(url, *a, **k):
+        captured['url'] = url
+        return _Conn()
+
+    import websocket
+    monkeypatch.setattr(websocket, 'create_connection', _fake_create_connection)
+
+    class _KC:
+        account = 'client@acme.com'
+        def websocket_url(self): return 'wss://x/ws'
+        def token(self): return 'TKN'
+
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            return ([{'key': '#message#c1#001', 'role': 'chariot', 'content': 'done'}], None)
+
+    host.sdk = types.SimpleNamespace(keychain=_KC(), search=_Search())
+    msgs = list(host._ws_messages('c1', after_key=''))
+    assert msgs and msgs[-1]['role'] == 'chariot'
+    assert captured['url'].startswith('wss://x/ws?')
+    assert 'token=TKN' in captured['url']
+    assert 'user=true' in captured['url']
+    assert 'account=client@acme.com' in captured['url']
+    sub = _json.loads(captured['sub'])
+    assert sub['action'] == 'subscribe'
+    assert sub['subscriptions'][0]['pattern'] == '#message#c1'
+    assert sub['subscriptions'][0]['matchType'] == 'prefix'
+
+
 def test_send_to_marcus_handles_ctrl_c(host):
     # _post_to_planner succeeds, but polling raises KeyboardInterrupt mid-stream
     host._post_to_planner = lambda m: {'conversation': {'uuid': 'c1'}}

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -94,3 +94,40 @@ def test_403_retries_through_praetorian_account(host):
     assert calls['n'] == 2
     assert out['conversation']['uuid'] == 'c1'
     assert h.sdk.keychain.account == 'client@acme.com'  # restored
+
+
+def test_poll_messages_yields_only_new_and_stops_on_chariot(host):
+    msgs_round1 = [{'key': '#message#c1#001', 'role': 'tool call', 'content': '{}'},
+                   {'key': '#message#c1#002', 'role': 'tool response', 'content': '{"assets":[1]}'}]
+    msgs_round2 = msgs_round1 + [{'key': '#message#c1#003', 'role': 'chariot', 'content': 'final answer'}]
+    rounds = iter([msgs_round1, msgs_round2])
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            return (next(rounds), None)
+    host.sdk = types.SimpleNamespace(search=_Search())
+    host.context = types.SimpleNamespace(verbose=False)
+    collected = list(host._poll_messages('c1', after_key='', max_wait=5, sleep=lambda s: None))
+    roles = [m['role'] for m in collected]
+    assert roles[-1] == 'chariot'
+    assert collected[-1]['content'] == 'final answer'
+
+def test_poll_messages_surfaces_persistent_errors(host):
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            raise RuntimeError('search down')
+    host.sdk = types.SimpleNamespace(search=_Search())
+    host.context = types.SimpleNamespace(verbose=False)
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+    with pytest.raises(MarcusError):
+        list(host._poll_messages('c1', after_key='', max_wait=2, sleep=lambda s: None,
+                                 error_threshold=1))
+
+def test_post_to_planner_guards_non_json_on_200(host):
+    # 200 OK but body is not JSON -> must raise MarcusError (the JSON-parse guard)
+    from praetorian_cli.ui.console.commands.marcus import MarcusError
+    ok_but_bad = _FakeResp(200, body='not json', ok=True)
+    def _raise(): raise ValueError('no json')
+    ok_but_bad.json = _raise
+    h, _ = _make_host_for_post(ok_but_bad)
+    with pytest.raises(MarcusError):
+        h._post_to_planner('hi')

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -131,3 +131,26 @@ def test_post_to_planner_guards_non_json_on_200(host):
     h, _ = _make_host_for_post(ok_but_bad)
     with pytest.raises(MarcusError):
         h._post_to_planner('hi')
+
+
+def test_send_to_marcus_handles_ctrl_c(host):
+    # _post_to_planner succeeds, but polling raises KeyboardInterrupt mid-stream
+    host._post_to_planner = lambda m: {'conversation': {'uuid': 'c1'}}
+    def _boom(*a, **k):
+        raise KeyboardInterrupt()
+    host._poll_messages = _boom
+    printed = []
+    class _Console:
+        def print(self, *a, **k): printed.append(' '.join(str(x) for x in a))
+        def status(self, *a, **k):
+            import contextlib; return contextlib.nullcontext()
+    host.console = _Console()
+    host.colors = {'primary': 'red'}
+    host.context = types.SimpleNamespace(account=None, mode='agent', conversation_id=None,
+                                         verbose=False)
+    class _Search:
+        def by_key_prefix(self, prefix, user=False): return ([], None)
+    host.sdk = types.SimpleNamespace(search=_Search())
+    result = host._send_to_marcus('hi')
+    assert result is None
+    assert any('cancel' in p.lower() or 'interrupt' in p.lower() for p in printed)

--- a/praetorian_cli/sdk/test/ui/test_console_marcus.py
+++ b/praetorian_cli/sdk/test/ui/test_console_marcus.py
@@ -201,6 +201,106 @@ def test_poll_messages_skips_non_dict_items(host):
 
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── WebSocket transport with polling fallback ────────────────────────────────
+
+def _ws_host(ws_url=None, token='jwt-tok', account=None):
+    h = _Host()
+
+    class _KC:
+        def websocket_url(self): return ws_url
+        def token(self): return token
+    _KC.account = account
+
+    class _Search:
+        calls = []
+        def by_key_prefix(self, prefix, user=False):
+            raise AssertionError('by_key_prefix should not be called in this test')
+
+    h.sdk = types.SimpleNamespace(keychain=_KC(), search=_Search())
+    return h
+
+
+def test_stream_uses_polling_when_no_ws_url(host):
+    h = _ws_host(ws_url=None)
+    sentinel = [{'key': 'a', 'role': 'chariot', 'content': 'polled'}]
+    h._poll_messages = lambda cid, after_key='': iter(sentinel)
+    h._ws_messages = lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError('ws should not be used when no url'))
+    assert list(h._stream_messages('c1')) == sentinel
+
+
+def test_stream_uses_ws_when_configured(host):
+    h = _ws_host(ws_url='wss://x')
+    ws_msgs = [{'key': '1', 'role': 'tool call', 'content': '{}'},
+               {'key': '2', 'role': 'chariot', 'content': 'ws-done'}]
+    h._ws_messages = lambda cid, after_key='': iter(ws_msgs)
+    def _poll_boom(*a, **k):
+        raise AssertionError('polling must not be called when ws works')
+    h._poll_messages = _poll_boom
+    assert list(h._stream_messages('c1')) == ws_msgs
+
+
+def test_stream_falls_back_to_polling_on_ws_unavailable_before_yield(host):
+    from praetorian_cli.ui.console.commands.marcus import _WSUnavailable
+    h = _ws_host(ws_url='wss://x')
+    def _ws_fail(cid, after_key=''):
+        raise _WSUnavailable('connect failed')
+        yield  # pragma: no cover (make it a generator)
+    h._ws_messages = _ws_fail
+    sentinel = [{'key': 'p', 'role': 'chariot', 'content': 'polled-fallback'}]
+    h._poll_messages = lambda cid, after_key='': iter(sentinel)
+    assert list(h._stream_messages('c1')) == sentinel
+
+
+def test_stream_raises_if_ws_drops_after_yield(host):
+    from praetorian_cli.ui.console.commands.marcus import _WSUnavailable, MarcusError
+    h = _ws_host(ws_url='wss://x')
+    def _ws_drop(cid, after_key=''):
+        yield {'key': '1', 'role': 'tool call', 'content': '{}'}
+        raise _WSUnavailable('dropped mid-stream')
+    h._ws_messages = _ws_drop
+    def _poll_boom(*a, **k):
+        raise AssertionError('must not fall back to polling after yielding')
+    h._poll_messages = _poll_boom
+    with pytest.raises(MarcusError):
+        list(h._stream_messages('c1'))
+
+
+def test_ws_messages_yields_until_chariot(host):
+    from unittest.mock import patch
+    h = _Host()
+
+    class _KC:
+        account = None
+        def websocket_url(self): return 'wss://x'
+        def token(self): return 'jwt-tok'
+
+    rounds = iter([
+        [{'key': '#message#c1#001', 'role': 'tool call', 'content': '{}'}],
+        [{'key': '#message#c1#001', 'role': 'tool call', 'content': '{}'},
+         {'key': '#message#c1#002', 'role': 'chariot', 'content': 'final'}],
+    ])
+
+    class _Search:
+        def by_key_prefix(self, prefix, user=False):
+            return (next(rounds), None)
+
+    h.sdk = types.SimpleNamespace(keychain=_KC(), search=_Search())
+
+    class _FakeConn:
+        def send(self, *a, **k): pass
+        def recv(self, *a, **k): return ''
+        def settimeout(self, *a, **k): pass
+        def close(self, *a, **k): pass
+
+    with patch('websocket.create_connection', return_value=_FakeConn()):
+        collected = list(h._ws_messages('c1', after_key=''))
+
+    roles = [m['role'] for m in collected]
+    assert roles == ['tool call', 'chariot']
+    assert collected[-1]['content'] == 'final'
+
+
 def test_send_to_marcus_handles_ctrl_c(host):
     # _post_to_planner succeeds, but polling raises KeyboardInterrupt mid-stream
     host._post_to_planner = lambda m: {'conversation': {'uuid': 'c1'}}
@@ -218,7 +318,9 @@ def test_send_to_marcus_handles_ctrl_c(host):
                                          verbose=False)
     class _Search:
         def by_key_prefix(self, prefix, user=False): return ([], None)
-    host.sdk = types.SimpleNamespace(search=_Search())
+    class _KC:
+        def websocket_url(self): return None
+    host.sdk = types.SimpleNamespace(search=_Search(), keychain=_KC())
     result = host._send_to_marcus('hi')
     assert result is None
     assert any('cancel' in p.lower() or 'interrupt' in p.lower() for p in printed)

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -12,6 +12,10 @@ from rich.panel import Panel
 from praetorian_cli.ui.aegis.theme import PRIMARY_RED, COMPLEMENTARY_GOLD
 
 
+class MarcusError(Exception):
+    """Raised for recoverable Marcus terminal errors (shown to the user)."""
+
+
 class MarcusCommands:
     """Marcus AI console commands. Mixed into GuardConsole."""
 
@@ -103,40 +107,58 @@ class MarcusCommands:
 
         self.console.print('[dim]Returned to console.[/dim]')
 
-    def _send_to_marcus(self, message: str) -> Optional[str]:
-        """Send message to Marcus and poll for response with live tool output."""
+    def _post_to_planner(self, message: str):
+        """POST to /planner, handling the 403 retry-as-Praetorian path safely.
+
+        Returns the parsed JSON dict. Raises on network/HTTP error; the keychain
+        account is always restored.
+        """
         url = self.sdk.url('/planner')
         payload = {'message': message, 'mode': self.context.mode}
         if self.context.conversation_id:
             payload['conversationId'] = self.context.conversation_id
 
-        with self.console.status('Sending...', spinner='dots', spinner_style=self.colors['primary']):
+        with self.console.status('Sending...', spinner='dots',
+                                 spinner_style=self.colors['primary']):
             response = self.sdk.chariot_request('POST', url, json=payload)
 
-        # If AI is disabled on the impersonated account, retry as the Praetorian user
         if response.status_code == 403 and self.context.account:
             login_user = self.sdk.accounts.login_principal()
             if login_user and login_user.endswith('@praetorian.com'):
-                self.console.print(f'[dim]AI not enabled on this account -- routing through {login_user}[/dim]')
-                # Temporarily clear impersonation for the AI call
+                self.console.print(
+                    f'[dim]AI not enabled on this account -- routing through {login_user}[/dim]')
                 saved_account = self.sdk.keychain.account
-                self.sdk.keychain.account = None
-                # Add engagement context to the message so Marcus queries the right data
-                if self.context.account not in message:
-                    message = f'[Context: querying data for account {self.context.account}] {message}'
-                payload['message'] = message
-                if self.context.conversation_id:
-                    payload.pop('conversationId', None)
-                    self.context.conversation_id = None
-                with self.console.status('Sending via Praetorian account...', spinner='dots', spinner_style=self.colors['primary']):
-                    response = self.sdk.chariot_request('POST', url, json=payload)
-                self.sdk.keychain.account = saved_account
+                try:
+                    self.sdk.keychain.account = None
+                    if self.context.account not in message:
+                        message = f'[Context: querying data for account {self.context.account}] {message}'
+                    payload['message'] = message
+                    if self.context.conversation_id:
+                        payload.pop('conversationId', None)
+                        self.context.conversation_id = None
+                    with self.console.status('Sending via Praetorian account...', spinner='dots',
+                                             spinner_style=self.colors['primary']):
+                        response = self.sdk.chariot_request('POST', url, json=payload)
+                finally:
+                    self.sdk.keychain.account = saved_account
 
         if not response.ok:
-            self.console.print(f'[error]API error: {response.status_code} - {response.text}[/error]')
+            raise MarcusError(f'API error: {response.status_code} - {response.text}')
+
+        try:
+            return response.json()
+        except (ValueError, json.JSONDecodeError):
+            raise MarcusError(
+                f'Unexpected non-JSON response ({response.status_code}): {response.text[:200]}')
+
+    def _send_to_marcus(self, message: str) -> Optional[str]:
+        """Send message to Marcus and poll for response with live tool output."""
+        try:
+            result = self._post_to_planner(message)
+        except MarcusError as e:
+            self.console.print(f'[error]{e}[/error]')
             return None
 
-        result = response.json()
         if not self.context.conversation_id and 'conversation' in result:
             self.context.conversation_id = result['conversation'].get('uuid')
 

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -251,6 +251,43 @@ class MarcusCommands:
         self.console.print('\n[warning]Timed out waiting for response[/warning]')
         return None
 
+    def _poll_messages(self, conversation_id, after_key='', *, max_wait=180,
+                       sleep=time.sleep, error_threshold=5):
+        """Yield new conversation messages in key order until a 'chariot' reply.
+
+        Pages by after_key (client-side filter). Backs off when idle. Raises
+        MarcusError after `error_threshold` consecutive fetch failures so
+        problems surface instead of hanging.
+        """
+        start = time.time()
+        last_key = after_key
+        delay = 1.0
+        consecutive_errors = 0
+        prefix = f'#message#{conversation_id}#'
+        while time.time() - start < max_wait:
+            try:
+                messages, _ = self.sdk.search.by_key_prefix(prefix, user=True)
+                consecutive_errors = 0
+            except Exception as e:
+                consecutive_errors += 1
+                if consecutive_errors >= error_threshold:
+                    raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
+                sleep(delay)
+                continue
+            new = sorted((m for m in messages if m.get('key', '') > last_key),
+                         key=lambda x: x.get('key', ''))
+            if new:
+                delay = 1.0
+                for msg in new:
+                    last_key = msg.get('key', '')
+                    yield msg
+                    if msg.get('role', '') == 'chariot':
+                        return
+            else:
+                delay = min(delay + 1.0, 3.0)
+            sleep(delay)
+        raise MarcusError('Timed out waiting for response')
+
     def _parse_tool_name(self, content: str, msg: dict = None) -> str:
         """Extract a human-readable tool name from a tool call message."""
         # Try explicit name fields first

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -5,6 +5,8 @@ import os
 import time
 from typing import Optional
 
+from requests.exceptions import RequestException
+
 from prompt_toolkit.formatted_text import HTML
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -120,7 +122,10 @@ class MarcusCommands:
 
         with self.console.status('Sending...', spinner='dots',
                                  spinner_style=self.colors['primary']):
-            response = self.sdk.chariot_request('POST', url, json=payload)
+            try:
+                response = self.sdk.chariot_request('POST', url, json=payload)
+            except RequestException as e:
+                raise MarcusError(f'Network error reaching Marcus: {e}')
 
         if response.status_code == 403 and self.context.account:
             login_user = self.sdk.accounts.login_principal()
@@ -138,7 +143,10 @@ class MarcusCommands:
                         self.context.conversation_id = None
                     with self.console.status('Sending via Praetorian account...', spinner='dots',
                                              spinner_style=self.colors['primary']):
-                        response = self.sdk.chariot_request('POST', url, json=payload)
+                        try:
+                            response = self.sdk.chariot_request('POST', url, json=payload)
+                        except RequestException as e:
+                            raise MarcusError(f'Network error reaching Marcus: {e}')
                 finally:
                     self.sdk.keychain.account = saved_account
 
@@ -155,11 +163,14 @@ class MarcusCommands:
         """Send message to Marcus and poll for response with live tool output."""
         try:
             result = self._post_to_planner(message)
+        except KeyboardInterrupt:
+            self.console.print('\n[warning]Cancelled — returned to console.[/warning]')
+            return None
         except MarcusError as e:
             self.console.print(f'[error]{e}[/error]')
             return None
 
-        if not self.context.conversation_id and 'conversation' in result:
+        if isinstance(result, dict) and not self.context.conversation_id and 'conversation' in result:
             self.context.conversation_id = result['conversation'].get('uuid')
 
         # Snapshot existing messages so we only process NEW ones from this request
@@ -235,7 +246,7 @@ class MarcusCommands:
                     raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
                 sleep(delay)
                 continue
-            new = sorted((m for m in messages if m.get('key', '') > last_key),
+            new = sorted((m for m in messages if isinstance(m, dict) and m.get('key', '') > last_key),
                          key=lambda x: x.get('key', ''))
             if new:
                 delay = 1.0

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -173,82 +173,44 @@ class MarcusCommands:
         except Exception:
             pass
 
-        # Poll for response -- show tool calls live
-        max_wait = 180
-        start_time = time.time()
+        tool_log = []
         pending_tool = None
-        tool_log = []  # Store all tool calls/responses for this interaction
-        seen_tool_keys = set()  # Track which tool messages we displayed live
-
-        acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
-        self.console.print(f'[dim]Thinking...[/dim]{acct_label}', end='')
-
-        while time.time() - start_time < max_wait:
-            try:
-                messages, _ = self.sdk.search.by_key_prefix(
-                    f'#message#{self.context.conversation_id}#', user=True
-                )
-                new_msgs = sorted(
-                    [m for m in messages if m.get('key', '') > last_key],
-                    key=lambda x: x.get('key', '')
-                )
-
-                for msg in new_msgs:
-                    role = msg.get('role', '')
-                    content = msg.get('content', '')
-                    last_key = msg.get('key', '')
-
-                    if role == 'chariot':
-                        if pending_tool:
-                            self.console.print()  # newline after tool output
-                        # Retroactively show any tool calls we missed during polling
-                        missed = [t for t in tool_log if t['key'] not in seen_tool_keys]
-                        if missed:
-                            self.console.print()
-                            for entry in missed:
-                                if entry['role'] == 'tool call':
-                                    self.console.print(f'  [dim]->[/dim] [accent]{entry["name"]}[/accent]', end='')
-                                elif entry['role'] == 'tool response':
-                                    summary = entry.get('summary', '')
-                                    if summary:
-                                        self.console.print(f' [dim]-- {summary}[/dim]', end='')
-                                    self.console.print(f' [success]done[/success]')
-                        # Save tool log for "show tools" command
-                        self._last_tool_log = tool_log
-                        return content
-                    elif role == 'tool call':
-                        tool_name = self._parse_tool_name(content, msg)
-                        tool_log.append({'role': role, 'name': tool_name, 'content': content, 'msg': msg, 'key': msg.get('key', '')})
-                        if pending_tool:
-                            self.console.print(f' [success]done[/success]')
-                        self.console.print(f'  [dim]->[/dim] [accent]{tool_name}[/accent]', end='')
-                        seen_tool_keys.add(msg.get('key', ''))
-                        if self.context.verbose:
-                            self.console.print()
-                            self._print_verbose_tool_call(content, msg)
-                        pending_tool = tool_name
-                    elif role == 'tool response':
-                        result_summary = self._parse_tool_result(content)
-                        inferred = self._infer_tool_from_response(content)
-                        tool_log.append({'role': role, 'name': inferred, 'content': content, 'summary': result_summary, 'key': msg.get('key', '')})
-                        # Retroactively fix the pending tool name if we inferred one
-                        if inferred and pending_tool == 'tool':
-                            # Rewrite the line: clear current and reprint with inferred name
-                            self.console.print(f'\r  [dim]->[/dim] [accent]{inferred}[/accent]', end='')
-                        if result_summary:
-                            self.console.print(f' [dim]-- {result_summary}[/dim]', end='')
-                        self.console.print(f' [success]done[/success]')
-                        seen_tool_keys.add(msg.get('key', ''))
-                        if self.context.verbose:
-                            self._print_verbose_tool_response(content)
-                        pending_tool = None
-            except Exception:
-                pass
-
-            time.sleep(1)
-
+        try:
+            for msg in self._poll_messages(self.context.conversation_id, after_key=last_key):
+                role = msg.get('role', '')
+                content = msg.get('content', '')
+                if role == 'chariot':
+                    self._last_tool_log = tool_log
+                    return content
+                elif role == 'tool call':
+                    tool_name = self._parse_tool_name(content, msg)
+                    tool_log.append({'role': role, 'name': tool_name, 'content': content,
+                                     'msg': msg, 'key': msg.get('key', '')})
+                    self.console.print(f'  [dim]->[/dim] [accent]{tool_name}[/accent]')
+                    if self.context.verbose:
+                        self._print_verbose_tool_call(content, msg)
+                    pending_tool = tool_name
+                elif role == 'tool response':
+                    result_summary = self._parse_tool_result(content)
+                    inferred = self._infer_tool_from_response(content)
+                    tool_log.append({'role': role, 'name': inferred, 'content': content,
+                                     'summary': result_summary, 'key': msg.get('key', '')})
+                    if result_summary:
+                        self.console.print(f'    [dim]-- {result_summary}[/dim] [success]done[/success]')
+                    else:
+                        self.console.print(f'    [success]done[/success]')
+                    if self.context.verbose:
+                        self._print_verbose_tool_response(content)
+                    pending_tool = None
+        except KeyboardInterrupt:
+            self._last_tool_log = tool_log
+            self.console.print('\n[warning]Cancelled — returned to console.[/warning]')
+            return None
+        except MarcusError as e:
+            self._last_tool_log = tool_log
+            self.console.print(f'\n[warning]{e}[/warning]')
+            return None
         self._last_tool_log = tool_log
-        self.console.print('\n[warning]Timed out waiting for response[/warning]')
         return None
 
     def _poll_messages(self, conversation_id, after_key='', *, max_wait=180,

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -272,7 +272,12 @@ class MarcusCommands:
         import websocket  # websocket-client
         ws_url = self.sdk.keychain.websocket_url()
         token = self.sdk.keychain.token()
+        # Token is embedded as a query-string parameter — must never be logged or
+        # interpolated into exception messages.
         url = f"{ws_url}?token={token}&user=true"
+        # Unlike _post_to_planner, the WS path does not perform the 403 "route
+        # through @praetorian.com" reroute — it assumes the account has direct AI
+        # access (opt-in transport).
         if self.sdk.keychain.account:
             url += f"&account={self.sdk.keychain.account}"
         try:
@@ -280,6 +285,8 @@ class MarcusCommands:
             conn.send(json.dumps({"action": "subscribe", "subscriptions": [
                 {"pattern": f"#message#{conversation_id}", "matchType": "prefix"}]}))
         except Exception as e:
+            # str(e) from websocket-client does not contain the URL/token, so
+            # this is safe; the URL variable is intentionally not interpolated here.
             raise _WSUnavailable(str(e))
         last_key = after_key
         start = time.time()
@@ -289,8 +296,9 @@ class MarcusCommands:
                     conn.settimeout(5)
                     conn.recv()  # block until a change event (content ignored; signal only)
                 except websocket.WebSocketTimeoutException:
-                    pass  # periodic wake to re-check / honor max_wait
+                    pass  # 5 s timeout doubles as an idle safety re-poll (intentional)
                 except Exception as e:
+                    # str(e) does not contain the URL/token — safe to forward as-is.
                     raise _WSUnavailable(str(e))
                 messages, _ = self.sdk.search.by_key_prefix(
                     f'#message#{conversation_id}#', user=True)

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -173,8 +173,9 @@ class MarcusCommands:
         except Exception:
             pass
 
+        acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
+        self.console.print(f'[dim]Thinking...[/dim]{acct_label}')
         tool_log = []
-        pending_tool = None
         try:
             for msg in self._poll_messages(self.context.conversation_id, after_key=last_key):
                 role = msg.get('role', '')
@@ -189,7 +190,6 @@ class MarcusCommands:
                     self.console.print(f'  [dim]->[/dim] [accent]{tool_name}[/accent]')
                     if self.context.verbose:
                         self._print_verbose_tool_call(content, msg)
-                    pending_tool = tool_name
                 elif role == 'tool response':
                     result_summary = self._parse_tool_result(content)
                     inferred = self._infer_tool_from_response(content)
@@ -201,14 +201,13 @@ class MarcusCommands:
                         self.console.print(f'    [success]done[/success]')
                     if self.context.verbose:
                         self._print_verbose_tool_response(content)
-                    pending_tool = None
         except KeyboardInterrupt:
             self._last_tool_log = tool_log
             self.console.print('\n[warning]Cancelled — returned to console.[/warning]')
             return None
         except MarcusError as e:
             self._last_tool_log = tool_log
-            self.console.print(f'\n[warning]{e}[/warning]')
+            self.console.print(f'\n[error]{e}[/error]')
             return None
         self._last_tool_log = tool_log
         return None
@@ -217,7 +216,7 @@ class MarcusCommands:
                        sleep=time.sleep, error_threshold=5):
         """Yield new conversation messages in key order until a 'chariot' reply.
 
-        Pages by after_key (client-side filter). Backs off when idle. Raises
+        Fetches the conversation and filters client-side for messages after `after_key`. Backs off when idle. Raises
         MarcusError after `error_threshold` consecutive fetch failures so
         problems surface instead of hanging.
         """

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -18,6 +18,10 @@ class MarcusError(Exception):
     """Raised for recoverable Marcus terminal errors (shown to the user)."""
 
 
+class _WSUnavailable(Exception):
+    """Internal: WebSocket transport unavailable; fall back to polling."""
+
+
 class MarcusCommands:
     """Marcus AI console commands. Mixed into GuardConsole."""
 
@@ -188,7 +192,7 @@ class MarcusCommands:
         self.console.print(f'[dim]Thinking...[/dim]{acct_label}')
         tool_log = []
         try:
-            for msg in self._poll_messages(self.context.conversation_id, after_key=last_key):
+            for msg in self._stream_messages(self.context.conversation_id, after_key=last_key):
                 role = msg.get('role', '')
                 content = msg.get('content', '')
                 if role == 'chariot':
@@ -259,6 +263,68 @@ class MarcusCommands:
                 delay = min(delay + 1.0, 3.0)
             sleep(delay)
         raise MarcusError('Timed out waiting for response')
+
+    def _ws_messages(self, conversation_id, after_key='', *, max_wait=180):
+        """Yield new conversation messages via the WebSocket change-feed until a
+        'chariot' reply. Reuses by_key_prefix to fetch message bodies on each WS
+        event. Raises MarcusError on timeout. Raises _WSUnavailable on
+        connect/subscribe failure so the caller can fall back to polling."""
+        import websocket  # websocket-client
+        ws_url = self.sdk.keychain.websocket_url()
+        token = self.sdk.keychain.token()
+        url = f"{ws_url}?token={token}&user=true"
+        if self.sdk.keychain.account:
+            url += f"&account={self.sdk.keychain.account}"
+        try:
+            conn = websocket.create_connection(url, timeout=10)
+            conn.send(json.dumps({"action": "subscribe", "subscriptions": [
+                {"pattern": f"#message#{conversation_id}", "matchType": "prefix"}]}))
+        except Exception as e:
+            raise _WSUnavailable(str(e))
+        last_key = after_key
+        start = time.time()
+        try:
+            while time.time() - start < max_wait:
+                try:
+                    conn.settimeout(5)
+                    conn.recv()  # block until a change event (content ignored; signal only)
+                except websocket.WebSocketTimeoutException:
+                    pass  # periodic wake to re-check / honor max_wait
+                except Exception as e:
+                    raise _WSUnavailable(str(e))
+                messages, _ = self.sdk.search.by_key_prefix(
+                    f'#message#{conversation_id}#', user=True)
+                new = sorted((m for m in messages if isinstance(m, dict) and m.get('key', '') > last_key),
+                             key=lambda x: x.get('key', ''))
+                for msg in new:
+                    last_key = msg.get('key', '')
+                    yield msg
+                    if msg.get('role', '') == 'chariot':
+                        return
+            raise MarcusError('Timed out waiting for response')
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def _stream_messages(self, conversation_id, after_key=''):
+        """Yield conversation messages via WebSocket if configured, else polling.
+        Falls back to polling if the WS connection/subscribe fails before any
+        message is yielded. If the WS drops after yielding, re-raise as
+        MarcusError to avoid silently replaying messages via polling."""
+        if self.sdk.keychain.websocket_url():
+            yielded = False
+            try:
+                for msg in self._ws_messages(conversation_id, after_key=after_key):
+                    yielded = True
+                    yield msg
+                return
+            except _WSUnavailable:
+                if yielded:
+                    raise MarcusError('WebSocket connection lost mid-stream')
+                # else fall through to polling
+        yield from self._poll_messages(conversation_id, after_key=after_key)
 
     def _parse_tool_name(self, content: str, msg: dict = None) -> str:
         """Extract a human-readable tool name from a tool call message."""

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -163,22 +163,28 @@ class MarcusCommands:
             raise MarcusError(
                 f'Unexpected non-JSON response ({response.status_code}): {response.text[:200]}')
 
+    def _snapshot_last_key(self, conversation_id: Optional[str]) -> str:
+        """Return the highest existing message key for a conversation, or '' if none/unknown."""
+        if not conversation_id:
+            return ''
+        try:
+            existing, _ = self.sdk.search.by_key_prefix(
+                f'#message#{conversation_id}#', user=True
+            )
+            if existing:
+                return max(m.get('key', '') for m in existing)
+        except Exception:
+            pass
+        return ''
+
     def _send_to_marcus(self, message: str) -> Optional[str]:
         """Send message to Marcus and poll for response with live tool output."""
         # Snapshot existing messages BEFORE the POST so we only process NEW ones
         # from this request — capturing it after the POST risks missing messages
         # when the response comes back fast. New conversations have no prior
         # messages to snapshot, so they start from after_key=''.
-        last_key = ''
-        if self.context.conversation_id:
-            try:
-                existing, _ = self.sdk.search.by_key_prefix(
-                    f'#message#{self.context.conversation_id}#', user=True
-                )
-                if existing:
-                    last_key = max(m.get('key', '') for m in existing)
-            except Exception:
-                pass
+        pre_conversation_id = self.context.conversation_id
+        last_key = self._snapshot_last_key(pre_conversation_id)
 
         try:
             result = self._post_to_planner(message)
@@ -191,6 +197,14 @@ class MarcusCommands:
 
         if isinstance(result, dict) and not self.context.conversation_id and 'conversation' in result:
             self.context.conversation_id = result['conversation'].get('uuid')
+
+        # A 403 retry inside _post_to_planner may have cleared conversation_id and
+        # started a brand-new conversation on the reroute. In that case the
+        # pre-POST snapshot above belongs to the OLD conversation's key namespace
+        # and must not be reused as after_key for the new one — re-snapshot
+        # against the finalized conversation_id.
+        if pre_conversation_id and self.context.conversation_id != pre_conversation_id:
+            last_key = self._snapshot_last_key(self.context.conversation_id)
 
         acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
         self.console.print(f'[dim]Thinking...[/dim]{acct_label}')

--- a/praetorian_cli/ui/console/commands/marcus.py
+++ b/praetorian_cli/ui/console/commands/marcus.py
@@ -165,6 +165,21 @@ class MarcusCommands:
 
     def _send_to_marcus(self, message: str) -> Optional[str]:
         """Send message to Marcus and poll for response with live tool output."""
+        # Snapshot existing messages BEFORE the POST so we only process NEW ones
+        # from this request — capturing it after the POST risks missing messages
+        # when the response comes back fast. New conversations have no prior
+        # messages to snapshot, so they start from after_key=''.
+        last_key = ''
+        if self.context.conversation_id:
+            try:
+                existing, _ = self.sdk.search.by_key_prefix(
+                    f'#message#{self.context.conversation_id}#', user=True
+                )
+                if existing:
+                    last_key = max(m.get('key', '') for m in existing)
+            except Exception:
+                pass
+
         try:
             result = self._post_to_planner(message)
         except KeyboardInterrupt:
@@ -176,17 +191,6 @@ class MarcusCommands:
 
         if isinstance(result, dict) and not self.context.conversation_id and 'conversation' in result:
             self.context.conversation_id = result['conversation'].get('uuid')
-
-        # Snapshot existing messages so we only process NEW ones from this request
-        last_key = ''
-        try:
-            existing, _ = self.sdk.search.by_key_prefix(
-                f'#message#{self.context.conversation_id}#', user=True
-            )
-            if existing:
-                last_key = max(m.get('key', '') for m in existing)
-        except Exception:
-            pass
 
         acct_label = f' [dim]({self.context.account})[/dim]' if self.context.account else ''
         self.console.print(f'[dim]Thinking...[/dim]{acct_label}')
@@ -290,6 +294,7 @@ class MarcusCommands:
             raise _WSUnavailable(str(e))
         last_key = after_key
         start = time.time()
+        yielded = False
         try:
             while time.time() - start < max_wait:
                 try:
@@ -300,12 +305,22 @@ class MarcusCommands:
                 except Exception as e:
                     # str(e) does not contain the URL/token — safe to forward as-is.
                     raise _WSUnavailable(str(e))
-                messages, _ = self.sdk.search.by_key_prefix(
-                    f'#message#{conversation_id}#', user=True)
+                try:
+                    messages, _ = self.sdk.search.by_key_prefix(
+                        f'#message#{conversation_id}#', user=True)
+                except Exception as e:
+                    # Fetching message bodies after a WS signal can fail too. If we've
+                    # already yielded messages this stream, surface it as a MarcusError
+                    # (caller must not silently replay via polling); otherwise treat it
+                    # like a connect/subscribe failure so the caller can fall back.
+                    if yielded:
+                        raise MarcusError(f'Lost connection while waiting for Marcus: {e}')
+                    raise _WSUnavailable(str(e))
                 new = sorted((m for m in messages if isinstance(m, dict) and m.get('key', '') > last_key),
                              key=lambda x: x.get('key', ''))
                 for msg in new:
                     last_key = msg.get('key', '')
+                    yielded = True
                     yield msg
                     if msg.get('role', '') == 'chariot':
                         return

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     boto3 >= 1.34.0
     requests >= 2.31.0
     truststore >= 0.10.0
+    websocket-client >= 1.6
     pytest >= 8.0.2
     mcp >= 1.12.2
     anyio >= 3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     requests >= 2.31.0
     truststore >= 0.10.0
     websocket-client >= 1.6
+    websocket-client>=1.6.0
     pytest >= 8.0.2
     mcp >= 1.12.2
     anyio >= 3.0.0


### PR DESCRIPTION
> **PR Stack (6/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> 3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)
> 4. #268 Knossos, Aegis management (st7-st9)
> 5. #269 Red Team CLI (st5)
> **6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)** (this PR)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> 8. #272 share, leaderboard, misc, multipart (st18-st21)
> 9. #244 skills, risk-status, conversation UX
> 10. #243 Hannibal hunt CLI + TUI
> 11. #228 Marcus terminal hardening
> 12. #226 module management system


## Summary
- **ST-10 (Nuclei templates)**: `nuclei list`, `branches`, `get`, `commit` commands for template management
- **ST-11 (Bifrost budget)**: `bifrost provision`, `get-budget`, `set-budget`, `set-categories`, `delete-category`, `conversation-cost`, `hunt-cost`
- **ST-14 (Engineer VMs)**: `engineer-vm create`, `list`, `get`, `delete`, `pause`, `resume`, `restore`, `extend`, `ssh-cert`, `code-server-token`
- **ST-15 (NIST CSF)**: `csf get`, `set-score`, `delete-score`, `set-target` for CSF assessment management

All Praetorian-only commands gated with `@praetorian_only`. Destructive ops use `@click.confirmation_option`. 33 tests passing.

## Test plan
- [x] `pytest test_nuclei_cli.py` — 7 tests pass
- [x] `pytest test_bifrost_cli.py` — 9 tests pass
- [x] `pytest test_engineer_vm_cli.py` — 14 tests pass
- [x] `pytest test_csf_cli.py` — 5 tests pass (includes read-only `get` without praetorian gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)