### PR TITLE
fix(test): make `guard test` safe by default (ENG-6571)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Developers](#developers)
     - [SDK](#sdk)
     - [Developing external scripts](#developing-external-scripts)
+    - [Running the test suite](#running-the-test-suite)
     - [Contributing](#contributing)
     - [Support](#support)
     - [License](#license)
@@ -344,6 +345,49 @@ guard --account guard+example@praetorian.com script --help
 
 For developing scripts, you can refer to
 this [readme file](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/script-development.md).
+
+
+## Running the test suite
+
+`guard test` runs the integration suites that ship with the package. **Some of
+those suites create, modify and delete real entities in whatever account the
+selected profile points at**, so the command is gated.
+
+Suites are selected with `-s`/`--suite`:
+
+| Suite | What it runs | Touches a live account? |
+| --- | --- | --- |
+| `safe` *(default)* | Local, offline unit tests | No |
+| `coherence` | End-to-end entity lifecycle tests | **Yes — creates and deletes assets, risks, settings, configurations** |
+| `cli` | CLI-level integration tests | **Yes — mutating** |
+| `tui` | Terminal UI tests | No |
+
+A bare `guard test` runs the `safe` suite only. It executes with a temporary
+`HOME` and with credential environment variables stripped, so it cannot reach
+your real credentials.
+
+The mutating suites additionally require:
+
+1. **An explicit profile and account.** Both must be given and non-empty —
+   `guard --profile <profile> --account <account> test --suite coherence`.
+   There is no fallback: an unset or blank value is an error, so the suite can
+   never quietly run against a default profile.
+2. **Interactive confirmation.** The command prints the suite, profile, account,
+   and whether the suite is live and mutating, then asks you to confirm.
+   Declining — or a non-interactive invocation, which cannot confirm — exits
+   non-zero without running any test.
+
+```zsh
+# Safe by default — no account is touched.
+guard test
+
+# Mutating suite: target must be explicit, and you must confirm.
+guard --profile "United States" --account guard+scratch@praetorian.com \
+    test --suite coherence
+```
+
+Never point a mutating suite at a production account. Use a dedicated scratch
+account whose contents you are willing to lose.
 
 
 ## Contributing

--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -4,6 +4,11 @@ import click
 @click.group()
 @click.pass_context
 def chariot(click_context):
+    from praetorian_cli.handlers.test import TestTarget
+
+    if isinstance(click_context.obj, TestTarget):
+        return
+
     # import done here to avoid circular import errors in praetorian_cli/handlers/cli_decorators.py
     from praetorian_cli.sdk.chariot import Chariot
 

--- a/praetorian_cli/handlers/test.py
+++ b/praetorian_cli/handlers/test.py
@@ -1,29 +1,195 @@
 import os
-import sys
 import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
 
 import click
-import pytest
 
 import praetorian_cli.sdk.test as test_module
 from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
 
 
+@dataclass(frozen=True)
+class TestSuite:
+    name: str
+    pytest_selector: tuple[str, ...]
+    local_safe: bool
+    live: bool
+    mutating: bool
+    tui: bool
+    requires_target: bool
+
+
+@dataclass(frozen=True)
+class TestTarget:
+    profile: str | None
+    account: str | None
+    proxy: str
+
+
+TEST_SUITES = {
+    "safe": TestSuite(
+        name="safe",
+        pytest_selector=("-m", "not coherence and not cli and not tui"),
+        local_safe=True,
+        live=False,
+        mutating=False,
+        tui=False,
+        requires_target=False,
+    ),
+    "coherence": TestSuite(
+        name="coherence",
+        pytest_selector=("-m", "coherence"),
+        local_safe=False,
+        live=True,
+        mutating=True,
+        tui=False,
+        requires_target=True,
+    ),
+    "cli": TestSuite(
+        name="cli",
+        pytest_selector=("-m", "cli"),
+        local_safe=False,
+        live=True,
+        mutating=True,
+        tui=False,
+        requires_target=True,
+    ),
+    "tui": TestSuite(
+        name="tui",
+        pytest_selector=("-m", "tui"),
+        local_safe=False,
+        live=False,
+        mutating=False,
+        tui=True,
+        requires_target=False,
+    ),
+}
+
+TEST_PROFILE_ENV = "CHARIOT_TEST_PROFILE"
+TEST_ACCOUNT_ENV = "CHARIOT_TEST_ACCOUNT"
+TEST_PROXY_ENV = "CHARIOT_PROXY"
+NON_LIVE_CREDENTIAL_ENV = (
+    "PRAETORIAN_CLI_USERNAME",
+    "PRAETORIAN_CLI_PASSWORD",
+    "PRAETORIAN_CLI_API_KEY_ID",
+    "PRAETORIAN_CLI_API_KEY_SECRET",
+    "PRAETORIAN_CLI_API",
+    "PRAETORIAN_CLI_CLIENT_ID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+)
+
+
+def _explicit_target(value, label):
+    if not isinstance(value, str) or not value or value != value.strip():
+        click.echo(f"Error: an explicit, unambiguous {label} is required for this test suite.", err=True)
+        raise SystemExit(2)
+    return value
+
+
+def _confirm_live_suite(suite, profile, account):
+    prompt = (
+        f"Suite: {suite.name}\n"
+        f"Profile: {profile}\n"
+        f"Account: {account}\n"
+        f"Mutation status: {'MUTATING' if suite.mutating else 'non-mutating'}\n"
+        f"Live status: {'LIVE' if suite.live else 'local'}\n"
+        "Run this suite"
+    )
+    try:
+        confirmed = click.confirm(prompt, default=False)
+    except click.Abort:
+        raise SystemExit(1)
+    if not confirmed:
+        raise SystemExit(1)
+
+
+def _test_environment(suite):
+    environment = os.environ.copy()
+    for name in (TEST_PROFILE_ENV, TEST_ACCOUNT_ENV, TEST_PROXY_ENV):
+        environment.pop(name, None)
+    if not suite.live and not suite.mutating:
+        for name in NON_LIVE_CREDENTIAL_ENV:
+            environment.pop(name, None)
+        environment["AWS_EC2_METADATA_DISABLED"] = "true"
+    return environment
+
+
+def _test_target(chariot):
+    if isinstance(chariot, TestTarget):
+        return chariot
+    return TestTarget(
+        profile=chariot.keychain.profile,
+        account=chariot.keychain.account,
+        proxy=chariot.proxy,
+    )
+
+
+def _configure_live_target(suite, target, environment):
+    if not (suite.requires_target or suite.live or suite.mutating):
+        return
+    profile = _explicit_target(target.profile, 'profile')
+    account = _explicit_target(target.account, 'account')
+    environment[TEST_PROFILE_ENV] = profile
+    environment[TEST_ACCOUNT_ENV] = account
+    if target.proxy:
+        environment[TEST_PROXY_ENV] = target.proxy
+    if suite.live or suite.mutating:
+        _confirm_live_suite(suite, profile, account)
+
+
+def _pytest_args(suite, key):
+    command = [test_module.__path__[0], *suite.pytest_selector]
+    if key:
+        command.extend(['-k', key])
+    return [sys.executable, '-m', 'pytest', *command]
+
+
+def _run_pytest(args, environment, *, isolated):
+    if not isolated:
+        return subprocess.run(args, env=environment)
+    with tempfile.TemporaryDirectory(prefix="praetorian-cli-test-home-") as isolated_home:
+        environment["HOME"] = isolated_home
+        environment["USERPROFILE"] = isolated_home
+        environment["AWS_SHARED_CREDENTIALS_FILE"] = os.path.join(isolated_home, ".aws", "credentials")
+        environment["AWS_CONFIG_FILE"] = os.path.join(isolated_home, ".aws", "config")
+        environment["BOTO_CONFIG"] = os.path.join(isolated_home, ".boto")
+        return subprocess.run(args, env=environment)
+
+
 @chariot.command()
 @cli_handler
-@click.option('-s', '--suite', type=click.Choice(['coherence', 'cli', 'tui']), help='Run a specific test suite')
+@click.option(
+    '-s',
+    '--suite',
+    type=click.Choice(tuple(TEST_SUITES)),
+    default='safe',
+    show_default=True,
+    help='Run a specific test suite',
+)
 @click.argument('key', required=False)
 def test(chariot, key, suite):
     """ Run integration test suite """
-    os.environ['CHARIOT_TEST_PROFILE'] = chariot.keychain.profile
-    os.environ['CHARIOT_PROXY'] = chariot.proxy
-    command = [test_module.__path__[0]]
-    if key:
-        command.extend(['-k', key])
-    if suite:
-        command.extend(['-m', suite])
-    # Run pytest in a subprocess to isolate from CLI pre-imports
-    args = [sys.executable, '-m', 'pytest'] + command
-    result = subprocess.run(args)
+    selected_suite = TEST_SUITES[suite]
+    non_live = not selected_suite.live and not selected_suite.mutating
+    environment = _test_environment(selected_suite)
+    _configure_live_target(selected_suite, _test_target(chariot), environment)
+    result = _run_pytest(_pytest_args(selected_suite, key), environment, isolated=non_live)
     raise SystemExit(result.returncode)

--- a/praetorian_cli/handlers/test.py
+++ b/praetorian_cli/handlers/test.py
@@ -135,11 +135,18 @@ def _test_environment(suite):
 def _test_target(chariot):
     if isinstance(chariot, TestTarget):
         return chariot
-    return TestTarget(
-        profile=chariot.keychain.profile,
-        account=chariot.keychain.account,
-        proxy=chariot.proxy,
+    # A TestTarget is the only carrier of an explicit target, and main.py's _supplied()
+    # is the only thing that fills one -- from COMMANDLINE/ENVIRONMENT values alone.
+    # Anything else arriving here is a context-wiring regression, not a target, so drop
+    # its profile and account: absent values are what _explicit_target rejects. Never
+    # read the keychain instead -- its profile carries the declared --profile default,
+    # which the user may never have chosen. Change the policy in main.py, not here.
+    click.echo(
+        'Warning: this invocation carries no explicit test target; '
+        'suites that require one will be refused.',
+        err=True,
     )
+    return TestTarget(profile=None, account=None, proxy=getattr(chariot, 'proxy', ''))
 
 
 def _configure_live_target(suite, target, environment):

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -33,7 +33,30 @@ from praetorian_cli.handlers.configure import configure
 from praetorian_cli.sdk.keychain import Keychain
 
 
-@click.group()
+class InvocationPathGroup(click.Group):
+    """Record the Click-resolved public command path before root setup runs."""
+
+    def resolve_command(self, ctx, args):
+        command_name, command, remaining = super().resolve_command(ctx, args)
+        nested_name = remaining[0] if remaining else None
+        ctx.meta["praetorian_invocation_path"] = (command_name, nested_name)
+        return command_name, command, remaining
+
+
+def _is_test_invocation(click_context):
+    path = click_context.meta.get("praetorian_invocation_path", ())
+    return click_context.invoked_subcommand == "test" or path == ("chariot", "test")
+
+
+def _test_target(profile, account, proxy):
+    return praetorian_cli.handlers.test.TestTarget(
+        profile=profile,
+        account=account,
+        proxy=proxy,
+    )
+
+
+@click.group(cls=InvocationPathGroup)
 @click.option('--profile', default='United States', help='The profile to use in the keychain file', show_default=True)
 @click.option('--account', default=None, help='Assume role into this account')
 @click.option('--debug', is_flag=True, default=False, help='Run the CLI in debug mode')
@@ -44,6 +67,9 @@ def main(click_context, profile, account, debug, proxy):
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
+    if _is_test_invocation(click_context):
+        click_context.obj = _test_target(profile, account, proxy)
+        return
     click_context.obj = {'keychain': Keychain(profile, account), 'proxy': proxy}
     praetorian_cli.handlers.script.load_dynamic_commands()
 
@@ -61,10 +87,15 @@ main.add_command(configure)
 @click.version_option()
 def guard_main(click_context, profile, account, debug, proxy):
     """Guard CLI - Praetorian's offensive security platform."""
-    from praetorian_cli.sdk.chariot import Chariot
     if debug:
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
+
+    if _is_test_invocation(click_context):
+        click_context.obj = _test_target(profile, account, proxy)
+        return
+
+    from praetorian_cli.sdk.chariot import Chariot
     click_context.obj = Chariot(Keychain(profile, account), proxy=proxy)
     praetorian_cli.handlers.script.load_dynamic_commands()
 

--- a/praetorian_cli/main.py
+++ b/praetorian_cli/main.py
@@ -4,6 +4,7 @@ import truststore
 truststore.inject_into_ssl()
 
 import click
+from click.core import ParameterSource
 
 import praetorian_cli.handlers.access
 import praetorian_cli.handlers.add
@@ -48,10 +49,23 @@ def _is_test_invocation(click_context):
     return click_context.invoked_subcommand == "test" or path == ("chariot", "test")
 
 
-def _test_target(profile, account, proxy):
+# A test target may only be built from values the user actually supplied. Anything
+# else -- notably the declared --profile default -- must reach the explicit-target
+# check as a value it rejects, so a destructive suite can never run against a
+# default the user never chose.
+SUPPLIED_PARAMETER_SOURCES = (ParameterSource.COMMANDLINE, ParameterSource.ENVIRONMENT)
+
+
+def _supplied(click_context, name, value):
+    if click_context.get_parameter_source(name) in SUPPLIED_PARAMETER_SOURCES:
+        return value
+    return None
+
+
+def _test_target(click_context, profile, account, proxy):
     return praetorian_cli.handlers.test.TestTarget(
-        profile=profile,
-        account=account,
+        profile=_supplied(click_context, 'profile', profile),
+        account=_supplied(click_context, 'account', account),
         proxy=proxy,
     )
 
@@ -68,7 +82,7 @@ def main(click_context, profile, account, debug, proxy):
         click.echo('Running in debug mode.')
     chariot.is_debug = debug
     if _is_test_invocation(click_context):
-        click_context.obj = _test_target(profile, account, proxy)
+        click_context.obj = _test_target(click_context, profile, account, proxy)
         return
     click_context.obj = {'keychain': Keychain(profile, account), 'proxy': proxy}
     praetorian_cli.handlers.script.load_dynamic_commands()
@@ -92,7 +106,7 @@ def guard_main(click_context, profile, account, debug, proxy):
     chariot.is_debug = debug
 
     if _is_test_invocation(click_context):
-        click_context.obj = _test_target(profile, account, proxy)
+        click_context.obj = _test_target(click_context, profile, account, proxy)
         return
 
     from praetorian_cli.sdk.chariot import Chariot

--- a/praetorian_cli/sdk/test/test_account.py
+++ b/praetorian_cli/sdk/test/test_account.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import setup_chariot, email_address
+from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, email_address
 
 
 @pytest.mark.coherence
 class TestAccount:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         self.collaborator_email = email_address()
 
     def test_add_collaborator(self):

--- a/praetorian_cli/sdk/test/test_agent.py
+++ b/praetorian_cli/sdk/test/test_agent.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Risk
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestRisk:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_affiliation(self):

--- a/praetorian_cli/sdk/test/test_asset.py
+++ b/praetorian_cli/sdk/test/test_asset.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestAsset:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_asset(self):

--- a/praetorian_cli/sdk/test/test_attribute.py
+++ b/praetorian_cli/sdk/test/test_attribute.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestAttribute:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.sdk.assets.add(self.asset_dns, self.asset_name)
 

--- a/praetorian_cli/sdk/test/test_capabilities.py
+++ b/praetorian_cli/sdk/test/test_capabilities.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestCapabilities:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
 
     def test_list_capabilities(self):
         capabilities = self.sdk.capabilities.list()

--- a/praetorian_cli/sdk/test/test_configuration.py
+++ b/praetorian_cli/sdk/test/test_configuration.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestConfigurations:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         if not self.sdk.is_praetorian_user():
             pytest.skip("This test is only available to Praetorian engineers")

--- a/praetorian_cli/sdk/test/test_conversation.py
+++ b/praetorian_cli/sdk/test/test_conversation.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import time
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
@@ -10,7 +10,8 @@ class TestConversation:
     """Test conversation functionality with the Chariot agent"""
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.conversation_id = None
         self.message_keys = []

--- a/praetorian_cli/sdk/test/test_definition.py
+++ b/praetorian_cli/sdk/test/test_definition.py
@@ -2,14 +2,15 @@ import os
 
 import pytest
 
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, setup_chariot
 
 
 @pytest.mark.coherence
 class TestDefinition:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         self.definition_name = f'test-definition-{epoch_micro()}'
         self.local_filepath = f'./{self.definition_name}.md'
         self.content = random_ip()

--- a/praetorian_cli/sdk/test/test_file.py
+++ b/praetorian_cli/sdk/test/test_file.py
@@ -2,14 +2,15 @@ import os
 
 import pytest
 
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, setup_chariot
 
 
 @pytest.mark.coherence
 class TestFile:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         micro = epoch_micro()
         self.chariot_filepath = f'home/test-file-{micro}.txt'
         self.encrypted_chariot_filepath = f'_encrypted/test-file-{micro}.txt'

--- a/praetorian_cli/sdk/test/test_job.py
+++ b/praetorian_cli/sdk/test/test_job.py
@@ -2,14 +2,15 @@ import pytest
 import json
 
 from praetorian_cli.sdk.model.utils import asset_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestJob:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
         self.was_frozen = False

--- a/praetorian_cli/sdk/test/test_key.py
+++ b/praetorian_cli/sdk/test/test_key.py
@@ -1,14 +1,15 @@
 import pytest
 import datetime
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestKey:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_key(self):

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.mcp_server import MCPServer
-from praetorian_cli.sdk.test.utils import setup_chariot, make_test_values, clean_test_entities
+from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, make_test_values, clean_test_entities
 
 
 @pytest.mark.coherence
 class TestMCP:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_mcp_default(self):

--- a/praetorian_cli/sdk/test/test_preseed.py
+++ b/praetorian_cli/sdk/test/test_preseed.py
@@ -2,14 +2,15 @@ import pytest
 
 from praetorian_cli.sdk.model.globals import Preseed
 from praetorian_cli.sdk.model.utils import asset_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestPreseed:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_preseed(self):

--- a/praetorian_cli/sdk/test/test_risk.py
+++ b/praetorian_cli/sdk/test/test_risk.py
@@ -2,14 +2,15 @@ import pytest
 
 from praetorian_cli.sdk.model.globals import Risk, Kind
 from praetorian_cli.sdk.entities.risks import get_note_entries
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestRisk:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_risk(self):

--- a/praetorian_cli/sdk/test/test_search.py
+++ b/praetorian_cli/sdk/test/test_search.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Asset, Kind, Risk
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSearch:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
         self.sdk.assets.add(self.asset_dns, self.asset_name)
         self.sdk.risks.add(self.asset_key, self.risk_name, Risk.TRIAGE_HIGH.value, self.comment)

--- a/praetorian_cli/sdk/test/test_seed.py
+++ b/praetorian_cli/sdk/test/test_seed.py
@@ -1,14 +1,15 @@
 import pytest
 
 from praetorian_cli.sdk.model.globals import Seed, Kind
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSeed:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_asset_seed(self):

--- a/praetorian_cli/sdk/test/test_setting.py
+++ b/praetorian_cli/sdk/test/test_setting.py
@@ -1,13 +1,14 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestSettings:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_setting(self):

--- a/praetorian_cli/sdk/test/test_test_handler.py
+++ b/praetorian_cli/sdk/test/test_test_handler.py
@@ -1,0 +1,448 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+import praetorian_cli.handlers.cli_decorators as cli_decorators
+import praetorian_cli.handlers.script as script_handler
+import praetorian_cli.handlers.test as test_handler
+import praetorian_cli.main as cli_main
+from praetorian_cli.sdk.keychain import Keychain as SdkKeychain
+
+
+PROFILE = "United States"
+ACCOUNT = "account-123"
+CREDENTIAL_ENV = (
+    "PRAETORIAN_CLI_USERNAME",
+    "PRAETORIAN_CLI_PASSWORD",
+    "PRAETORIAN_CLI_API_KEY_ID",
+    "PRAETORIAN_CLI_API_KEY_SECRET",
+    "PRAETORIAN_CLI_API",
+    "PRAETORIAN_CLI_CLIENT_ID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+)
+CREDENTIAL_FILE_ENV = (
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "BOTO_CONFIG",
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def guard_preconsent_sentinels():
+    with (
+        patch.object(
+            cli_main,
+            "Keychain",
+            side_effect=AssertionError("Keychain constructed before consent"),
+        ) as keychain,
+        patch(
+            "praetorian_cli.sdk.chariot.Chariot",
+            side_effect=AssertionError("Chariot constructed before consent"),
+        ) as chariot,
+        patch.object(
+            script_handler,
+            "load_dynamic_commands",
+            side_effect=AssertionError("dynamic commands loaded before consent"),
+        ) as loader,
+        patch.object(
+            cli_decorators.requests,
+            "get",
+            side_effect=AssertionError("network used before consent"),
+        ) as network,
+        patch.object(
+            SdkKeychain,
+            "load",
+            side_effect=AssertionError("Keychain loaded before consent"),
+        ) as keychain_load,
+        patch.object(
+            SdkKeychain,
+            "token",
+            side_effect=AssertionError("token requested before consent"),
+        ) as token,
+    ):
+        yield SimpleNamespace(
+            keychain=keychain,
+            chariot=chariot,
+            loader=loader,
+            network=network,
+            keychain_load=keychain_load,
+            token=token,
+        )
+
+
+def _chariot(profile=PROFILE, account=ACCOUNT):
+    return SimpleNamespace(
+        keychain=SimpleNamespace(profile=profile, account=account),
+        proxy="http://localhost:8080",
+    )
+
+
+def _invoke(runner, argv, *, chariot=None, input=None, returncode=0, env=None):
+    completed = SimpleNamespace(returncode=returncode)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            test_handler.test,
+            argv,
+            obj=chariot or _chariot(),
+            input=input,
+            env=env,
+        )
+    return result, run
+
+
+def _guard_test_args(suite):
+    return ["--profile", PROFILE, "--account", ACCOUNT, "test", "--suite", suite]
+
+
+def _public_test_args(entry_point, suite, *, include_account=True):
+    args = ["--profile", PROFILE]
+    if include_account:
+        args.extend(["--account", ACCOUNT])
+    if entry_point is cli_main.main:
+        args.append("chariot")
+    return [*args, "test", "--suite", suite]
+
+
+@pytest.mark.parametrize("entry_point", [cli_main.guard_main, cli_main.main])
+@pytest.mark.parametrize(
+    ("include_account", "input"),
+    [(False, "y\n"), (True, "n\n"), (True, "")],
+    ids=["missing-target", "refusal", "eof"],
+)
+def test_every_public_live_path_is_inert_before_consent(
+    runner,
+    guard_preconsent_sentinels,
+    monkeypatch,
+    tmp_path,
+    entry_point,
+    include_account,
+    input,
+):
+    imported = tmp_path / "imported"
+    (tmp_path / "sentinel.py").write_text(
+        f"from pathlib import Path\nPath({str(imported)!r}).write_text('imported')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PRAETORIAN_SCRIPTS_PATH", str(tmp_path))
+
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started before consent"),
+    ) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, "coherence", include_account=include_account),
+            input=input,
+        )
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+    assert not imported.exists()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+@pytest.mark.parametrize("entry_point", [cli_main.guard_main, cli_main.main])
+def test_every_public_live_path_propagates_confirmed_target_and_status(
+    runner,
+    guard_preconsent_sentinels,
+    entry_point,
+):
+    completed = SimpleNamespace(returncode=5)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, "coherence"),
+            input="y\n",
+        )
+
+    assert result.exit_code == 5
+    assert result.output.count("[y/N]") == 1
+    assert result.output.count(f"Profile: {PROFILE}") == 1
+    assert result.output.count(f"Account: {ACCOUNT}") == 1
+    environment = run.call_args.kwargs["env"]
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_refusal_has_no_preconsent_side_effects(runner, guard_preconsent_sentinels):
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started before consent"),
+    ) as run:
+        result = runner.invoke(cli_main.guard_main, _guard_test_args("coherence"), input="n\n")
+
+    assert result.exit_code != 0
+    assert "coherence" in result.output
+    assert PROFILE in result.output
+    assert ACCOUNT in result.output
+    run.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_missing_target_has_no_preconsent_side_effects(runner, guard_preconsent_sentinels):
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started without a target"),
+    ) as run:
+        result = runner.invoke(
+            cli_main.guard_main,
+            ["--profile", PROFILE, "test", "--suite", "coherence"],
+            input="y\n",
+        )
+
+    assert result.exit_code != 0
+    assert "account" in result.output.lower()
+    run.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_live_acceptance_propagates_pytest_status_without_root_initialization(
+    runner,
+    guard_preconsent_sentinels,
+):
+    completed = SimpleNamespace(returncode=5)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(cli_main.guard_main, _guard_test_args("coherence"), input="y\n")
+
+    assert result.exit_code == 5
+    run.assert_called_once()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_safe_suite_skips_root_initialization_and_remains_noninteractive(
+    runner,
+    guard_preconsent_sentinels,
+):
+    completed = SimpleNamespace(returncode=0)
+    with (
+        patch.object(test_handler.subprocess, "run", return_value=completed) as run,
+        patch.object(test_handler.click, "confirm", side_effect=AssertionError("unexpected prompt")) as confirm,
+    ):
+        result = runner.invoke(cli_main.guard_main, ["test"])
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    confirm.assert_not_called()
+    assert all(not mock.called for mock in vars(guard_preconsent_sentinels).values())
+
+
+def test_guard_non_test_command_preserves_normal_initialization(runner):
+    keychain_value = object()
+    chariot_value = object()
+    with (
+        patch.object(cli_main, "Keychain", return_value=keychain_value) as keychain,
+        patch("praetorian_cli.sdk.chariot.Chariot", return_value=chariot_value) as chariot,
+        patch.object(script_handler, "load_dynamic_commands") as loader,
+    ):
+        result = runner.invoke(cli_main.guard_main, ["list", "--help"])
+
+    assert result.exit_code == 0
+    keychain.assert_called_once_with("United States", None)
+    chariot.assert_called_once_with(keychain_value, proxy="")
+    loader.assert_called_once_with()
+
+
+def test_legacy_non_test_command_preserves_normal_initialization(runner):
+    keychain_value = object()
+    chariot_value = object()
+    with (
+        patch.object(cli_main, "Keychain", return_value=keychain_value) as keychain,
+        patch("praetorian_cli.sdk.chariot.Chariot", return_value=chariot_value) as chariot,
+        patch.object(script_handler, "load_dynamic_commands") as loader,
+    ):
+        result = runner.invoke(cli_main.main, ["chariot", "list", "--help"])
+
+    assert result.exit_code == 0
+    keychain.assert_called_once_with("United States", None)
+    chariot.assert_called_once_with(keychain=keychain_value, proxy="")
+    loader.assert_called_once_with()
+
+
+def test_live_confirmation_discloses_target_and_mutation(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "coherence" in result.output
+    assert PROFILE in result.output
+    assert ACCOUNT in result.output
+    assert "mutating" in result.output.lower()
+    assert result.output.count("[y/N]") == 1
+    run.assert_called_once()
+
+
+def test_live_suite_propagates_exact_disclosed_target(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n")
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+    assert environment["CHARIOT_PROXY"] == "http://localhost:8080"
+
+
+@pytest.mark.parametrize(("profile", "account"), [(PROFILE, None), (None, ACCOUNT), ("", ACCOUNT), (PROFILE, "")])
+def test_missing_target_fails_before_subprocess(runner, profile, account):
+    result, run = _invoke(
+        runner,
+        ["--suite", "coherence"],
+        chariot=_chariot(profile=profile, account=account),
+        input="y\n",
+    )
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_live_refusal_is_a_nonzero_noop(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="n\n")
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_live_confirmation_eof_is_a_nonzero_noop(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="")
+
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_safe_suite_is_noninteractive_and_keyless(runner):
+    with patch.object(test_handler.click, "confirm", side_effect=AssertionError("unexpected prompt")) as confirm:
+        result, run = _invoke(runner, [])
+
+    assert result.exit_code == 0
+    confirm.assert_not_called()
+    command = run.call_args.args[0]
+    assert command[-2:] == ["-m", "not coherence and not cli and not tui"]
+    environment = run.call_args.kwargs["env"]
+    assert "CHARIOT_TEST_PROFILE" not in environment
+    assert "CHARIOT_TEST_ACCOUNT" not in environment
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_non_live_suite_scrubs_inherited_credentials(runner, suite):
+    inherited = {name: f"sentinel-{index}" for index, name in enumerate(CREDENTIAL_ENV)}
+
+    result, run = _invoke(runner, ["--suite", suite], env=inherited)
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert all(
+        name not in environment
+        for name in CREDENTIAL_ENV
+        if name not in CREDENTIAL_FILE_ENV
+    )
+    assert all(environment.get(name) != inherited[name] for name in CREDENTIAL_FILE_ENV)
+    assert environment["AWS_EC2_METADATA_DISABLED"] == "true"
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_non_live_suite_isolates_default_credential_stores(runner, tmp_path, suite):
+    ambient_home = tmp_path / "ambient-home"
+    sentinel_paths = (
+        ambient_home / ".praetorian" / "keychain.ini",
+        ambient_home / ".aws" / "credentials",
+        ambient_home / ".aws" / "config",
+    )
+    for path in sentinel_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("credential-sentinel", encoding="utf-8")
+
+    observed = {}
+
+    def inspect_environment(_args, *, env):
+        isolated_home = Path(env["HOME"])
+        observed.update(
+            isolated_home=isolated_home,
+            home_was_dir=isolated_home.is_dir(),
+            userprofile=env.get("USERPROFILE"),
+            shared_credentials_file=env.get("AWS_SHARED_CREDENTIALS_FILE"),
+            aws_config_file=env.get("AWS_CONFIG_FILE"),
+            boto_config=env.get("BOTO_CONFIG"),
+            keychain_exists=(isolated_home / ".praetorian" / "keychain.ini").exists(),
+        )
+        return SimpleNamespace(returncode=0)
+
+    with patch.object(test_handler.subprocess, "run", side_effect=inspect_environment) as run:
+        result = runner.invoke(
+            test_handler.test,
+            ["--suite", suite],
+            obj=_chariot(),
+            env={"HOME": str(ambient_home), "USERPROFILE": str(ambient_home)},
+        )
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    isolated_home = observed["isolated_home"]
+    assert observed["home_was_dir"]
+    assert isolated_home != ambient_home
+    assert observed["userprofile"] == str(isolated_home)
+    assert observed["shared_credentials_file"] == str(isolated_home / ".aws" / "credentials")
+    assert observed["aws_config_file"] == str(isolated_home / ".aws" / "config")
+    assert observed["boto_config"] == str(isolated_home / ".boto")
+    assert observed["keychain_exists"] is False
+
+
+def test_live_suite_retains_inherited_auth_environment(runner):
+    inherited = {name: f"sentinel-{index}" for index, name in enumerate(CREDENTIAL_ENV)}
+
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n", env=inherited)
+
+    assert result.exit_code == 0
+    environment = run.call_args.kwargs["env"]
+    assert all(environment[name] == value for name, value in inherited.items())
+    assert environment["CHARIOT_TEST_PROFILE"] == PROFILE
+    assert environment["CHARIOT_TEST_ACCOUNT"] == ACCOUNT
+
+
+@pytest.mark.parametrize(
+    ("suite", "selector", "input"),
+    [
+        ("safe", "not coherence and not cli and not tui", None),
+        ("coherence", "coherence", "y\n"),
+        ("cli", "cli", "y\n"),
+        ("tui", "tui", None),
+    ],
+)
+def test_every_suite_uses_its_explicit_selector(runner, suite, selector, input):
+    result, run = _invoke(runner, ["--suite", suite], input=input)
+
+    assert result.exit_code == 0
+    command = run.call_args.args[0]
+    marker_index = max(index for index, argument in enumerate(command) if argument == "-m")
+    assert command[marker_index + 1] == selector
+
+
+def test_pytest_exit_status_is_propagated(runner):
+    result, run = _invoke(runner, ["--suite", "coherence"], input="y\n", returncode=5)
+
+    assert result.exit_code == 5
+    run.assert_called_once()

--- a/praetorian_cli/sdk/test/test_test_handler.py
+++ b/praetorian_cli/sdk/test/test_test_handler.py
@@ -14,6 +14,20 @@ from praetorian_cli.sdk.keychain import Keychain as SdkKeychain
 
 PROFILE = "United States"
 ACCOUNT = "account-123"
+
+# handlers.test._test_target() emits this (err=True) when a non-TestTarget context
+# reaches it, and _explicit_target() emits REFUSAL the same way.
+#
+# Stream note, measured on click 8.3.0 (the version pinned here) -- do not "fix" the
+# assertions below to .stdout. click 8.2 removed mix_stderr; Result.output became its
+# OWN stream interleaving stdout and stderr in write order, so err=True text lands in
+# .output as well as .stderr, while .stdout holds only real stdout. Asserting stderr
+# text against .stdout would therefore pass unconditionally. .output is used here
+# because it is the union of both streams: the strongest home for a "never appears"
+# assertion.
+FALLBACK_WARNING = "no explicit test target"
+REFUSAL = "an explicit, unambiguous profile is required"
+
 CREDENTIAL_ENV = (
     "PRAETORIAN_CLI_USERNAME",
     "PRAETORIAN_CLI_PASSWORD",
@@ -93,20 +107,36 @@ def guard_preconsent_sentinels():
         )
 
 
-def _chariot(profile=PROFILE, account=ACCOUNT):
+def _target(profile=PROFILE, account=ACCOUNT):
+    """The context an explicit target actually arrives as.
+
+    A TestTarget is the only carrier of an explicit target, and main.py's _supplied()
+    is the only thing that fills one. Any other shape reaching the handler is a
+    context-wiring regression -- see _sdk_context() for that case.
+    """
+    return test_handler.TestTarget(profile=profile, account=account, proxy="http://localhost:8080")
+
+
+def _sdk_context(profile=PROFILE, account=ACCOUNT):
+    """An SDK-shaped context: what the non-test routes put on click_context.obj.
+
+    Deliberately NOT a TestTarget, so it drives handlers.test._test_target()'s
+    refusal branch. Its keychain carries the declared --profile default, which is
+    exactly the value that must never be inferred as a target.
+    """
     return SimpleNamespace(
         keychain=SimpleNamespace(profile=profile, account=account),
         proxy="http://localhost:8080",
     )
 
 
-def _invoke(runner, argv, *, chariot=None, input=None, returncode=0, env=None):
+def _invoke(runner, argv, *, target=None, input=None, returncode=0, env=None):
     completed = SimpleNamespace(returncode=returncode)
     with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
         result = runner.invoke(
             test_handler.test,
             argv,
-            obj=chariot or _chariot(),
+            obj=target or _target(),
             input=input,
             env=env,
         )
@@ -312,7 +342,7 @@ def test_missing_target_fails_before_subprocess(runner, profile, account):
     result, run = _invoke(
         runner,
         ["--suite", "coherence"],
-        chariot=_chariot(profile=profile, account=account),
+        target=_target(profile=profile, account=account),
         input="y\n",
     )
 
@@ -395,7 +425,7 @@ def test_non_live_suite_isolates_default_credential_stores(runner, tmp_path, sui
         result = runner.invoke(
             test_handler.test,
             ["--suite", suite],
-            obj=_chariot(),
+            obj=_target(),
             env={"HOME": str(ambient_home), "USERPROFILE": str(ambient_home)},
         )
 
@@ -446,3 +476,85 @@ def test_pytest_exit_status_is_propagated(runner):
 
     assert result.exit_code == 5
     run.assert_called_once()
+
+
+@pytest.mark.parametrize("suite", ["coherence", "cli"])
+def test_sdk_context_refuses_live_suite_without_inferring_a_target(runner, suite):
+    # run.assert_not_called() below is the guard. The side_effect is only a perturbation:
+    # cli_decorators.handle_error catches Exception and then touches chariot.is_debug,
+    # which is unset when the command is invoked directly, so this AssertionError would
+    # surface as exit 1 rather than propagating. Do not trust it as a tripwire.
+    with patch.object(
+        test_handler.subprocess,
+        "run",
+        side_effect=AssertionError("subprocess started without an explicit target"),
+    ) as run:
+        result = runner.invoke(
+            test_handler.test,
+            ["--suite", suite],
+            obj=_sdk_context(),
+            input="y\n",
+        )
+
+    # "y" is supplied so a refusal here can only be the gate, never an operator declining.
+    assert result.exit_code == 2
+    assert FALLBACK_WARNING in result.output
+    assert REFUSAL in result.output
+    # click.confirm is deliberately left UNPATCHED: the prompt's own marker is the
+    # witness that consent was never reached, and leaving it real is what makes the
+    # two disclosure assertions below able to fail -- a keychain-inferring regression
+    # prints "Profile: <profile>" here, which a confirm mock would have swallowed.
+    assert "[y/N]" not in result.output
+    assert PROFILE not in result.output
+    assert ACCOUNT not in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("suite", ["safe", "tui"])
+def test_sdk_context_runs_non_live_suite_without_exporting_a_target(runner, suite):
+    completed = SimpleNamespace(returncode=0)
+    with (
+        patch.object(test_handler.subprocess, "run", return_value=completed) as run,
+        patch.object(
+            test_handler.click,
+            "confirm",
+            side_effect=AssertionError("unexpected prompt"),
+        ) as confirm,
+    ):
+        result = runner.invoke(test_handler.test, ["--suite", suite], obj=_sdk_context())
+
+    assert result.exit_code == 0
+    # Proves the refusal branch was taken -- without this the launch below could be
+    # passing because the context was accepted as a target.
+    assert FALLBACK_WARNING in result.output
+    assert REFUSAL not in result.output
+    run.assert_called_once()
+    confirm.assert_not_called()
+    environment = run.call_args.kwargs["env"]
+    assert "CHARIOT_TEST_PROFILE" not in environment
+    assert "CHARIOT_TEST_ACCOUNT" not in environment
+
+
+@pytest.mark.parametrize(
+    "entry_point", [cli_main.guard_main, cli_main.main], ids=["guard_main", "main"]
+)
+# Non-live only, deliberately. A live suite cannot exercise the assertion this test
+# exists for: any regression that emits FALLBACK_WARNING also refuses the live suite, so
+# exit_code fails first and the sentinel line is never reached -- measured, and it merely
+# duplicated test_every_public_live_path_propagates_confirmed_target_and_status. Do not
+# add "coherence" back.
+@pytest.mark.parametrize("suite", ["safe"])
+def test_public_routes_never_reach_the_target_inference_fallback(runner, entry_point, suite):
+    completed = SimpleNamespace(returncode=0)
+    with patch.object(test_handler.subprocess, "run", return_value=completed) as run:
+        result = runner.invoke(
+            entry_point,
+            _public_test_args(entry_point, suite),
+            input="y\n",
+        )
+
+    # Reaching the launch is what makes the absence below load-bearing: the route ran
+    # end to end rather than dying before _test_target() could have warned.
+    assert result.exit_code == 0
+    run.assert_called_once()
+    assert FALLBACK_WARNING not in result.output

--- a/praetorian_cli/sdk/test/test_test_target.py
+++ b/praetorian_cli/sdk/test/test_test_target.py
@@ -3,8 +3,11 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from click.core import ParameterSource
+from click.testing import CliRunner
 
 import praetorian_cli.handlers.test as test_handler
+import praetorian_cli.main as cli_main
 from praetorian_cli.sdk.test import utils
 
 
@@ -229,3 +232,138 @@ def test_safe_suite_uses_an_explicit_keyless_selector():
     assert suite.pytest_selector == ("-m", "not coherence and not cli and not tui")
     assert suite.local_safe is True
     assert suite.requires_target is False
+
+
+# The Click layer is where the --profile default is injected, so the explicit-target
+# gate can only be exercised through the public entry points. `guard` is the shipped
+# console script (setup.cfg: guard = praetorian_cli.main:guard_main); under the legacy
+# `praetorian` entry point the same command sits under the `chariot` group.
+ENTRY_POINTS = [(cli_main.guard_main, []), (cli_main.main, ['chariot'])]
+ENTRY_POINT_IDS = ['guard_main', 'main']
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _coherence_argv(command_path, *root_options):
+    return [*root_options, *command_path, 'test', '--suite', 'coherence']
+
+
+def _invoke_gated(runner, entry_point, argv):
+    """Drive the public CLI with the live-suite launcher armed to fail loudly.
+
+    `--suite coherence` creates, mutates and deletes real entities in a real Guard
+    account. Nothing here may reach subprocess.run, and the confirmation prompt --
+    if the gate ever lets execution get that far -- is answered with a refusal.
+    """
+    with patch.object(
+        test_handler.subprocess,
+        'run',
+        side_effect=AssertionError('a live, mutating suite was launched'),
+    ) as run:
+        result = runner.invoke(entry_point, argv, input='n\n')
+    return result, run
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_defaulted_profile(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(command_path, '--account', 'someone@example.com'),
+    )
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous profile is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_accepts_explicitly_passed_default_profile(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(
+            command_path,
+            '--profile',
+            'United States',
+            '--account',
+            'someone@example.com',
+        ),
+    )
+
+    assert 'Suite: coherence' in result.output
+    assert 'Profile: United States' in result.output
+    assert 'MUTATING' in result.output
+    assert result.exit_code == 1
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_missing_target_entirely(runner, entry_point, command_path):
+    result, run = _invoke_gated(runner, entry_point, _coherence_argv(command_path))
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous profile is required' in result.output
+    assert 'unambiguous account' not in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(('entry_point', 'command_path'), ENTRY_POINTS, ids=ENTRY_POINT_IDS)
+def test_coherence_suite_rejects_defaulted_account(runner, entry_point, command_path):
+    result, run = _invoke_gated(
+        runner,
+        entry_point,
+        _coherence_argv(command_path, '--profile', 'Canada'),
+    )
+
+    assert result.exit_code == 2
+    assert 'an explicit, unambiguous account is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ('profile', 'account', 'label'),
+    [
+        ('', 'a@b.c', 'profile'),
+        (' United States ', 'a@b.c', 'profile'),
+        ('United States', '', 'account'),
+    ],
+    ids=['empty-profile', 'untrimmed-profile', 'empty-account'],
+)
+def test_coherence_suite_rejects_blank_or_untrimmed_explicit_values(runner, profile, account, label):
+    result, run = _invoke_gated(
+        runner,
+        cli_main.guard_main,
+        _coherence_argv([], '--profile', profile, '--account', account),
+    )
+
+    assert result.exit_code == 2
+    assert f'an explicit, unambiguous {label} is required' in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'argv',
+    [['test'], ['test', '--suite', 'safe']],
+    ids=['implicit-default', 'explicit-safe'],
+)
+def test_safe_suite_needs_no_explicit_target(runner, argv):
+    with patch.object(test_handler.subprocess, 'run', return_value=Mock(returncode=0)) as run:
+        result = runner.invoke(cli_main.guard_main, argv, input='n\n')
+
+    assert result.exit_code == 0
+    run.assert_called_once()
+    assert 'explicit, unambiguous' not in result.output
+
+
+def test_supplied_only_honours_commandline_and_environment_sources():
+    assert cli_main.SUPPLIED_PARAMETER_SOURCES == (
+        ParameterSource.COMMANDLINE,
+        ParameterSource.ENVIRONMENT,
+    )
+    assert ParameterSource.DEFAULT not in cli_main.SUPPLIED_PARAMETER_SOURCES
+    assert ParameterSource.DEFAULT_MAP not in cli_main.SUPPLIED_PARAMETER_SOURCES
+    assert ParameterSource.PROMPT not in cli_main.SUPPLIED_PARAMETER_SOURCES

--- a/praetorian_cli/sdk/test/test_test_target.py
+++ b/praetorian_cli/sdk/test/test_test_target.py
@@ -1,0 +1,231 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+import praetorian_cli.handlers.test as test_handler
+from praetorian_cli.sdk.test import utils
+
+
+@pytest.mark.parametrize(
+    ("profile", "account"),
+    [
+        (None, "account-123"),
+        ("", "account-123"),
+        ("United States", None),
+        ("United States", ""),
+    ],
+)
+def test_setup_chariot_requires_explicit_account(profile, account):
+    with patch.object(utils, "Keychain") as keychain, patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(ValueError, match="profile and account"):
+            utils.setup_chariot(profile, account)
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+
+
+def test_setup_chariot_requires_both_explicit_arguments():
+    with patch.object(utils, "Keychain") as keychain, patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(TypeError):
+            utils.setup_chariot()
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+
+
+def test_setup_chariot_propagates_selected_account_without_environment_fallback(monkeypatch):
+    selected_keychain = SimpleNamespace(profile="United States", account="account-123")
+    selected_chariot = object()
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "other-profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "other-account")
+
+    with patch.object(utils, "Keychain", return_value=selected_keychain) as keychain, \
+         patch.object(utils, "Chariot", return_value=selected_chariot) as chariot:
+        result = utils.setup_chariot("United States", "account-123")
+
+    assert result is selected_chariot
+    keychain.assert_called_once_with(profile="United States", account="account-123")
+    chariot.assert_called_once_with(selected_keychain)
+
+
+def test_setup_chariot_rejects_mismatched_target_before_sdk_construction():
+    mismatched_keychain = SimpleNamespace(profile="United States", account="other-account")
+
+    with patch.object(utils, "Keychain", return_value=mismatched_keychain), \
+         patch.object(utils, "Chariot") as chariot:
+        with pytest.raises(ValueError, match="does not match"):
+            utils.setup_chariot("United States", "account-123")
+
+    chariot.assert_not_called()
+
+
+def test_selected_test_target_reads_exact_handler_environment(monkeypatch):
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "Selected Profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "selected-account")
+
+    assert utils.selected_test_target() == ("Selected Profile", "selected-account")
+
+
+@pytest.mark.parametrize(
+    ("profile", "account"),
+    [
+        (None, None),
+        ("Selected Profile", None),
+        (None, "selected-account"),
+        (" ", "selected-account"),
+        ("Selected Profile", " selected-account"),
+    ],
+)
+def test_selected_test_target_rejects_missing_partial_or_malformed_before_sdk(
+    monkeypatch,
+    profile,
+    account,
+):
+    for name, value in (
+        ("CHARIOT_TEST_PROFILE", profile),
+        ("CHARIOT_TEST_ACCOUNT", account),
+    ):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    with patch.object(utils, "Keychain") as keychain, \
+         patch.object(utils, "Chariot") as chariot, \
+         patch("praetorian_cli.sdk.keychain.requests.get") as network:
+        with pytest.raises(ValueError, match="profile and account"):
+            utils.selected_test_target()
+
+    keychain.assert_not_called()
+    chariot.assert_not_called()
+    network.assert_not_called()
+
+
+def test_existing_setup_class_reaches_keychain_with_selected_target(monkeypatch):
+    from praetorian_cli.sdk.test.test_seed import TestSeed
+
+    monkeypatch.setenv("CHARIOT_TEST_PROFILE", "Selected Profile")
+    monkeypatch.setenv("CHARIOT_TEST_ACCOUNT", "selected-account")
+    selected_keychain = SimpleNamespace(profile="Selected Profile", account="selected-account")
+    selected_chariot = object()
+
+    with patch.object(utils, "Keychain", return_value=selected_keychain) as keychain, \
+         patch.object(utils, "Chariot", return_value=selected_chariot) as chariot:
+        instance = TestSeed()
+        instance.setup_class()
+
+    assert instance.sdk is selected_chariot
+    keychain.assert_called_once_with(profile="Selected Profile", account="selected-account")
+    chariot.assert_called_once_with(selected_keychain)
+
+
+def test_z_cli_helpers_forward_confirmed_target_as_inert_argv(monkeypatch):
+    from praetorian_cli.sdk.test import test_z_cli
+
+    confirmed_profile = "Selected Profile; $(profile-command)"
+    confirmed_account = "selected+account;$(account-command)@example.com"
+    configured_default = "configured-default@example.com"
+    monkeypatch.setenv(utils.TEST_PROFILE_ENV, confirmed_profile)
+    monkeypatch.setenv(utils.TEST_ACCOUNT_ENV, confirmed_account)
+    sdk = SimpleNamespace(
+        keychain=SimpleNamespace(
+            profile=confirmed_profile,
+            account=configured_default,
+        )
+    )
+    child = Mock(
+        side_effect=[
+            SimpleNamespace(returncode=0, stdout='{"items": []}', stderr=""),
+            SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ]
+    )
+
+    with patch.object(test_z_cli, "setup_chariot", return_value=sdk), patch.object(
+        test_z_cli, "run", child
+    ):
+        test_case = test_z_cli.TestZCli()
+        test_case.setup_class()
+        assert test_case.run_json('list assets -f "#asset#alpha beta"') == {"items": []}
+        test_case.verify('delete asset "#asset#alpha beta"')
+
+    expected_prefix = [
+        "guard",
+        "--profile",
+        confirmed_profile,
+        "--account",
+        confirmed_account,
+    ]
+    assert child.call_args_list[0].args[0] == expected_prefix + [
+        "list",
+        "assets",
+        "-f",
+        "#asset#alpha beta",
+    ]
+    assert child.call_args_list[1].args[0] == expected_prefix + [
+        "delete",
+        "asset",
+        "#asset#alpha beta",
+    ]
+    for call in child.call_args_list:
+        assert call.kwargs.get("shell", False) is False
+
+
+@pytest.mark.parametrize(
+    ("method", "command"),
+    [
+        ("run_json", "list assets"),
+        ("verify", "delete asset target"),
+    ],
+)
+def test_z_cli_helpers_fail_closed_without_confirmed_target(method, command):
+    from praetorian_cli.sdk.test import test_z_cli
+
+    child = Mock()
+    test_case = test_z_cli.TestZCli()
+    test_case.sdk = SimpleNamespace(
+        keychain=SimpleNamespace(profile="profile-default", account="account-default")
+    )
+
+    with patch.object(test_z_cli, "run", child):
+        with pytest.raises(ValueError, match="confirmed profile and account"):
+            getattr(test_case, method)(command)
+
+    child.assert_not_called()
+
+
+def test_test_handler_callback_stays_below_review_limit():
+    callback = inspect.unwrap(test_handler.test.callback)
+
+    assert len(inspect.getsourcelines(callback)[0]) < 50
+
+
+def test_suite_risk_is_explicit_for_every_suite():
+    expected = {
+        "safe": (True, False, False, False, False),
+        "coherence": (False, True, True, False, True),
+        "cli": (False, True, True, False, True),
+        "tui": (False, False, False, True, False),
+    }
+
+    assert set(test_handler.TEST_SUITES) == set(expected)
+    for name, risk in expected.items():
+        suite = test_handler.TEST_SUITES[name]
+        assert suite.name == name
+        assert (
+            suite.local_safe,
+            suite.live,
+            suite.mutating,
+            suite.tui,
+            suite.requires_target,
+        ) == risk
+        assert suite.pytest_selector
+
+
+def test_safe_suite_uses_an_explicit_keyless_selector():
+    suite = test_handler.TEST_SUITES["safe"]
+
+    assert suite.pytest_selector == ("-m", "not coherence and not cli and not tui")
+    assert suite.local_safe is True
+    assert suite.requires_target is False

--- a/praetorian_cli/sdk/test/test_webhook.py
+++ b/praetorian_cli/sdk/test/test_webhook.py
@@ -5,14 +5,15 @@ import requests
 
 from praetorian_cli.sdk.model.globals import Risk
 from praetorian_cli.sdk.model.utils import risk_key
-from praetorian_cli.sdk.test.utils import make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.coherence
 class TestWebhook:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_create_webhook(self):

--- a/praetorian_cli/sdk/test/test_webpage.py
+++ b/praetorian_cli/sdk/test/test_webpage.py
@@ -1,6 +1,6 @@
 import pytest
 
-from praetorian_cli.sdk.test.utils import make_test_values, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, make_test_values, setup_chariot
 
 
 @pytest.mark.coherence
@@ -8,7 +8,8 @@ class TestWebpage:
     """Test suite for the Webpage entity class."""
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        profile, account = selected_test_target()
+        self.sdk = setup_chariot(profile, account)
         make_test_values(self)
 
     def test_add_webpage(self):

--- a/praetorian_cli/sdk/test/test_z_cli.py
+++ b/praetorian_cli/sdk/test/test_z_cli.py
@@ -1,19 +1,21 @@
 import os
 import json
+import shlex
 from subprocess import run
 
 import pytest
 
 from praetorian_cli.sdk.model.globals import AddRisk, Asset, Risk, Seed, Preseed
 from praetorian_cli.sdk.model.utils import configuration_key
-from praetorian_cli.sdk.test.utils import epoch_micro, random_ip, make_test_values, clean_test_entities, setup_chariot
+from praetorian_cli.sdk.test.utils import selected_test_target, epoch_micro, random_ip, make_test_values, clean_test_entities, setup_chariot
 
 
 @pytest.mark.cli
 class TestZCli:
 
     def setup_class(self):
-        self.sdk = setup_chariot()
+        self._confirmed_profile, self._confirmed_account = selected_test_target()
+        self.sdk = setup_chariot(self._confirmed_profile, self._confirmed_account)
 
     def test_asset_cli(self):
         o = make_test_values(lambda: None)
@@ -452,15 +454,13 @@ class TestZCli:
 
     def run_json(self, command):
         """Run a CLI command and return parsed JSON output."""
-        result = run(f'guard --profile "{self.sdk.keychain.profile}" {command}', capture_output=True,
-                     text=True, shell=True)
+        result = run(self._guard_argv(command), capture_output=True, text=True)
         assert result.returncode == 0, f'CLI "{command}" failed with exit code {result.returncode}; stderr: {result.stderr}'
         assert len(result.stderr) == 0, f'CLI "{command}" should not have content in stderr; instead, got {result.stderr}'
         return json.loads(result.stdout)
 
     def verify(self, command, expected_stdout=[], expected_stderr=[], ignore_stdout=False):
-        result = run(f'guard --profile "{self.sdk.keychain.profile}" {command}', capture_output=True,
-                     text=True, shell=True)
+        result = run(self._guard_argv(command), capture_output=True, text=True)
         if expected_stdout:
             for out in expected_stdout:
                 assert out in result.stdout, f'CLI "{command}" does not contain {out} in stdout; instead, got {result.stdout}'
@@ -475,3 +475,17 @@ class TestZCli:
         else:
             assert len(result.stderr) == 0, \
                 f'CLI "{command}" should not have content in stderr; instead, got {result.stderr}'
+
+    def _guard_argv(self, command):
+        profile = getattr(self, '_confirmed_profile', None)
+        account = getattr(self, '_confirmed_account', None)
+        if (
+            not isinstance(profile, str)
+            or not profile
+            or profile != profile.strip()
+            or not isinstance(account, str)
+            or not account
+            or account != account.strip()
+        ):
+            raise ValueError('A confirmed profile and account are required for CLI tests.')
+        return ['guard', '--profile', profile, '--account', account, *shlex.split(command)]

--- a/praetorian_cli/sdk/test/utils.py
+++ b/praetorian_cli/sdk/test/utils.py
@@ -1,11 +1,15 @@
-import os
 import time
+from os import environ
 from random import randint
 
 from praetorian_cli.sdk.chariot import Chariot
 from praetorian_cli.sdk.keychain import Keychain
 from praetorian_cli.sdk.model.globals import Risk, Preseed
 from praetorian_cli.sdk.model.utils import risk_key, asset_key, ad_domain_key, attribute_key, seed_asset_key, preseed_key, setting_key, configuration_key
+
+
+TEST_PROFILE_ENV = 'CHARIOT_TEST_PROFILE'
+TEST_ACCOUNT_ENV = 'CHARIOT_TEST_ACCOUNT'
 
 
 def epoch_micro():
@@ -84,8 +88,34 @@ def clean_test_entities(sdk, o):
     sdk.settings.delete(o.setting_key)
     sdk.configurations.delete(o.configuration_key)
 
-def setup_chariot():
-    return Chariot(Keychain(os.environ.get('CHARIOT_TEST_PROFILE')))
+def setup_chariot(profile, account):
+    if (
+        not isinstance(profile, str)
+        or not profile
+        or profile != profile.strip()
+        or not isinstance(account, str)
+        or not account
+        or account != account.strip()
+    ):
+        raise ValueError('An explicit profile and account are required for live tests.')
+
+    keychain = Keychain(profile=profile, account=account)
+    if keychain.profile != profile or keychain.account != account:
+        raise ValueError('Constructed test target does not match the selected profile and account.')
+    return Chariot(keychain)
+
+
+def selected_test_target():
+    profile = environ.get(TEST_PROFILE_ENV)
+    account = environ.get(TEST_ACCOUNT_ENV)
+    if (
+        not profile
+        or profile != profile.strip()
+        or not account
+        or account != account.strip()
+    ):
+        raise ValueError('An explicit profile and account are required for live tests.')
+    return profile, account
 
 
 def email_address():


### PR DESCRIPTION
Closes ENG-6571.

## What this is

First of seven per-ticket PRs re-derived from the ENG-6569 (guard-cli OSS-readiness)
audit branch. That branch had accumulated 14 commits mixing six tickets together;
each ticket now ships as its own reviewable PR so findings can be adjudicated
per ticket. This PR carries **only** ENG-6571.

## Problem

`praetorian_cli/handlers/test.py`: `--suite` was optional, so a bare `guard test`
ran the entire shipped integration suite against whatever backend the current
profile points at — no confirmation, no target check. `setup_chariot()` in
`praetorian_cli/sdk/test/utils.py` built `Chariot(Keychain(CHARIOT_TEST_PROFILE))`
from the profile alone and ignored `--account` entirely. Those suites add, update
and delete real assets, risks, settings and configurations; `clean_test_entities()`
deletes them. A client running `guard test` "to see if it works" mutates their
production account.

## What changed

- **`--suite` now defaults to `safe`.** A bare `guard test` runs the local,
  non-mutating suite. This is the core fix.
- **`TEST_SUITES` declares each suite's risk** (`live`, `mutating`,
  `requires_target`), so the gate is a property of the suite rather than
  scattered conditionals.
- **Live/mutating suites require affirmative confirmation.** `_confirm_live_suite`
  prints suite, profile, account, mutation status and live status, then
  `click.confirm(default=False)`. Declining or aborting exits non-zero without
  running anything.
- **Targets must be explicit.** `_explicit_target` rejects a missing, empty or
  untrimmed profile/account; `selected_test_target()` in `sdk/test/utils.py`
  hard-errors rather than silently falling back, so `--account` can no longer be
  dropped on the floor.
- **Non-live suites run sealed off.** `_test_environment` scrubs test/credential
  env vars and `_run_pytest(isolated=True)` gives the safe suite a temporary
  `HOME`, so a "safe" run cannot reach real credentials.
- **The root group no longer authenticates for `test`.** `InvocationPathGroup`
  records the Click-resolved command path during `resolve_command`, so the root
  callback can detect a `test` invocation and install a `TestTarget` instead of
  constructing `Chariot(Keychain(...))`.
- **The target-inference fallback fails closed.** `_test_target` in
  `handlers/test.py` used to synthesize a target from `chariot.keychain` whenever
  it received anything that was not a `TestTarget` — resurrecting exactly the
  `--profile` default that the explicit-target check exists to reject. It now
  warns on stderr and returns an empty target, so a context-wiring regression
  refuses a mutating suite instead of quietly running one against a defaulted
  profile. Found and fixed in review on this PR.
- **README documents the gate** — a new "Running the test suite" section with a
  per-suite risk table, the explicit-target and confirmation requirements, and a
  do-not-point-this-at-production warning (ENG-6571 acceptance criterion 4).

## Premise review — PROCEED (with notes)

Trigger fired: this adds new machinery (a Click `Group` subclass, a suite
descriptor table, an env-scrubbing layer) rather than a one-line fix.

**Is this the right fix at the right layer?** For the P0 itself, yes. The suite
default, the risk table, the confirmation and the explicit-target check all sit
in the command that owns the behavior, and they discharge the ticket's four
acceptance criteria directly.

One layering caveat, recorded rather than blocking. `InvocationPathGroup` exists
because the root callback has an eager side effect — it constructs and
authenticates a `Chariot` before any subcommand runs — so avoiding that for
`test` requires special-casing `test` in the root group. The layer-correct fix is
lazy SDK construction, which would make the special case unnecessary; that is
sibling **ENG-6585** (eager imports / lazy loading). Blocking a P0 safety hole on
that refactor is the wrong trade, so this proceeds as a deliberate tactical fix
and ENG-6585 subsumes the general case.

Two notes for reviewers, neither a hold:

1. `_is_test_invocation` detects via *either* `invoked_subcommand == "test"` *or*
   the recorded `("chariot", "test")` path. The redundancy is worth a look, but
   the failure mode is fail-safe: a missed detection means `guard test`
   authenticates unnecessarily (today's behavior) while the suite gate still
   applies — it does not bypass the gate.
2. `NON_LIVE_CREDENTIAL_ENV` is a 23-entry denylist. It is belt-and-braces with
   the isolated `HOME`, but denylists drift as new credential providers appear;
   an allowlist would age better if this surface grows.

Also note for **ENG-6641** (CLI exits 0 on error): `test` now ends in
`raise SystemExit(result.returncode)`, so suite exit codes propagate. That should
survive the error-boundary rework.

One change was **dropped** from this PR after measurement. An earlier draft added
`except click.ClickException: raise` to `handle_error`, on the theory that the
blanket `except Exception` would otherwise swallow the confirmation abort. That
theory is false: every abort on this path raises `SystemExit`, which derives from
`BaseException` and so was never caught by `except Exception`; and `click.Abort`
is a `RuntimeError`, so the new arm would not have caught it either. Reverting the
two lines leaves the test counts identical, confirming they were inert here. The
gate is real without them. They belong to ENG-6641, which owns `handle_error` and
carries the test that actually exercises that arm, so `cli_decorators.py` is
untouched by this PR.

## Scope

In: the command gate, the target check, `setup_chariot()` profile/account
handling, and the live-suite test files updated to obtain their target
explicitly.

Out: relocating the test suite out of the wheel (ENG-6584, which this unblocks);
the SDK exception hierarchy (ENG-6570); the error boundary and exit codes
(ENG-6641); update-check behavior (ENG-6643). None of those files are touched
here at all — `cli_decorators.py` is byte-identical to `main`.

## Verification

**No test CI exists in this repository.** `.github/workflows/` contains only
the three reviewer workflows and the graph builder, so every number below is a
local measurement, not a gate. **ENG-6574** covers adding one; until it lands
these figures are reproducible by hand but not enforced on merge.

Diff vs `main`: **27 files, 1323 insertions / 64 deletions** —
26 files under `praetorian_cli/` plus `README.md`. `main` here is
`origin/main`, which is identical to this branch's merge base.

**New tests for this ticket** (`test_test_handler.py` 39 +
`test_test_target.py` 34):

```
73 passed
```

**Whole offline suite**, `-m "not coherence and not cli and not tui"
--ignore=praetorian_cli/sdk/test/ui`:

| | passed | deselected |
| --- | --- | --- |
| this branch | 229 | 144 |
| this branch, the two new files also ignored | 156 | 144 |

The second row is the baseline, measured **on this branch** by ignoring only
the two new files rather than by comparing against a separate checkout. That is
the stronger form of the claim: it shows the 156 pre-existing tests still
pass and still classify identically with all of this branch's production changes
applied. 229 - 156 = 73 = 39 + 34, so the delta is the
new tests and nothing else, and the deselected count is unmoved — nothing was
silently skipped into the gate's blind spot. That 144 has held across every
revision of this branch.

Also checked, since the slice touches the root group: `import
praetorian_cli.main` succeeds and `--help` exits 0 on both `main` and
`guard_main` (the real entry point per `setup.cfg`).

Two pre-existing conditions surfaced while running this and are **not** caused
by this PR — neither is touched here:

- `truststore` is imported at `main.py:1` and declared in `setup.cfg`, but the
  released `praetorian-cli` 2.4.4 predates that dependency, so a bare system
  interpreter cannot import `praetorian_cli.main`. Measured in a venv with the
  dependency installed.
- `pytest.ini` lives in `praetorian_cli/sdk/test/` rather than at the repo root,
  so the `coherence` / `cli` / `tui` markers are unregistered when pytest runs
  from the root. Filtering still works; the warnings are cosmetic. **ENG-6584**
  owns relocating the suite.

The live/mutating suites were **not** executed — that is the whole point of the
gate, and doing so would mutate a real account.

