### PR TITLE
feat: share links, leaderboard, misc hardening, multipart upload

### DIFF
--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -51,17 +51,17 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
+        except click.ClickException:
+            raise
         except click.Abort:
             raise
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
-        except click.ClickException:
         except click.exceptions.Exit:
+            raise
         except CancelledError:
+            raise
         except Exception as exc:
             if _debug_enabled(ctx):
+                raise
             raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper

--- a/praetorian_cli/handlers/leaderboard.py
+++ b/praetorian_cli/handlers/leaderboard.py
@@ -1,0 +1,45 @@
+import sys
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group()
+def leaderboard():
+    """Leaderboard snapshots and weight configuration"""
+    pass
+
+
+@leaderboard.command('get')
+@cli_handler
+@praetorian_only
+def get_leaderboard(chariot):
+    """Get the current leaderboard snapshot"""
+    print_json(chariot.leaderboard.get())
+
+
+@leaderboard.command('get-weights')
+@cli_handler
+@praetorian_only
+def get_weights(chariot):
+    """Get leaderboard weight configuration"""
+    print_json(chariot.leaderboard.get_weights())
+
+
+@leaderboard.command('set-weights')
+@cli_handler
+@praetorian_only
+def set_weights(chariot):
+    """Update leaderboard weights (reads JSON from stdin)
+
+    Stdin JSON should be a map of weight names to numeric values.
+    """
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Weights JSON is required via stdin')
+    weights = json.loads(raw)
+    print_json(chariot.leaderboard.set_weights(weights))

--- a/praetorian_cli/handlers/leaderboard.py
+++ b/praetorian_cli/handlers/leaderboard.py
@@ -5,7 +5,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import print_json, error
 
 
 @chariot.group()
@@ -38,8 +38,13 @@ def set_weights(chariot):
 
     Stdin JSON should be a map of weight names to numeric values.
     """
+    if sys.stdin.isatty():
+        raise click.UsageError('Weights JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Weights JSON is required via stdin')
-    weights = json.loads(raw)
+    try:
+        weights = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
     print_json(chariot.leaderboard.set_weights(weights))

--- a/praetorian_cli/handlers/misc.py
+++ b/praetorian_cli/handlers/misc.py
@@ -253,6 +253,23 @@ def jira_custom_fields(chariot):
     print_json(chariot.misc.jira_custom_fields(body))
 
 
+@integration_setup.command('jira-optional-custom-fields')
+@cli_handler
+@praetorian_only
+def jira_optional_custom_fields(chariot):
+    """Get Jira optional custom fields (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.jira_optional_custom_fields(body))
+
+
 @integration_setup.command('jira-priorities')
 @cli_handler
 @praetorian_only

--- a/praetorian_cli/handlers/misc.py
+++ b/praetorian_cli/handlers/misc.py
@@ -8,6 +8,25 @@ from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
 from praetorian_cli.handlers.utils import print_json, error
 
 
+def _read_stdin(description):
+    """Read raw text from stdin, erroring if it is not piped in or is empty."""
+    if sys.stdin.isatty():
+        raise click.UsageError(f'{description} is required via stdin')
+    content = sys.stdin.read().strip()
+    if not content:
+        raise click.UsageError(f'{description} is required via stdin')
+    return content
+
+
+def _read_json_stdin(description):
+    """Read and parse JSON from stdin."""
+    raw = _read_stdin(description)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+
+
 # --- Technology ---
 
 @chariot.command('update-technology')
@@ -86,15 +105,7 @@ def create_monitor(chariot):
     Required fields: name, techniques [{technique_id, name}]
     Optional: filters, executed_at, expires_in (e.g. "168h")
     """
-    if sys.stdin.isatty():
-        raise click.UsageError('Monitor session JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Monitor session JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Monitor session JSON')
     print_json(chariot.misc.create_monitor(body))
 
 
@@ -182,15 +193,7 @@ def parse_burp(chariot, url, filename):
 @praetorian_only
 def notify_vulnerability(chariot):
     """Dispatch a threat notification for a vulnerability (reads JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Vulnerability JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Vulnerability JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Vulnerability JSON')
     print_json(chariot.misc.notify_vulnerability(body))
 
 
@@ -207,15 +210,7 @@ def integration_setup():
 @praetorian_only
 def validate_integration(chariot):
     """Validate an integration configuration (reads JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.validate_integration(body))
 
 
@@ -224,15 +219,7 @@ def validate_integration(chariot):
 @praetorian_only
 def jira_transitions(chariot):
     """Get Jira workflow transitions (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.jira_transitions(body))
 
 
@@ -241,15 +228,7 @@ def jira_transitions(chariot):
 @praetorian_only
 def jira_custom_fields(chariot):
     """Get Jira custom fields (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.jira_custom_fields(body))
 
 
@@ -258,15 +237,7 @@ def jira_custom_fields(chariot):
 @praetorian_only
 def jira_optional_custom_fields(chariot):
     """Get Jira optional custom fields (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.jira_optional_custom_fields(body))
 
 
@@ -275,15 +246,7 @@ def jira_optional_custom_fields(chariot):
 @praetorian_only
 def jira_priorities(chariot):
     """Get Jira priorities (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.jira_priorities(body))
 
 
@@ -292,15 +255,7 @@ def jira_priorities(chariot):
 @praetorian_only
 def linear_teams(chariot):
     """Get Linear teams (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.linear_teams(body))
 
 
@@ -309,15 +264,7 @@ def linear_teams(chariot):
 @praetorian_only
 def linear_workflow_states(chariot):
     """Get Linear workflow states (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.linear_workflow_states(body))
 
 
@@ -326,15 +273,7 @@ def linear_workflow_states(chariot):
 @praetorian_only
 def linear_projects(chariot):
     """Get Linear projects (reads integration config JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Integration config JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Integration config JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Integration config JSON')
     print_json(chariot.misc.linear_projects(body))
 
 
@@ -378,15 +317,7 @@ def planner():
 @cli_handler
 def compact(chariot):
     """Compact a planner conversation (reads JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Compact request JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Compact request JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Compact request JSON')
     print_json(chariot.misc.planner_compact(body))
 
 
@@ -394,15 +325,7 @@ def compact(chariot):
 @cli_handler
 def stop(chariot):
     """Stop a running planner conversation (reads JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Stop request JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Stop request JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Stop request JSON')
     print_json(chariot.misc.planner_stop(body))
 
 
@@ -410,15 +333,7 @@ def stop(chariot):
 @cli_handler
 def interaction(chariot):
     """Record a planner interaction (reads JSON from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Interaction JSON is required via stdin')
-    raw = sys.stdin.read().strip()
-    if not raw:
-        raise click.UsageError('Interaction JSON is required via stdin')
-    try:
-        body = json.loads(raw)
-    except json.JSONDecodeError as e:
-        error(f'Invalid JSON input: {e}')
+    body = _read_json_stdin('Interaction JSON')
     print_json(chariot.misc.planner_interaction(body))
 
 
@@ -436,7 +351,7 @@ def planner_cost(chariot, uuid):
 @click.confirmation_option(prompt='Are you sure you want to delete this conversation?')
 def delete_conversation(chariot, uuid):
     """Delete a planner conversation"""
-    print_json(chariot.misc.delete_planner({'uuid': uuid}))
+    print_json(chariot.misc.delete_planner(uuid))
 
 
 # --- Hunt memory/cost ---
@@ -447,11 +362,7 @@ def delete_conversation(chariot, uuid):
 @click.argument('title')
 def set_hunt_memory(chariot, uuid, title):
     """Set hunt memory content (reads content from stdin)"""
-    if sys.stdin.isatty():
-        raise click.UsageError('Memory content is required via stdin')
-    content = sys.stdin.read().strip()
-    if not content:
-        raise click.UsageError('Memory content is required via stdin')
+    content = _read_stdin('Memory content')
     print_json(chariot.misc.put_hunt_memory(uuid, title, content))
 
 

--- a/praetorian_cli/handlers/misc.py
+++ b/praetorian_cli/handlers/misc.py
@@ -1,0 +1,380 @@
+import sys
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
+from praetorian_cli.handlers.utils import print_json
+
+
+# --- Technology ---
+
+@chariot.command('update-technology')
+@cli_handler
+@click.option('--key', required=True, help='Technology key (CPE-based)')
+@click.option('--name', default=None, help='Common name')
+@click.option('--comment', default=None, help='Comment about the technology')
+def update_technology(chariot, key, name, comment):
+    """Update a technology record"""
+    body = {'key': key}
+    if name is not None:
+        body['name'] = name
+    if comment is not None:
+        body['comment'] = comment
+    print_json(chariot.misc.update_technology(body))
+
+
+# --- Ticket ---
+
+@chariot.group()
+def ticket():
+    """Ticket lifecycle management"""
+    pass
+
+
+@ticket.command('create')
+@cli_handler
+@click.option('--risk', required=True, help='Risk key')
+@click.option('--account', required=True, help='Integration account key')
+@click.option('--template-id', default='', help='Ticket template ID')
+def create_ticket(chariot, risk, account, template_id):
+    """Create a ticket for a risk"""
+    body = {'risk': risk, 'account': account}
+    if template_id:
+        body['templateId'] = template_id
+    print_json(chariot.misc.create_ticket(body))
+
+
+@ticket.command('refresh')
+@cli_handler
+@click.option('--provider', required=True, help='Ticket provider (e.g. jira)')
+@click.option('--ticket-id', required=True, help='External ticket ID')
+def refresh_ticket(chariot, provider, ticket_id):
+    """Refresh/fetch a ticket from its provider"""
+    print_json(chariot.misc.update_ticket({
+        'provider': provider, 'ticketID': ticket_id,
+    }))
+
+
+@ticket.command('delete')
+@cli_handler
+@click.option('--provider', required=True, help='Ticket provider (e.g. jira)')
+@click.option('--ticket-id', required=True, help='External ticket ID')
+@click.confirmation_option(prompt='Are you sure you want to delete this ticket?')
+def delete_ticket(chariot, provider, ticket_id):
+    """Delete a ticket"""
+    print_json(chariot.misc.delete_ticket({
+        'provider': provider, 'ticketID': ticket_id,
+    }))
+
+
+# --- Monitor (Breach & Attack Simulation) ---
+
+@chariot.group()
+def monitor():
+    """Breach and attack simulation monitoring"""
+    pass
+
+
+@monitor.command('create')
+@cli_handler
+@praetorian_only
+def create_monitor(chariot):
+    """Create a monitoring session (reads JSON from stdin)
+
+    Required fields: name, techniques [{technique_id, name}]
+    Optional: filters, executed_at, expires_in (e.g. "168h")
+    """
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Monitor session JSON is required via stdin')
+    print_json(chariot.misc.create_monitor(json.loads(raw)))
+
+
+@monitor.command('update')
+@cli_handler
+@praetorian_only
+@click.option('--id', 'session_id', required=True, help='Monitor session ID')
+@click.option('--executed-at', required=True, help='Execution timestamp (RFC3339)')
+def update_monitor(chariot, session_id, executed_at):
+    """Update a monitoring session execution time"""
+    print_json(chariot.misc.update_monitor(session_id, {'executed_at': executed_at}))
+
+
+@monitor.command('delete')
+@cli_handler
+@praetorian_only
+@click.option('--id', 'session_id', required=True, help='Monitor session ID')
+@click.confirmation_option(prompt='Are you sure you want to cancel this session?')
+def delete_monitor(chariot, session_id):
+    """Cancel a monitoring session"""
+    print_json(chariot.misc.delete_monitor(session_id))
+
+
+# --- Feature flags ---
+
+@chariot.group()
+def flag():
+    """Feature flag management"""
+    pass
+
+
+@flag.command('set')
+@cli_handler
+@praetorian_only
+@click.argument('name')
+def set_flag(chariot, name):
+    """Enable a feature flag (requires admin role)"""
+    print_json(chariot.misc.set_flag(name))
+
+
+@flag.command('delete')
+@cli_handler
+@praetorian_only
+@click.argument('name')
+@click.confirmation_option(prompt='Are you sure you want to delete this flag?')
+def delete_flag(chariot, name):
+    """Delete a feature flag (requires admin role)"""
+    print_json(chariot.misc.delete_flag(name))
+
+
+# --- Repository ---
+
+@chariot.command('add-repository')
+@cli_handler
+@click.option('--name', required=True, help='Repository name')
+@click.option('--source-archive-key', required=True, help='S3 key of the uploaded zip')
+def add_repository(chariot, name, source_archive_key):
+    """Register a previously-uploaded zip as a repository asset"""
+    print_json(chariot.misc.create_repository(name, source_archive_key))
+
+
+# --- Burp ---
+
+@chariot.command('parse-burp')
+@cli_handler
+@click.option('--url', default=None, help='URL of the API definition')
+@click.option('--filename', default=None, help='Filename hint for content parsing')
+def parse_burp(chariot, url, filename):
+    """Parse a Burp API definition (reads content from stdin if --url not given)"""
+    if url:
+        print_json(chariot.misc.parse_burp(url=url))
+    else:
+        content = sys.stdin.read().strip()
+        if not content:
+            raise click.UsageError('Provide --url or pipe API definition content via stdin')
+        print_json(chariot.misc.parse_burp(content=content, filename=filename))
+
+
+# --- Vulnerability ---
+
+@chariot.command('notify-vulnerability')
+@cli_handler
+@praetorian_only
+def notify_vulnerability(chariot):
+    """Dispatch a threat notification for a vulnerability (reads JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Vulnerability JSON is required via stdin')
+    print_json(chariot.misc.notify_vulnerability(json.loads(raw)))
+
+
+# --- Integration helpers ---
+
+@chariot.group('integration-setup')
+def integration_setup():
+    """Integration validation and setup helpers"""
+    pass
+
+
+@integration_setup.command('validate')
+@cli_handler
+@praetorian_only
+def validate_integration(chariot):
+    """Validate an integration configuration (reads JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.validate_integration(json.loads(raw)))
+
+
+@integration_setup.command('jira-transitions')
+@cli_handler
+@praetorian_only
+def jira_transitions(chariot):
+    """Get Jira workflow transitions (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.jira_transitions(json.loads(raw)))
+
+
+@integration_setup.command('jira-custom-fields')
+@cli_handler
+@praetorian_only
+def jira_custom_fields(chariot):
+    """Get Jira custom fields (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.jira_custom_fields(json.loads(raw)))
+
+
+@integration_setup.command('jira-priorities')
+@cli_handler
+@praetorian_only
+def jira_priorities(chariot):
+    """Get Jira priorities (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.jira_priorities(json.loads(raw)))
+
+
+@integration_setup.command('linear-teams')
+@cli_handler
+@praetorian_only
+def linear_teams(chariot):
+    """Get Linear teams (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.linear_teams(json.loads(raw)))
+
+
+@integration_setup.command('linear-workflow-states')
+@cli_handler
+@praetorian_only
+def linear_workflow_states(chariot):
+    """Get Linear workflow states (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.linear_workflow_states(json.loads(raw)))
+
+
+@integration_setup.command('linear-projects')
+@cli_handler
+@praetorian_only
+def linear_projects(chariot):
+    """Get Linear projects (reads integration config JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Integration config JSON is required via stdin')
+    print_json(chariot.misc.linear_projects(json.loads(raw)))
+
+
+# --- Risk visited ---
+
+@chariot.command('risk-visited')
+@cli_handler
+@praetorian_only
+@click.argument('key')
+@click.option('--comment', default='', help='Visit comment')
+def risk_visited(chariot, key, comment):
+    """Mark a risk as visited"""
+    print_json(chariot.misc.risk_visited(key, comment))
+
+
+# --- Agent listing ---
+
+@chariot.command('agent-list')
+@cli_handler
+def agent_list(chariot):
+    """List registered agents"""
+    print_json(chariot.misc.agent_list())
+
+
+@chariot.command('agents')
+@cli_handler
+def agents_list(chariot):
+    """List conversation AI agents"""
+    print_json(chariot.misc.agents())
+
+
+# --- Planner (conversation AI) ---
+
+@chariot.group()
+def planner():
+    """Conversation AI planner management"""
+    pass
+
+
+@planner.command('compact')
+@cli_handler
+def compact(chariot):
+    """Compact a planner conversation (reads JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Compact request JSON is required via stdin')
+    print_json(chariot.misc.planner_compact(json.loads(raw)))
+
+
+@planner.command('stop')
+@cli_handler
+def stop(chariot):
+    """Stop a running planner conversation (reads JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Stop request JSON is required via stdin')
+    print_json(chariot.misc.planner_stop(json.loads(raw)))
+
+
+@planner.command('interaction')
+@cli_handler
+def interaction(chariot):
+    """Record a planner interaction (reads JSON from stdin)"""
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Interaction JSON is required via stdin')
+    print_json(chariot.misc.planner_interaction(json.loads(raw)))
+
+
+@planner.command('cost')
+@cli_handler
+@click.argument('uuid')
+def planner_cost(chariot, uuid):
+    """Get cost for a planner conversation"""
+    print_json(chariot.misc.planner_cost(uuid))
+
+
+@planner.command('delete')
+@cli_handler
+@click.argument('uuid')
+@click.confirmation_option(prompt='Are you sure you want to delete this conversation?')
+def delete_conversation(chariot, uuid):
+    """Delete a planner conversation"""
+    print_json(chariot.misc.delete_planner({'uuid': uuid}))
+
+
+# --- Hunt memory/cost ---
+
+@chariot.command('set-hunt-memory')
+@cli_handler
+@click.argument('uuid')
+@click.argument('title')
+def set_hunt_memory(chariot, uuid, title):
+    """Set hunt memory content (reads content from stdin)"""
+    content = sys.stdin.read().strip()
+    if not content:
+        raise click.UsageError('Memory content is required via stdin')
+    print_json(chariot.misc.put_hunt_memory(uuid, title, content))
+
+
+@chariot.command('delete-hunt-memory')
+@cli_handler
+@click.argument('uuid')
+@click.argument('title')
+@click.confirmation_option(prompt='Are you sure you want to delete this memory?')
+def delete_hunt_memory(chariot, uuid, title):
+    """Delete hunt memory by title"""
+    print_json(chariot.misc.delete_hunt_memory(uuid, title))
+
+
+@chariot.command('hunt-cost')
+@cli_handler
+@click.argument('uuid')
+def hunt_cost(chariot, uuid):
+    """Get cost for a hunt"""
+    print_json(chariot.misc.hunt_cost(uuid))

--- a/praetorian_cli/handlers/misc.py
+++ b/praetorian_cli/handlers/misc.py
@@ -5,7 +5,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler, praetorian_only
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import print_json, error
 
 
 # --- Technology ---
@@ -86,10 +86,16 @@ def create_monitor(chariot):
     Required fields: name, techniques [{technique_id, name}]
     Optional: filters, executed_at, expires_in (e.g. "168h")
     """
+    if sys.stdin.isatty():
+        raise click.UsageError('Monitor session JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Monitor session JSON is required via stdin')
-    print_json(chariot.misc.create_monitor(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.create_monitor(body))
 
 
 @monitor.command('update')
@@ -161,6 +167,8 @@ def parse_burp(chariot, url, filename):
     if url:
         print_json(chariot.misc.parse_burp(url=url))
     else:
+        if sys.stdin.isatty():
+            raise click.UsageError('Provide --url or pipe API definition content via stdin')
         content = sys.stdin.read().strip()
         if not content:
             raise click.UsageError('Provide --url or pipe API definition content via stdin')
@@ -174,10 +182,16 @@ def parse_burp(chariot, url, filename):
 @praetorian_only
 def notify_vulnerability(chariot):
     """Dispatch a threat notification for a vulnerability (reads JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Vulnerability JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Vulnerability JSON is required via stdin')
-    print_json(chariot.misc.notify_vulnerability(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.notify_vulnerability(body))
 
 
 # --- Integration helpers ---
@@ -193,10 +207,16 @@ def integration_setup():
 @praetorian_only
 def validate_integration(chariot):
     """Validate an integration configuration (reads JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.validate_integration(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.validate_integration(body))
 
 
 @integration_setup.command('jira-transitions')
@@ -204,10 +224,16 @@ def validate_integration(chariot):
 @praetorian_only
 def jira_transitions(chariot):
     """Get Jira workflow transitions (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.jira_transitions(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.jira_transitions(body))
 
 
 @integration_setup.command('jira-custom-fields')
@@ -215,10 +241,16 @@ def jira_transitions(chariot):
 @praetorian_only
 def jira_custom_fields(chariot):
     """Get Jira custom fields (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.jira_custom_fields(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.jira_custom_fields(body))
 
 
 @integration_setup.command('jira-priorities')
@@ -226,10 +258,16 @@ def jira_custom_fields(chariot):
 @praetorian_only
 def jira_priorities(chariot):
     """Get Jira priorities (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.jira_priorities(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.jira_priorities(body))
 
 
 @integration_setup.command('linear-teams')
@@ -237,10 +275,16 @@ def jira_priorities(chariot):
 @praetorian_only
 def linear_teams(chariot):
     """Get Linear teams (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.linear_teams(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.linear_teams(body))
 
 
 @integration_setup.command('linear-workflow-states')
@@ -248,10 +292,16 @@ def linear_teams(chariot):
 @praetorian_only
 def linear_workflow_states(chariot):
     """Get Linear workflow states (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.linear_workflow_states(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.linear_workflow_states(body))
 
 
 @integration_setup.command('linear-projects')
@@ -259,10 +309,16 @@ def linear_workflow_states(chariot):
 @praetorian_only
 def linear_projects(chariot):
     """Get Linear projects (reads integration config JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Integration config JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Integration config JSON is required via stdin')
-    print_json(chariot.misc.linear_projects(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.linear_projects(body))
 
 
 # --- Risk visited ---
@@ -305,30 +361,48 @@ def planner():
 @cli_handler
 def compact(chariot):
     """Compact a planner conversation (reads JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Compact request JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Compact request JSON is required via stdin')
-    print_json(chariot.misc.planner_compact(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.planner_compact(body))
 
 
 @planner.command('stop')
 @cli_handler
 def stop(chariot):
     """Stop a running planner conversation (reads JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Stop request JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Stop request JSON is required via stdin')
-    print_json(chariot.misc.planner_stop(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.planner_stop(body))
 
 
 @planner.command('interaction')
 @cli_handler
 def interaction(chariot):
     """Record a planner interaction (reads JSON from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Interaction JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Interaction JSON is required via stdin')
-    print_json(chariot.misc.planner_interaction(json.loads(raw)))
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    print_json(chariot.misc.planner_interaction(body))
 
 
 @planner.command('cost')
@@ -356,6 +430,8 @@ def delete_conversation(chariot, uuid):
 @click.argument('title')
 def set_hunt_memory(chariot, uuid, title):
     """Set hunt memory content (reads content from stdin)"""
+    if sys.stdin.isatty():
+        raise click.UsageError('Memory content is required via stdin')
     content = sys.stdin.read().strip()
     if not content:
         raise click.UsageError('Memory content is required via stdin')

--- a/praetorian_cli/handlers/multipart.py
+++ b/praetorian_cli/handlers/multipart.py
@@ -5,7 +5,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import print_json, error
 
 
 @chariot.group('multipart')
@@ -42,10 +42,18 @@ def complete(chariot):
 
     Stdin JSON: {"name": "...", "uploadId": "...", "parts": [{"partNumber": 1, "etag": "..."}]}
     """
+    if sys.stdin.isatty():
+        raise click.UsageError('Completion JSON is required via stdin')
     raw = sys.stdin.read().strip()
     if not raw:
         raise click.UsageError('Completion JSON is required via stdin')
-    body = json.loads(raw)
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as e:
+        error(f'Invalid JSON input: {e}')
+    for key in ('name', 'uploadId', 'parts'):
+        if key not in body:
+            error(f'Missing required key "{key}" in JSON input')
     print_json(chariot.multipart.complete(
         body['name'], body['uploadId'], body['parts'],
         praetorian=body.get('praetorian', False),

--- a/praetorian_cli/handlers/multipart.py
+++ b/praetorian_cli/handlers/multipart.py
@@ -1,0 +1,63 @@
+import sys
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group('multipart')
+def multipart():
+    """Multipart file upload management"""
+    pass
+
+
+@multipart.command('create')
+@cli_handler
+@click.option('--name', required=True, help='File name/key')
+@click.option('--praetorian', is_flag=True, default=False, help='Use praetorian file partition')
+@click.option('--ttl', default=None, type=int, help='Time-to-live in seconds')
+def create(chariot, name, praetorian, ttl):
+    """Initiate a multipart upload and get an upload ID"""
+    print_json(chariot.multipart.create(name, praetorian=praetorian, ttl=ttl))
+
+
+@multipart.command('part-url')
+@cli_handler
+@click.option('--name', required=True, help='File name/key')
+@click.option('--upload-id', required=True, help='Upload ID from create')
+@click.option('--part-number', required=True, type=int, help='Part number (1-based)')
+@click.option('--praetorian', is_flag=True, default=False, help='Use praetorian file partition')
+def part_url(chariot, name, upload_id, part_number, praetorian):
+    """Get a presigned URL for uploading a part"""
+    print_json(chariot.multipart.get_part_url(name, upload_id, part_number, praetorian=praetorian))
+
+
+@multipart.command('complete')
+@cli_handler
+def complete(chariot):
+    """Complete a multipart upload (reads JSON from stdin)
+
+    Stdin JSON: {"name": "...", "uploadId": "...", "parts": [{"partNumber": 1, "etag": "..."}]}
+    """
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise click.UsageError('Completion JSON is required via stdin')
+    body = json.loads(raw)
+    print_json(chariot.multipart.complete(
+        body['name'], body['uploadId'], body['parts'],
+        praetorian=body.get('praetorian', False),
+    ))
+
+
+@multipart.command('abort')
+@cli_handler
+@click.option('--name', required=True, help='File name/key')
+@click.option('--upload-id', required=True, help='Upload ID to abort')
+@click.option('--praetorian', is_flag=True, default=False, help='Use praetorian file partition')
+@click.confirmation_option(prompt='Are you sure you want to abort this upload?')
+def abort(chariot, name, upload_id, praetorian):
+    """Abort a multipart upload"""
+    print_json(chariot.multipart.abort(name, upload_id, praetorian=praetorian))

--- a/praetorian_cli/handlers/multipart.py
+++ b/praetorian_cli/handlers/multipart.py
@@ -52,10 +52,10 @@ def complete(chariot):
     except json.JSONDecodeError as e:
         error(f'Invalid JSON input: {e}')
     for key in ('name', 'uploadId', 'parts'):
-        if key not in body:
-            error(f'Missing required key "{key}" in JSON input')
+        if body.get(key) is None:
+            raise click.UsageError(f'Missing required key "{key}" in JSON input')
     print_json(chariot.multipart.complete(
-        body['name'], body['uploadId'], body['parts'],
+        body.get('name'), body.get('uploadId'), body.get('parts'),
         praetorian=body.get('praetorian', False),
     ))
 

--- a/praetorian_cli/handlers/share.py
+++ b/praetorian_cli/handlers/share.py
@@ -5,7 +5,7 @@ import click
 
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
-from praetorian_cli.handlers.utils import print_json
+from praetorian_cli.handlers.utils import print_json, error
 
 
 @chariot.group()
@@ -21,11 +21,18 @@ def share():
 def create(chariot, name, query_filter):
     """Create a new share link (reads optional config JSON from stdin)"""
     body = {'name': name}
-    raw = sys.stdin.read().strip()
-    if raw:
-        body.update(json.loads(raw))
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+        if raw:
+            try:
+                body.update(json.loads(raw))
+            except json.JSONDecodeError as e:
+                error(f'Invalid JSON input: {e}')
     if query_filter:
-        body['filter'] = json.loads(query_filter)
+        try:
+            body['filter'] = json.loads(query_filter)
+        except json.JSONDecodeError as e:
+            error(f'Invalid JSON input: {e}')
     print_json(chariot.share.create(body))
 
 

--- a/praetorian_cli/handlers/share.py
+++ b/praetorian_cli/handlers/share.py
@@ -28,6 +28,9 @@ def create(chariot, name, query_filter):
                 body.update(json.loads(raw))
             except json.JSONDecodeError as e:
                 error(f'Invalid JSON input: {e}')
+            if name:
+                # CLI flag takes precedence over piped JSON
+                body['name'] = name
     if query_filter:
         try:
             body['filter'] = json.loads(query_filter)

--- a/praetorian_cli/handlers/share.py
+++ b/praetorian_cli/handlers/share.py
@@ -1,0 +1,53 @@
+import sys
+import json
+
+import click
+
+from praetorian_cli.handlers.chariot import chariot
+from praetorian_cli.handlers.cli_decorators import cli_handler
+from praetorian_cli.handlers.utils import print_json
+
+
+@chariot.group()
+def share():
+    """Manage secure share links"""
+    pass
+
+
+@share.command('create')
+@cli_handler
+@click.option('--name', required=True, help='Display name for the share link')
+@click.option('--filter', 'query_filter', default=None, help='Query filter for shared data (JSON string)')
+def create(chariot, name, query_filter):
+    """Create a new share link (reads optional config JSON from stdin)"""
+    body = {'name': name}
+    raw = sys.stdin.read().strip()
+    if raw:
+        body.update(json.loads(raw))
+    if query_filter:
+        body['filter'] = json.loads(query_filter)
+    print_json(chariot.share.create(body))
+
+
+@share.command('list')
+@cli_handler
+def list_shares(chariot):
+    """List all share links"""
+    print_json(chariot.share.list())
+
+
+@share.command('delete')
+@cli_handler
+@click.argument('share_id')
+@click.confirmation_option(prompt='Are you sure you want to delete this share link?')
+def delete(chariot, share_id):
+    """Delete a share link"""
+    print_json(chariot.share.delete(share_id))
+
+
+@share.command('resolve')
+@cli_handler
+@click.argument('token')
+def resolve(chariot, token):
+    """Resolve a share link by its token"""
+    print_json(chariot.share.resolve(token))

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -27,11 +27,14 @@ import praetorian_cli.handlers.knossos  # noqa: F401
 import praetorian_cli.handlers.run
 import praetorian_cli.handlers.schedule
 import praetorian_cli.handlers.imports
+import praetorian_cli.handlers.leaderboard
 import praetorian_cli.handlers.link
 import praetorian_cli.handlers.list
 import praetorian_cli.handlers.purge
 import praetorian_cli.handlers.onboarding
 import praetorian_cli.handlers.plextrac
+import praetorian_cli.handlers.misc
+import praetorian_cli.handlers.multipart
 import praetorian_cli.handlers.query
 import praetorian_cli.handlers.tenant
 import praetorian_cli.handlers.osint  # noqa: F401
@@ -40,6 +43,7 @@ import praetorian_cli.handlers.red_team  # noqa: F401
 import praetorian_cli.handlers.report
 import praetorian_cli.handlers.script
 import praetorian_cli.handlers.search
+import praetorian_cli.handlers.share
 import praetorian_cli.handlers.test
 import praetorian_cli.handlers.unlink
 import praetorian_cli.handlers.update

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -24,6 +24,9 @@ from praetorian_cli.sdk.entities.osint import OSINT
 from praetorian_cli.sdk.entities.knossos import Knossos
 from praetorian_cli.sdk.entities.onboarding import Onboarding
 from praetorian_cli.sdk.entities.plextrac import PlexTrac
+from praetorian_cli.sdk.entities.leaderboard import Leaderboard
+from praetorian_cli.sdk.entities.misc import Misc
+from praetorian_cli.sdk.entities.multipart import Multipart
 from praetorian_cli.sdk.entities.preseeds import Preseeds
 from praetorian_cli.sdk.entities.remediation import Remediation
 from praetorian_cli.sdk.entities.red_team import RedTeam
@@ -35,6 +38,7 @@ from praetorian_cli.sdk.entities.schema import Schema
 from praetorian_cli.sdk.entities.search import Search
 from praetorian_cli.sdk.entities.seeds import Seeds
 from praetorian_cli.sdk.entities.settings import Settings
+from praetorian_cli.sdk.entities.share import Share
 from praetorian_cli.sdk.entities.statistics import Statistics
 from praetorian_cli.sdk.entities.webpage import Webpage
 from praetorian_cli.sdk.entities.webhook import Webhook
@@ -85,6 +89,10 @@ class Chariot:
         self.hackerone = HackerOne(self)
         self.onboarding = Onboarding(self)
         self.plextrac = PlexTrac(self)
+        self.leaderboard = Leaderboard(self)
+        self.misc = Misc(self)
+        self.multipart = Multipart(self)
+        self.share = Share(self)
         self.proxy = proxy
 
         if self.proxy == '' and os.environ.get('CHARIOT_PROXY'):

--- a/praetorian_cli/sdk/entities/leaderboard.py
+++ b/praetorian_cli/sdk/entities/leaderboard.py
@@ -1,0 +1,13 @@
+class Leaderboard:
+
+    def __init__(self, api):
+        self.api = api
+
+    def get(self):
+        return self.api.get('leaderboard')
+
+    def get_weights(self):
+        return self.api.get('leaderboard/weights')
+
+    def set_weights(self, weights):
+        return self.api.put('leaderboard/weights', weights)

--- a/praetorian_cli/sdk/entities/misc.py
+++ b/praetorian_cli/sdk/entities/misc.py
@@ -36,7 +36,7 @@ class Misc:
     def create_repository(self, name, source_archive_key):
         return self.api.post('repository', {
             'name': name,
-            'source_archive_key': source_archive_key,
+            'sourceArchiveKey': source_archive_key,
         })
 
     def parse_burp(self, content=None, url=None, filename=None):
@@ -97,8 +97,11 @@ class Misc:
     def planner_cost(self, uuid):
         return self.api.get('planner/' + quote(str(uuid), safe='') + '/cost')
 
-    def delete_planner(self, body):
-        return self.api.delete('planner', body, {})
+    def delete_planner(self, uuid):
+        # Routing follows the same path-embedded-uuid pattern as planner_cost()
+        # and other per-resource delete methods (e.g. hunts.delete, schedules.delete),
+        # rather than addressing the flat 'planner' endpoint with uuid in the body.
+        return self.api.delete('planner/' + quote(str(uuid), safe=''), {}, {})
 
     def put_hunt_memory(self, uuid, title, content):
         return self.api.put('hunt/' + quote(str(uuid), safe='') + '/memory/' + quote(str(title), safe=''), {'content': content})

--- a/praetorian_cli/sdk/entities/misc.py
+++ b/praetorian_cli/sdk/entities/misc.py
@@ -1,0 +1,107 @@
+class Misc:
+
+    def __init__(self, api):
+        self.api = api
+
+    def update_technology(self, body):
+        return self.api.put('technology', body)
+
+    def create_ticket(self, body):
+        return self.api.post('ticket', body)
+
+    def update_ticket(self, body):
+        return self.api.put('ticket', body)
+
+    def delete_ticket(self, body):
+        return self.api.delete('ticket', body, {})
+
+    def create_monitor(self, body):
+        return self.api.post('monitor', body)
+
+    def update_monitor(self, session_id, body):
+        return self.api.put('monitor', body, params={'id': session_id})
+
+    def delete_monitor(self, session_id):
+        return self.api.delete('monitor', {}, params={'id': session_id})
+
+    def set_flag(self, name):
+        return self.api.put('flag', {'name': name})
+
+    def delete_flag(self, name):
+        return self.api.delete('flag', {'name': name}, {})
+
+    def create_repository(self, name, source_archive_key):
+        return self.api.post('repository', {
+            'name': name,
+            'source_archive_key': source_archive_key,
+        })
+
+    def parse_burp(self, content=None, url=None, filename=None):
+        body = {}
+        if content:
+            body['content'] = content
+        if url:
+            body['url'] = url
+        if filename:
+            body['filename'] = filename
+        return self.api.post('burp/parse', body)
+
+    def notify_vulnerability(self, body):
+        return self.api.post('vulnerability/notify', body)
+
+    def validate_integration(self, body):
+        return self.api.post('integration/validate', body)
+
+    def jira_transitions(self, body):
+        return self.api.post('integration/jira/transitions', body)
+
+    def jira_custom_fields(self, body):
+        return self.api.post('integration/jira/custom-fields', body)
+
+    def jira_optional_custom_fields(self, body):
+        return self.api.post('integration/jira/optional-custom-fields', body)
+
+    def jira_priorities(self, body):
+        return self.api.post('integration/jira/priorities', body)
+
+    def linear_teams(self, body):
+        return self.api.post('integration/linear/teams', body)
+
+    def linear_workflow_states(self, body):
+        return self.api.post('integration/linear/workflow-states', body)
+
+    def linear_projects(self, body):
+        return self.api.post('integration/linear/projects', body)
+
+    def risk_visited(self, key, comment=''):
+        return self.api.put('risk/visited', {'key': key, 'comment': comment})
+
+    def agent_list(self):
+        return self.api.get('agent/list')
+
+    def agents(self):
+        return self.api.get('agents')
+
+    def planner_compact(self, body):
+        return self.api.post('planner/compact', body)
+
+    def planner_stop(self, body):
+        return self.api.post('planner/stop', body)
+
+    def planner_interaction(self, body):
+        return self.api.post('planner/interaction', body)
+
+    def planner_cost(self, uuid):
+        return self.api.get('planner/' + uuid + '/cost')
+
+    def delete_planner(self, body):
+        return self.api.delete('planner', body, {})
+
+    def put_hunt_memory(self, uuid, title, content):
+        return self.api.put('hunt/' + uuid + '/memory/' + title, {'content': content})
+
+    def delete_hunt_memory(self, uuid, title):
+        return self.api.delete('hunt/' + uuid + '/memory/' + title, {}, {})
+
+    def hunt_cost(self, uuid):
+        return self.api.get('hunt/' + uuid + '/cost')

--- a/praetorian_cli/sdk/entities/misc.py
+++ b/praetorian_cli/sdk/entities/misc.py
@@ -1,3 +1,6 @@
+from urllib.parse import quote
+
+
 class Misc:
 
     def __init__(self, api):
@@ -92,16 +95,16 @@ class Misc:
         return self.api.post('planner/interaction', body)
 
     def planner_cost(self, uuid):
-        return self.api.get('planner/' + uuid + '/cost')
+        return self.api.get('planner/' + quote(str(uuid), safe='') + '/cost')
 
     def delete_planner(self, body):
         return self.api.delete('planner', body, {})
 
     def put_hunt_memory(self, uuid, title, content):
-        return self.api.put('hunt/' + uuid + '/memory/' + title, {'content': content})
+        return self.api.put('hunt/' + quote(str(uuid), safe='') + '/memory/' + quote(str(title), safe=''), {'content': content})
 
     def delete_hunt_memory(self, uuid, title):
-        return self.api.delete('hunt/' + uuid + '/memory/' + title, {}, {})
+        return self.api.delete('hunt/' + quote(str(uuid), safe='') + '/memory/' + quote(str(title), safe=''), {}, {})
 
     def hunt_cost(self, uuid):
-        return self.api.get('hunt/' + uuid + '/cost')
+        return self.api.get('hunt/' + quote(str(uuid), safe='') + '/cost')

--- a/praetorian_cli/sdk/entities/multipart.py
+++ b/praetorian_cli/sdk/entities/multipart.py
@@ -1,0 +1,41 @@
+class Multipart:
+
+    def __init__(self, api):
+        self.api = api
+
+    def create(self, name, praetorian=False, ttl=None):
+        params = {'name': name}
+        if praetorian:
+            params['praetorian'] = 'true'
+        if ttl is not None:
+            params['ttl'] = str(ttl)
+        return self.api.post('file/multipart/create', {}, params=params)
+
+    def get_part_url(self, name, upload_id, part_number, praetorian=False):
+        params = {
+            'name': name,
+            'uploadId': upload_id,
+            'partNumber': str(part_number),
+        }
+        if praetorian:
+            params['praetorian'] = 'true'
+        return self.api.post('file/multipart/part', {}, params=params)
+
+    def complete(self, name, upload_id, parts, praetorian=False):
+        params = {}
+        if praetorian:
+            params['praetorian'] = 'true'
+        return self.api.post('file/multipart/complete', {
+            'name': name,
+            'uploadId': upload_id,
+            'parts': parts,
+        }, params=params)
+
+    def abort(self, name, upload_id, praetorian=False):
+        params = {}
+        if praetorian:
+            params['praetorian'] = 'true'
+        return self.api.post('file/multipart/abort', {
+            'name': name,
+            'uploadId': upload_id,
+        }, params=params)

--- a/praetorian_cli/sdk/entities/multipart.py
+++ b/praetorian_cli/sdk/entities/multipart.py
@@ -22,20 +22,19 @@ class Multipart:
         return self.api.post('file/multipart/part', {}, params=params)
 
     def complete(self, name, upload_id, parts, praetorian=False):
-        params = {}
-        if praetorian:
-            params['praetorian'] = 'true'
-        return self.api.post('file/multipart/complete', {
+        params = {
             'name': name,
             'uploadId': upload_id,
-            'parts': parts,
-        }, params=params)
+        }
+        if praetorian:
+            params['praetorian'] = 'true'
+        return self.api.post('file/multipart/complete', {'parts': parts}, params=params)
 
     def abort(self, name, upload_id, praetorian=False):
-        params = {}
-        if praetorian:
-            params['praetorian'] = 'true'
-        return self.api.post('file/multipart/abort', {
+        params = {
             'name': name,
             'uploadId': upload_id,
-        }, params=params)
+        }
+        if praetorian:
+            params['praetorian'] = 'true'
+        return self.api.post('file/multipart/abort', {}, params=params)

--- a/praetorian_cli/sdk/entities/share.py
+++ b/praetorian_cli/sdk/entities/share.py
@@ -1,0 +1,16 @@
+class Share:
+
+    def __init__(self, api):
+        self.api = api
+
+    def create(self, body):
+        return self.api.post('share', body)
+
+    def list(self):
+        return self.api.get('share')
+
+    def delete(self, share_id):
+        return self.api.delete('share', {'id': share_id}, {})
+
+    def resolve(self, token):
+        return self.api.get('share/' + token)

--- a/praetorian_cli/sdk/entities/share.py
+++ b/praetorian_cli/sdk/entities/share.py
@@ -1,3 +1,6 @@
+from urllib.parse import quote
+
+
 class Share:
 
     def __init__(self, api):
@@ -13,4 +16,4 @@ class Share:
         return self.api.delete('share', {'id': share_id}, {})
 
     def resolve(self, token):
-        return self.api.get('share/' + token)
+        return self.api.get('share/' + quote(str(token), safe=''))

--- a/praetorian_cli/sdk/test/test_leaderboard_cli.py
+++ b/praetorian_cli/sdk/test/test_leaderboard_cli.py
@@ -1,0 +1,56 @@
+"""Unit tests for leaderboard CLI commands."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+import praetorian_cli.handlers.leaderboard  # noqa: F401
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    sdk.is_praetorian_user.return_value = True
+    sdk.leaderboard.get.return_value = [{'rank': 1, 'name': 'Engineer A', 'score': 100}]
+    sdk.leaderboard.get_weights.return_value = {'critical': 10, 'high': 5, 'medium': 2}
+    sdk.leaderboard.set_weights.return_value = {'status': 'updated'}
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv, input=None, **kwargs):
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, input=input, **kwargs)
+
+
+def test_get_leaderboard(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['leaderboard', 'get'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.leaderboard.get.assert_called_once()
+
+
+def test_get_weights(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['leaderboard', 'get-weights'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.leaderboard.get_weights.assert_called_once()
+
+
+def test_set_weights(runner, fake_sdk):
+    stdin = '{"critical": 15, "high": 8, "medium": 3}'
+    result = _invoke(runner, fake_sdk, ['leaderboard', 'set-weights'], input=stdin, catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.leaderboard.set_weights.assert_called_once_with({
+        'critical': 15, 'high': 8, 'medium': 3,
+    })
+
+
+def test_set_weights_no_stdin(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['leaderboard', 'set-weights'], input='', catch_exceptions=True)
+    assert result.exit_code != 0 or 'ERROR' in result.output

--- a/praetorian_cli/sdk/test/test_misc_cli.py
+++ b/praetorian_cli/sdk/test/test_misc_cli.py
@@ -1,0 +1,185 @@
+"""Unit tests for misc CLI commands (ST-20)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+import praetorian_cli.handlers.misc  # noqa: F401
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    sdk.is_praetorian_user.return_value = True
+    sdk.misc.update_technology.return_value = [{'key': '#technology#cpe:2.3:a:apache:http_server'}]
+    sdk.misc.create_ticket.return_value = {'status': 'created'}
+    sdk.misc.update_ticket.return_value = {'status': 'refreshed'}
+    sdk.misc.delete_ticket.return_value = {'status': 'deleted'}
+    sdk.misc.create_monitor.return_value = {'id': 'session-1'}
+    sdk.misc.update_monitor.return_value = {'id': 'session-1'}
+    sdk.misc.delete_monitor.return_value = {'status': 'cancelled'}
+    sdk.misc.set_flag.return_value = {'name': 'enable_knossos'}
+    sdk.misc.delete_flag.return_value = {'name': 'enable_knossos'}
+    sdk.misc.create_repository.return_value = {'name': 'my-repo'}
+    sdk.misc.parse_burp.return_value = {'endpoints': []}
+    sdk.misc.notify_vulnerability.return_value = {'status': 'dispatched'}
+    sdk.misc.validate_integration.return_value = {'valid': True}
+    sdk.misc.jira_transitions.return_value = {'statuses': []}
+    sdk.misc.jira_custom_fields.return_value = {'fields': []}
+    sdk.misc.jira_priorities.return_value = {'priorities': []}
+    sdk.misc.linear_teams.return_value = {'teams': []}
+    sdk.misc.linear_workflow_states.return_value = {'states': []}
+    sdk.misc.linear_projects.return_value = {'projects': []}
+    sdk.misc.risk_visited.return_value = {'status': 'ok'}
+    sdk.misc.agent_list.return_value = [{'name': 'agent1'}]
+    sdk.misc.agents.return_value = [{'name': 'planner'}]
+    sdk.misc.planner_compact.return_value = {'status': 'compacted'}
+    sdk.misc.planner_stop.return_value = {'status': 'stopped'}
+    sdk.misc.planner_interaction.return_value = {'status': 'ok'}
+    sdk.misc.planner_cost.return_value = {'cost': 0.5}
+    sdk.misc.delete_planner.return_value = {'status': 'deleted'}
+    sdk.misc.put_hunt_memory.return_value = {'status': 'ok'}
+    sdk.misc.delete_hunt_memory.return_value = {'status': 'deleted'}
+    sdk.misc.hunt_cost.return_value = {'cost': 1.0}
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv, input=None, **kwargs):
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, input=input, **kwargs)
+
+
+def test_update_technology(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'update-technology', '--key', '#technology#cpe:2.3:a:apache', '--name', 'Apache',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.update_technology.assert_called_once()
+
+
+def test_create_ticket(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'ticket', 'create', '--risk', '#risk#123', '--account', '#account#jira',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.create_ticket.assert_called_once()
+
+
+def test_delete_ticket(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'ticket', 'delete', '--provider', 'jira', '--ticket-id', 'PROJ-123', '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.delete_ticket.assert_called_once()
+
+
+def test_create_monitor(runner, fake_sdk):
+    stdin = '{"name": "test", "techniques": [{"technique_id": "T1", "name": "test"}]}'
+    result = _invoke(runner, fake_sdk, ['monitor', 'create'], input=stdin, catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.create_monitor.assert_called_once()
+
+
+def test_delete_monitor(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'monitor', 'delete', '--id', 'session-1', '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.delete_monitor.assert_called_once_with('session-1')
+
+
+def test_set_flag(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['flag', 'set', 'enable_knossos'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.set_flag.assert_called_once_with('enable_knossos')
+
+
+def test_delete_flag(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'flag', 'delete', 'enable_knossos', '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.delete_flag.assert_called_once_with('enable_knossos')
+
+
+def test_add_repository(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'add-repository', '--name', 'my-repo', '--source-archive-key', 's3key',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.create_repository.assert_called_once_with('my-repo', 's3key')
+
+
+def test_parse_burp_url(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'parse-burp', '--url', 'https://example.com/api.yaml',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.parse_burp.assert_called_once_with(url='https://example.com/api.yaml')
+
+
+def test_validate_integration(runner, fake_sdk):
+    stdin = '{"provider": "jira", "secret": {"token": "abc"}}'
+    result = _invoke(runner, fake_sdk, [
+        'integration-setup', 'validate',
+    ], input=stdin, catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.validate_integration.assert_called_once()
+
+
+def test_risk_visited(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'risk-visited', '#risk#123', '--comment', 'reviewed',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.risk_visited.assert_called_once_with('#risk#123', 'reviewed')
+
+
+def test_agent_list(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['agent-list'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.agent_list.assert_called_once()
+
+
+def test_agents(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['agents'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.agents.assert_called_once()
+
+
+def test_planner_cost(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'planner', 'cost', '550e8400-e29b-41d4-a716-446655440000',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.planner_cost.assert_called_once_with('550e8400-e29b-41d4-a716-446655440000')
+
+
+def test_delete_planner(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'planner', 'delete', '550e8400-e29b-41d4-a716-446655440000', '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.delete_planner.assert_called_once()
+
+
+def test_set_hunt_memory(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'set-hunt-memory', 'uuid1', 'findings',
+    ], input='Important findings here', catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.put_hunt_memory.assert_called_once_with('uuid1', 'findings', 'Important findings here')
+
+
+def test_hunt_cost(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['hunt-cost', 'uuid1'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.misc.hunt_cost.assert_called_once_with('uuid1')

--- a/praetorian_cli/sdk/test/test_multipart_cli.py
+++ b/praetorian_cli/sdk/test/test_multipart_cli.py
@@ -1,0 +1,79 @@
+"""Unit tests for multipart upload CLI commands (ST-21)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+import praetorian_cli.handlers.multipart  # noqa: F401
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    sdk.multipart.create.return_value = {'uploadId': 'upload-123'}
+    sdk.multipart.get_part_url.return_value = {'url': 'https://s3.example.com/part'}
+    sdk.multipart.complete.return_value = {'status': 'completed'}
+    sdk.multipart.abort.return_value = {'status': 'aborted'}
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv, input=None, **kwargs):
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, input=input, **kwargs)
+
+
+def test_create(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'multipart', 'create', '--name', 'large-file.zip',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.multipart.create.assert_called_once_with('large-file.zip', praetorian=False, ttl=None)
+
+
+def test_create_with_praetorian(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'multipart', 'create', '--name', 'report.pdf', '--praetorian', '--ttl', '3600',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.multipart.create.assert_called_once_with('report.pdf', praetorian=True, ttl=3600)
+
+
+def test_part_url(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'multipart', 'part-url',
+        '--name', 'large-file.zip',
+        '--upload-id', 'upload-123',
+        '--part-number', '1',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.multipart.get_part_url.assert_called_once_with(
+        'large-file.zip', 'upload-123', 1, praetorian=False,
+    )
+
+
+def test_complete(runner, fake_sdk):
+    stdin = '{"name": "large-file.zip", "uploadId": "upload-123", "parts": [{"partNumber": 1, "etag": "abc"}]}'
+    result = _invoke(runner, fake_sdk, ['multipart', 'complete'], input=stdin, catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.multipart.complete.assert_called_once_with(
+        'large-file.zip', 'upload-123', [{'partNumber': 1, 'etag': 'abc'}], praetorian=False,
+    )
+
+
+def test_abort(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'multipart', 'abort',
+        '--name', 'large-file.zip',
+        '--upload-id', 'upload-123',
+        '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.multipart.abort.assert_called_once_with('large-file.zip', 'upload-123', praetorian=False)

--- a/praetorian_cli/sdk/test/test_share_cli.py
+++ b/praetorian_cli/sdk/test/test_share_cli.py
@@ -1,0 +1,69 @@
+"""Unit tests for share CLI commands."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.chariot import chariot
+import praetorian_cli.handlers.share  # noqa: F401
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_sdk():
+    sdk = MagicMock()
+    sdk.share.create.return_value = {'id': 'share-1', 'token': 'abc123'}
+    sdk.share.list.return_value = [{'id': 'share-1', 'name': 'test'}]
+    sdk.share.delete.return_value = {'status': 'deleted'}
+    sdk.share.resolve.return_value = {'id': 'share-1', 'data': {}}
+    return sdk
+
+
+def _invoke(runner, fake_sdk, argv, input=None, **kwargs):
+    obj = {'keychain': MagicMock(), 'proxy': ''}
+    with patch('praetorian_cli.sdk.chariot.Chariot', return_value=fake_sdk), \
+         patch('praetorian_cli.handlers.cli_decorators.upgrade_check', lambda f: f):
+        return runner.invoke(chariot, argv, obj=obj, input=input, **kwargs)
+
+
+def test_create(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'share', 'create', '--name', 'My Share',
+    ], input='', catch_exceptions=False)
+    assert result.exit_code == 0
+    call_args = fake_sdk.share.create.call_args[0][0]
+    assert call_args['name'] == 'My Share'
+
+
+def test_create_with_filter(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'share', 'create', '--name', 'Filtered',
+        '--filter', '{"status": "O"}',
+    ], input='', catch_exceptions=False)
+    assert result.exit_code == 0
+    call_args = fake_sdk.share.create.call_args[0][0]
+    assert call_args['filter'] == {'status': 'O'}
+
+
+def test_list(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['share', 'list'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.share.list.assert_called_once()
+
+
+def test_delete(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, [
+        'share', 'delete', 'share-1', '--yes',
+    ], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.share.delete.assert_called_once_with('share-1')
+
+
+def test_resolve(runner, fake_sdk):
+    result = _invoke(runner, fake_sdk, ['share', 'resolve', 'abc123'], catch_exceptions=False)
+    assert result.exit_code == 0
+    fake_sdk.share.resolve.assert_called_once_with('abc123')


### PR DESCRIPTION
> **PR Stack (8/12)** — merge from bottom to top.
>
> 1. #266 CLI parity scaffolding
> 2. #265 Guard CLI/SDK parity (st1-st4)
> 3. #267 Constantine, OSINT, remediation, enrichment (st6-st8)
> 4. #268 Knossos, Aegis management (st7-st9)
> 5. #269 Red Team CLI (st5)
> 6. #270 nuclei, bifrost, engineer-vm, CSF (st10-st15)
> 7. #271 HackerOne, PlexTrac, Onboarding, Export (st12-st17)
> **8. #272 share, leaderboard, misc, multipart (st18-st21)** (this PR)
> 9. #244 skills, risk-status, conversation UX
> 10. #243 Hannibal hunt CLI + TUI
> 11. #228 Marcus terminal hardening
> 12. #226 module management system


## Summary
- **ST-18 (Share links)**: SDK entity + CLI handler for create, list, delete, resolve
- **ST-19 (Leaderboard)**: SDK entity + CLI handler for get, get-weights, set-weights (all `@praetorian_only`)
- **ST-20 (Misc hardening)**: SDK entity + CLI handler covering 30+ backend routes:
  - Technology update, ticket create/refresh/delete, monitor create/update/delete
  - Feature flag set/delete, repository add, Burp parse, vulnerability notify
  - Integration validate + Jira transitions/custom-fields/priorities + Linear teams/workflow-states/projects
  - Risk visited, agent-list, agents, planner compact/stop/interaction/cost/delete
  - Hunt memory set/delete, hunt cost
  - Routes confirmed absent: attack-graph, osint_teams, slack/start, chat/link, chat/channel
- **ST-21 (Multipart upload)**: SDK entity + CLI handler for create, part-url, complete, abort

## Test plan
- [x] 5 share link tests pass
- [x] 4 leaderboard tests pass
- [x] 17 misc hardening tests pass
- [x] 5 multipart upload tests pass
- [ ] End-to-end validation against staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)