### PR TITLE
fix(cli): stop swallowing errors and exiting 0 on failure (ENG-6641)

### DIFF
--- a/praetorian_cli/handlers/chariot.py
+++ b/praetorian_cli/handlers/chariot.py
@@ -9,7 +9,9 @@ def chariot(click_context):
     if isinstance(click_context.obj, TestTarget):
         return
 
-    # import done here to avoid circular import errors in praetorian_cli/handlers/cli_decorators.py
+    # Deferred import: keeps the cost of importing the whole SDK off the
+    # module-import path, so `guard --help` and unrelated commands do not pay
+    # for it. ENG-6585 owns making this lazy loading systematic.
     from praetorian_cli.sdk.chariot import Chariot
 
     """ Command group for interacting with the Guard product """

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,4 +1,4 @@
-import traceback
+from concurrent.futures import CancelledError
 from functools import wraps
 from importlib.metadata import version
 
@@ -6,8 +6,14 @@ import click
 import requests
 from packaging.version import Version
 
-from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.utils import error
+
+
+UNEXPECTED_ERROR_MESSAGE = "An unexpected error occurred. Re-run with --debug for details."
+
+
+def _debug_enabled(ctx):
+    return bool(ctx.find_root().params.get("debug", False))
 
 
 def handle_error(func):
@@ -16,10 +22,18 @@ def handle_error(func):
     def wrapper(ctx, *args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as e:
-            error(str(e), quit=False)
-            if chariot.is_debug:
-                click.echo(traceback.format_exc())
+        except click.ClickException:
+            raise
+        except click.Abort:
+            raise
+        except click.exceptions.Exit:
+            raise
+        except CancelledError:
+            raise
+        except Exception as exc:
+            if _debug_enabled(ctx):
+                raise
+            raise click.ClickException(UNEXPECTED_ERROR_MESSAGE) from exc
 
     return wrapper
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -9,11 +9,29 @@ from packaging.version import Version
 from praetorian_cli.handlers.utils import error
 
 
-UNEXPECTED_ERROR_MESSAGE = "An unexpected error occurred. Re-run with --debug for details."
+DEBUG_HINT = "(re-run with --debug for the full traceback)"
 
 
 def _debug_enabled(ctx):
     return bool(ctx.find_root().params.get("debug", False))
+
+
+# POLICY: every command routes through this boundary, which passes the
+# exception's message through unchanged -- no sanitizing, summarizing, or
+# redacting. The SDK raises bare `Exception`/`ValueError` as its normal
+# error-reporting mechanism (`process_failure` in praetorian_cli/sdk/chariot.py,
+# praetorian_cli/sdk/entities/*.py), so that message IS the user-facing text.
+#
+# WHERE TO CHANGE: classification is ENG-6570, redaction is ENG-6781 -- neither
+# here. Nor is this the only egress path: praetorian_cli/sdk/mcp_server.py
+# returns `str(e)` to its caller, and the SDK is a public library surface.
+def _error_message(exc):
+    """Surface the exception's own message, plus the `--debug` hint.
+
+    Falls back to the exception's type name when its message is blank.
+    """
+    message = str(exc).strip() or type(exc).__name__
+    return f"{message}\n{DEBUG_HINT}"
 
 
 def handle_error(func):
@@ -33,7 +51,7 @@ def handle_error(func):
         except Exception as exc:
             if _debug_enabled(ctx):
                 raise
-            raise click.ClickException(UNEXPECTED_ERROR_MESSAGE) from exc
+            raise click.ClickException(_error_message(exc)) from exc
 
     return wrapper
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -16,9 +16,11 @@ def _debug_enabled(ctx):
     return bool(ctx.find_root().params.get("debug", False))
 
 
-# POLICY: every command routes through this boundary, which passes the
-# exception's message through unchanged -- no sanitizing, summarizing, or
-# redacting. The SDK raises bare `Exception`/`ValueError` as its normal
+# POLICY: every command routes through this boundary, which surfaces the
+# exception's own message -- no sanitizing, summarizing, or redacting. The one
+# normalization is outer whitespace: it is trimmed so the appended hint lands on
+# the line immediately after the message (and so a whitespace-only message
+# counts as blank). The SDK raises bare `Exception`/`ValueError` as its normal
 # error-reporting mechanism (`process_failure` in praetorian_cli/sdk/chariot.py,
 # praetorian_cli/sdk/entities/*.py), so that message IS the user-facing text.
 #

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -1,0 +1,371 @@
+"""Error-boundary contract for the shared `@cli_handler` decorator.
+
+`handle_error` used to end every unexpected failure with `error(str(e), quit=False)`,
+which printed and *returned* -- so the decorated command returned `None` normally and
+the process exited 0 on every failure. These tests pin the replacement contract:
+
+* an unexpected exception exits non-zero with a redacted, actionable message,
+* `--debug` gives the original exception (and its traceback, on stderr) back,
+* and the deliberate control-flow exceptions -- `ClickException`, `Abort`,
+  `Exit`, `CancelledError`, `SystemExit` -- keep their own status and text
+  instead of being flattened into the generic failure.
+
+Offline only: every command raises before `upgrade_check` can reach the network,
+and each test arms `requests.get` to fail loudly if that ever stops being true.
+"""
+
+import asyncio
+import subprocess
+import sys
+from concurrent.futures import CancelledError as FutureCancelledError
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+
+class SentinelBaseException(BaseException):
+    pass
+
+
+def _command_raising(exception):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        raise exception
+
+    return command
+
+
+def _command_calling(action):
+    """A `@cli_handler` command whose body runs `action()` instead of raising.
+
+    Needed for the paths a bare `raise` cannot express: `ctx.exit(...)`, which
+    Click raises for you, and `utils.error(...)`, which exits from inside the
+    handled-error helper.
+    """
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        return action()
+
+    return command
+
+
+def _debug_root(command):
+    """A root group carrying the real `--debug` flag, with `command` mounted on it.
+
+    `handle_error` reads the flag off the root context's params
+    (`ctx.find_root().params["debug"]`), not off the `chariot` group -- so a
+    synthetic root that declares `--debug` is a faithful stand-in. The real
+    `guard_main` is deliberately NOT used: it builds a `Chariot(Keychain(...))`
+    and is not offline-safe.
+    """
+
+    @click.group()
+    @click.option("--debug", is_flag=True)
+    @click.pass_context
+    def root(ctx, debug):
+        ctx.obj = object()
+
+    root.add_command(command)
+    return root
+
+
+def _disable_update_request(monkeypatch):
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    request = Mock(side_effect=AssertionError("update check ran after failed command"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    return request
+
+
+# `upgrade_check`'s bare `except:` swallows anything raisable, so an in-process
+# guard cannot make a stray network call visible in a child process. `os._exit`
+# cannot be caught: if the advisory ever runs, the child's status is 97 and the
+# return-code assertion fails instead of the request silently going out.
+_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.handlers.cli_decorators as decorators
+decorators.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+
+def _run_child(script):
+    return subprocess.run(
+        [sys.executable, "-c", _NETWORK_TRIPWIRE + script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_ordinary_exception_is_redacted_in_normal_mode_and_chained(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("SECRET_UNEXPECTED_SENTINEL")
+
+    result = CliRunner().invoke(
+        _command_raising(cause),
+        obj=object(),
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, click.ClickException)
+    assert result.exception.__cause__ is cause
+    assert str(result.exception) == "An unexpected error occurred. Re-run with --debug for details."
+    assert "SECRET_UNEXPECTED_SENTINEL" not in str(result.exception)
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status", "expected_text"),
+    [
+        (click.ClickException("actionable failure"), 1, "actionable failure"),
+        (click.UsageError("actionable usage guidance"), 2, "actionable usage guidance"),
+    ],
+)
+def test_deliberate_click_exceptions_preserve_status_and_actionable_text(
+    monkeypatch,
+    exception,
+    expected_status,
+    expected_text,
+):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert result.exit_code == expected_status
+    assert expected_text in result.output
+    assert "An unexpected error occurred" not in result.output
+    request.assert_not_called()
+
+
+def test_explicit_debug_mode_preserves_unexpected_exception_identity(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("debug details")
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    assert result.exc_info is not None
+    request.assert_not_called()
+
+
+def test_real_process_normal_mode_hides_unexpected_traceback_and_message():
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("SECRET_UNEXPECTED_SENTINEL")
+
+command.main(obj=object())
+"""
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert output == "Error: An unexpected error occurred. Re-run with --debug for details.\n"
+    assert "SECRET_UNEXPECTED_SENTINEL" not in output
+    assert "Traceback" not in output
+
+
+def test_real_process_debug_mode_preserves_unexpected_traceback_and_message():
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("DEBUG_UNEXPECTED_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert "DEBUG_UNEXPECTED_SENTINEL" in output
+    assert "Traceback" in output
+
+
+def test_debug_traceback_goes_to_stderr_not_stdout():
+    """A caller piping stdout must not receive a traceback in its data stream.
+
+    The old implementation printed it with `click.echo(traceback.format_exc())`
+    -- no `err=True` -- so `guard --debug ... > data.json` interleaved a
+    traceback into the file. Measured in a real child process rather than with
+    `CliRunner`: `CliRunner`'s `catch_exceptions=True` intercepts the re-raised
+    exception before any traceback is printed, so it cannot observe the stream
+    the traceback lands on at all.
+    """
+    result = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("STREAM_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" in result.stderr
+    assert "STREAM_SENTINEL" in result.stderr
+    assert result.stdout == ""
+
+
+def test_keyboard_interrupt_keeps_click_abort_semantics_and_skips_update(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(KeyboardInterrupt()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.output
+    assert "Error:" not in result.output
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize("exception", [asyncio.CancelledError(), SentinelBaseException("stop")])
+def test_cancellation_and_base_exception_are_not_translated_or_swallowed(monkeypatch, exception):
+    request = _disable_update_request(monkeypatch)
+
+    with pytest.raises(type(exception)) as raised:
+        CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert raised.value is exception
+    request.assert_not_called()
+
+
+def test_future_cancellation_is_not_translated_or_swallowed(monkeypatch):
+    """`concurrent.futures.CancelledError` derives from `Exception` on this runtime.
+
+    Unlike `asyncio.CancelledError` (a `BaseException` since 3.8) the futures
+    variant is caught by a bare `except Exception`, so the dedicated arm is what
+    keeps a cancelled background task from being reported as an unexpected bug.
+    """
+    request = _disable_update_request(monkeypatch)
+    exception = FutureCancelledError("cancelled")
+
+    assert issubclass(FutureCancelledError, Exception)
+    assert FutureCancelledError is not asyncio.CancelledError
+
+    result = CliRunner().invoke(_command_raising(exception), obj=object())
+
+    assert result.exit_code == 1
+    assert result.exception is exception
+    request.assert_not_called()
+
+
+def test_abort_keeps_its_own_message_and_exit_code(monkeypatch):
+    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
+
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(click.Abort()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.output
+    assert UNEXPECTED_ERROR_MESSAGE not in result.output
+    request.assert_not_called()
+
+
+def test_ctx_exit_zero_stays_a_success(monkeypatch):
+    """`ctx.exit(0)` must remain a success.
+
+    `click.exceptions.Exit` is a `RuntimeError`, so without its own arm a
+    deliberate early success is caught by the generic handler and reported as a
+    failure -- turning `exit 0` into `exit 1`.
+    """
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: click.get_current_context().exit(0))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 0
+    assert result.output == ""
+    assert result.exception is None
+    request.assert_not_called()
+
+
+def test_ctx_exit_nonzero_preserves_its_status(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: click.get_current_context().exit(3))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 3
+    assert "An unexpected error occurred" not in result.output
+    request.assert_not_called()
+
+
+def test_sys_exit_passes_through_unchanged(monkeypatch):
+    """`SystemExit` is a `BaseException`; the chain must not start catching it."""
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_calling(lambda: sys.exit(7)), obj=object())
+
+    assert result.exit_code == 7
+    assert "An unexpected error occurred" not in result.output
+    request.assert_not_called()
+
+
+def test_handled_user_facing_error_is_unchanged(monkeypatch):
+    """The *handled* error path is untouched by this change.
+
+    `utils.error` prints `ERROR: <message>` to stderr and exits 1. It must keep
+    its own actionable text -- not be redacted -- and must not be re-labelled
+    with Click's `Error:` prefix.
+    """
+    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
+    from praetorian_cli.handlers.utils import error
+
+    request = _disable_update_request(monkeypatch)
+    command = _command_calling(lambda: error("profile 'staging' is not configured"))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 1
+    assert "ERROR: profile 'staging' is not configured" in result.stderr
+    assert UNEXPECTED_ERROR_MESSAGE not in result.output
+    request.assert_not_called()
+
+
+def test_unexpected_error_message_is_a_module_constant():
+    """The redacted message must keep its actionable half.
+
+    Redaction without a route to the details is a dead end for the user, so pin
+    that the constant still names the flag that recovers them.
+    """
+    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
+
+    assert "--debug" in UNEXPECTED_ERROR_MESSAGE

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -219,12 +219,14 @@ def test_blank_message_falls_back_to_the_exception_type(monkeypatch):
     [
         (Exception(SDK_API_FAILURE_MESSAGE), SDK_API_FAILURE_MESSAGE),
         (ValueError(SDK_VALIDATION_MESSAGE), SDK_VALIDATION_MESSAGE),
+        (Exception(SDK_API_FAILURE_MESSAGE + '\n'), SDK_API_FAILURE_MESSAGE),
         (Exception(), "Exception"),
         (ValueError("   "), "ValueError"),
     ],
     ids=[
         "multi-line-sdk-message",
         "single-line-sdk-message",
+        "sdk-message-with-trailing-newline",
         "no-message",
         "whitespace-only-message",
     ],
@@ -248,7 +250,10 @@ def test_debug_hint_is_appended_once_after_the_intact_message(
     both branches of a re-split `_error_message`, would append it twice.
 
     The two blank cases also pin the preserved fallback to the exception's type
-    name (`.strip()` is what makes whitespace-only count as blank).
+    name (`.strip()` is what makes whitespace-only count as blank). The
+    trailing-newline case is the other half of that same trim -- a real HTTP
+    response body can end in one -- and pins that the hint still lands on the
+    line *immediately* after the message, never after a blank one.
     """
     request = _disable_update_request(monkeypatch)
 

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -4,11 +4,25 @@
 which printed and *returned* -- so the decorated command returned `None` normally and
 the process exited 0 on every failure. These tests pin the replacement contract:
 
-* an unexpected exception exits non-zero with a redacted, actionable message,
-* `--debug` gives the original exception (and its traceback, on stderr) back,
+* an unexpected exception exits non-zero and keeps *its own* message, because the
+  SDK raises bare `Exception`/`ValueError` as its normal error-reporting mechanism
+  (`Chariot.process_failure` raises `Exception('[404] Request failed\\nError: ...')`,
+  `assets.py` raises `ValueError('Invalid asset type: ...')`) -- replacing that text
+  destroys the only actionable detail the user gets,
+* *every* non-debug error message ends with `cli_decorators.DEBUG_HINT` on its own
+  trailing line, exactly once, with the original message left intact ahead of it --
+  so a user who gets only a one-line message still learns how to obtain the
+  traceback. A message-less exception falls back to the exception's type name and
+  carries the hint just the same,
+* no raw traceback reaches the user unless `--debug` is passed,
+* `--debug` gives the original exception (and its traceback, on stderr) back --
+  unwrapped and hint-free, since the traceback the hint advertises is already there,
 * and the deliberate control-flow exceptions -- `ClickException`, `Abort`,
   `Exit`, `CancelledError`, `SystemExit` -- keep their own status and text
-  instead of being flattened into the generic failure.
+  instead of being flattened into a generic failure.
+
+Message *redaction* is deliberately out of scope here: it needs the SDK exception
+hierarchy (ENG-6570) to classify what is safe to show, and is owned by ENG-6781.
 
 Offline only: every command raises before `upgrade_check` can reach the network,
 and each test arms `requests.get` to fail loudly if that ever stops being true.
@@ -23,6 +37,24 @@ from unittest.mock import Mock
 import click
 import pytest
 from click.testing import CliRunner
+
+# Imported, never transcribed: these tests pin that the hint is *appended*, not
+# what its wording is. A copied literal would let the source's text drift away
+# from the suite's silently -- and would turn a deliberate re-wording into a
+# spurious test failure here.
+from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+
+# The exact shape `Chariot.process_failure` raises on a failed API call
+# (praetorian_cli/sdk/chariot.py). Both halves -- the status line and the response
+# body -- have to reach the user.
+SDK_API_FAILURE_MESSAGE = '[404] Request failed\nError: {"message":"asset not found"}'
+
+# The shape the SDK entity helpers raise on bad input, e.g.
+# `raise ValueError(f'Invalid asset type: {asset_type}')` in
+# praetorian_cli/sdk/entities/assets.py.
+SDK_VALIDATION_MESSAGE = 'Invalid asset type: bogus'
+
+TRACEBACK_HEADER = "Traceback (most recent call last)"
 
 
 class SentinelBaseException(BaseException):
@@ -105,9 +137,9 @@ def _run_child(script):
     )
 
 
-def test_ordinary_exception_is_redacted_in_normal_mode_and_chained(monkeypatch):
+def test_ordinary_exception_keeps_its_message_in_normal_mode_and_chained(monkeypatch):
     request = _disable_update_request(monkeypatch)
-    cause = RuntimeError("SECRET_UNEXPECTED_SENTINEL")
+    cause = RuntimeError("UNEXPECTED_SENTINEL")
 
     result = CliRunner().invoke(
         _command_raising(cause),
@@ -118,9 +150,212 @@ def test_ordinary_exception_is_redacted_in_normal_mode_and_chained(monkeypatch):
     assert result.exit_code == 1
     assert isinstance(result.exception, click.ClickException)
     assert result.exception.__cause__ is cause
-    assert str(result.exception) == "An unexpected error occurred. Re-run with --debug for details."
-    assert "SECRET_UNEXPECTED_SENTINEL" not in str(result.exception)
+    assert str(result.exception) == f"UNEXPECTED_SENTINEL\n{DEBUG_HINT}"
     request.assert_not_called()
+
+
+# --- SDK-shaped failures: the messages the CLI exists to relay ------------------
+#
+# The SDK reports every API and validation failure by raising bare `Exception` /
+# `ValueError` with the actionable text in the message. A handler that replaces
+# that text with a generic string satisfies ENG-6641's exit-code AC while
+# destroying the only thing the user can act on -- these tests catch that.
+
+
+def test_sdk_api_failure_message_reaches_the_user(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(Exception(SDK_API_FAILURE_MESSAGE)),
+        obj=object(),
+    )
+
+    assert result.exit_code == 1
+    # `result.output` is the interleaved stdout+stderr stream; `result.stdout` is
+    # empty on this path, so asserting against it would be vacuous.
+    assert "[404] Request failed" in result.output
+    assert "asset not found" in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+def test_sdk_validation_failure_message_reaches_the_user(monkeypatch):
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(ValueError(SDK_VALIDATION_MESSAGE)),
+        obj=object(),
+    )
+
+    assert result.exit_code == 1
+    assert SDK_VALIDATION_MESSAGE in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+def test_blank_message_falls_back_to_the_exception_type(monkeypatch):
+    """A message-less exception must not render as a bare `Error:` with nothing after it."""
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(_command_raising(Exception()), obj=object())
+
+    assert result.exit_code == 1
+    assert "Error: Exception" in result.output
+    assert "--debug" in result.output
+    assert TRACEBACK_HEADER not in result.output
+    request.assert_not_called()
+
+
+# --- the `--debug` hint: appended to EVERY non-debug message ---------------------
+#
+# The hint used to appear only when `str(exc)` was blank, which left the common
+# case -- a real SDK message -- with no way for the user to discover `--debug`.
+# It is now appended unconditionally, so the non-blank cases below are the newly
+# introduced behaviour and the blank ones pin the half that was preserved.
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_body"),
+    [
+        (Exception(SDK_API_FAILURE_MESSAGE), SDK_API_FAILURE_MESSAGE),
+        (ValueError(SDK_VALIDATION_MESSAGE), SDK_VALIDATION_MESSAGE),
+        (Exception(), "Exception"),
+        (ValueError("   "), "ValueError"),
+    ],
+    ids=[
+        "multi-line-sdk-message",
+        "single-line-sdk-message",
+        "no-message",
+        "whitespace-only-message",
+    ],
+)
+def test_debug_hint_is_appended_once_after_the_intact_message(
+    monkeypatch,
+    exception,
+    expected_body,
+):
+    """The hint is a trailing line appended to the message, exactly once.
+
+    Exact equality is what makes this a contract rather than a smoke test: it pins
+    that the body survives *verbatim and in full* ahead of the hint. A containment
+    check would pass on a message the boundary had truncated, reordered, or spliced
+    the hint into the middle of -- the multi-line SDK case is precisely where that
+    could happen unnoticed.
+
+    The `count` assertion is not redundant with it. Equality pins today's single
+    occurrence; `count` names *double-appending* as the specific regression being
+    guarded -- a second `@handle_error` in the decorator chain, or a hint added to
+    both branches of a re-split `_error_message`, would append it twice.
+
+    The two blank cases also pin the preserved fallback to the exception's type
+    name (`.strip()` is what makes whitespace-only count as blank).
+    """
+    request = _disable_update_request(monkeypatch)
+
+    result = CliRunner().invoke(
+        _command_raising(exception),
+        obj=object(),
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 1
+    assert str(result.exception) == f"{expected_body}\n{DEBUG_HINT}"
+    assert str(result.exception).count(DEBUG_HINT) == 1
+    request.assert_not_called()
+
+
+def test_debug_mode_adds_no_hint_and_leaves_the_exception_unwrapped(monkeypatch):
+    """`--debug` is unaffected: the original exception propagates, hint-free.
+
+    The hint exists to tell a user how to reach a traceback. Under `--debug` they
+    already have one, and `_error_message` is never reached -- so the hint must not
+    appear anywhere in the traceback path, and the exception must arrive unwrapped
+    rather than as a `ClickException` carrying an annotated message.
+
+    Identity is measured in-process; the absence of the hint from the real output
+    stream has to be measured in a child process, because `CliRunner` intercepts
+    the re-raise before Python prints anything.
+    """
+    request = _disable_update_request(monkeypatch)
+    cause = RuntimeError("DEBUG_NO_HINT_SENTINEL")
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    # Not re-wrapped, and no hint spliced into its message.
+    assert str(result.exception) == "DEBUG_NO_HINT_SENTINEL"
+    request.assert_not_called()
+
+    child = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise RuntimeError("DEBUG_NO_HINT_SENTINEL")
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    output = child.stdout + child.stderr
+    assert child.returncode == 1
+    assert TRACEBACK_HEADER in child.stderr
+    assert "DEBUG_NO_HINT_SENTINEL" in child.stderr
+    assert DEBUG_HINT not in output
+
+
+def test_debug_mode_preserves_sdk_error_identity_and_traceback(monkeypatch):
+    """`--debug` on an SDK-shaped failure: same exception object, real traceback.
+
+    Identity is measured in-process (`CliRunner` intercepts the re-raise), while
+    the traceback has to be measured in a real child process -- `CliRunner`
+    catches the exception before Python can print one.
+    """
+    request = _disable_update_request(monkeypatch)
+    cause = Exception(SDK_API_FAILURE_MESSAGE)
+    command = _command_raising(cause)
+
+    result = CliRunner().invoke(_debug_root(command), ["--debug", command.name])
+
+    assert result.exit_code == 1
+    assert result.exception is cause
+    request.assert_not_called()
+
+    child = _run_child(
+        """
+import click
+from praetorian_cli.handlers.cli_decorators import cli_handler
+
+@click.group()
+@click.option("--debug", is_flag=True)
+@click.pass_context
+def root(ctx, debug):
+    ctx.obj = object()
+
+@root.command()
+@cli_handler
+def command(_sdk):
+    raise Exception('[404] Request failed\\nError: {"message":"asset not found"}')
+
+root.main(["--debug", "command"])
+"""
+    )
+
+    assert child.returncode == 1
+    assert TRACEBACK_HEADER in child.stderr
+    assert "[404] Request failed" in child.stderr
+    assert "asset not found" in child.stderr
 
 
 @pytest.mark.parametrize(
@@ -142,7 +377,7 @@ def test_deliberate_click_exceptions_preserve_status_and_actionable_text(
 
     assert result.exit_code == expected_status
     assert expected_text in result.output
-    assert "An unexpected error occurred" not in result.output
+    assert TRACEBACK_HEADER not in result.output
     request.assert_not_called()
 
 
@@ -159,7 +394,7 @@ def test_explicit_debug_mode_preserves_unexpected_exception_identity(monkeypatch
     request.assert_not_called()
 
 
-def test_real_process_normal_mode_hides_unexpected_traceback_and_message():
+def test_real_process_normal_mode_shows_message_without_traceback():
     result = _run_child(
         """
 import click
@@ -168,7 +403,7 @@ from praetorian_cli.handlers.cli_decorators import cli_handler
 @click.command()
 @cli_handler
 def command(_sdk):
-    raise RuntimeError("SECRET_UNEXPECTED_SENTINEL")
+    raise RuntimeError("UNEXPECTED_SENTINEL")
 
 command.main(obj=object())
 """
@@ -176,8 +411,9 @@ command.main(obj=object())
 
     output = result.stdout + result.stderr
     assert result.returncode == 1
-    assert output == "Error: An unexpected error occurred. Re-run with --debug for details.\n"
-    assert "SECRET_UNEXPECTED_SENTINEL" not in output
+    # Whole rendered stream, exactly: Click's `Error: ` prefix, the message, then
+    # the hint on its own line. Nothing else -- no traceback, no update advisory.
+    assert output == f"Error: UNEXPECTED_SENTINEL\n{DEBUG_HINT}\n"
     assert "Traceback" not in output
 
 
@@ -287,15 +523,13 @@ def test_future_cancellation_is_not_translated_or_swallowed(monkeypatch):
 
 
 def test_abort_keeps_its_own_message_and_exit_code(monkeypatch):
-    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
-
     request = _disable_update_request(monkeypatch)
 
     result = CliRunner().invoke(_command_raising(click.Abort()), obj=object())
 
     assert result.exit_code == 1
     assert "Aborted!" in result.output
-    assert UNEXPECTED_ERROR_MESSAGE not in result.output
+    assert "Error:" not in result.output
     request.assert_not_called()
 
 
@@ -324,7 +558,7 @@ def test_ctx_exit_nonzero_preserves_its_status(monkeypatch):
     result = CliRunner().invoke(command, obj=object())
 
     assert result.exit_code == 3
-    assert "An unexpected error occurred" not in result.output
+    assert result.output == ""
     request.assert_not_called()
 
 
@@ -335,7 +569,7 @@ def test_sys_exit_passes_through_unchanged(monkeypatch):
     result = CliRunner().invoke(_command_calling(lambda: sys.exit(7)), obj=object())
 
     assert result.exit_code == 7
-    assert "An unexpected error occurred" not in result.output
+    assert "Error:" not in result.output
     request.assert_not_called()
 
 
@@ -343,10 +577,9 @@ def test_handled_user_facing_error_is_unchanged(monkeypatch):
     """The *handled* error path is untouched by this change.
 
     `utils.error` prints `ERROR: <message>` to stderr and exits 1. It must keep
-    its own actionable text -- not be redacted -- and must not be re-labelled
-    with Click's `Error:` prefix.
+    its own actionable text and must not be re-labelled with Click's `Error:`
+    prefix.
     """
-    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
     from praetorian_cli.handlers.utils import error
 
     request = _disable_update_request(monkeypatch)
@@ -356,16 +589,5 @@ def test_handled_user_facing_error_is_unchanged(monkeypatch):
 
     assert result.exit_code == 1
     assert "ERROR: profile 'staging' is not configured" in result.stderr
-    assert UNEXPECTED_ERROR_MESSAGE not in result.output
+    assert "Error:" not in result.output
     request.assert_not_called()
-
-
-def test_unexpected_error_message_is_a_module_constant():
-    """The redacted message must keep its actionable half.
-
-    Redaction without a route to the details is a dead end for the user, so pin
-    that the constant still names the flag that recovers them.
-    """
-    from praetorian_cli.handlers.cli_decorators import UNEXPECTED_ERROR_MESSAGE
-
-    assert "--debug" in UNEXPECTED_ERROR_MESSAGE


### PR DESCRIPTION
Closes ENG-6641.

## What this is

Second of seven per-ticket PRs re-derived from the ENG-6569 (guard-cli
OSS-readiness) audit branch, which had 14 commits mixing six tickets together.
This PR carries **only** ENG-6641.

## Problem

`handle_error` in `praetorian_cli/handlers/cli_decorators.py` ended with

```python
except Exception as e:
    error(str(e), quit=False)
    if chariot.is_debug:
        click.echo(traceback.format_exc())
```

`quit=False` means it prints and returns, so the decorated command returns
`None` normally and **the process exits 0 on every failure**. Every command in
the CLI wears this decorator. Measured on `main`: a command raising
`RuntimeError('boom')` prints `ERROR: boom` and exits **0**. Anything scripting
this CLI — CI, a cron job, a shell `&&` chain — reads success from a failed
command.

Two smaller problems in the same block:

- The `--debug` traceback went to **stdout** (`click.echo` with no `err=True`),
  so a caller piping stdout got a traceback mixed into its data.
- `str(exc)` is `""` for `click.Abort` and for `CancelledError`, so those
  printed a bare `ERROR: ` with no message.

## What changed

```python
except click.ClickException:
    raise
except click.Abort:
    raise
except click.exceptions.Exit:
    raise
except CancelledError:
    raise
except Exception as exc:
    if _debug_enabled(ctx):
        raise
    raise click.ClickException(_error_message(exc)) from exc
```

An unexpected exception becomes a **non-zero exit** carrying the exception's own
message plus a `--debug` hint; `--debug` re-raises so the traceback comes out of
Python's own handler (on stderr, where it belongs) with the original exception
identity intact. `from exc` keeps the cause chained.

`_error_message` is two lines: the exception's message, falling back to its type
name when blank (`click.Abort` and `CancelledError` both stringify to `""`), then
the hint on its own line. **It does not redact.** The SDK raises bare
`Exception`/`ValueError` as its normal error-reporting mechanism — 44 of the 47
raise sites under `praetorian_cli/sdk` are bare builtins, and there are zero
domain exception classes in production code — so the exception's message *is* the
user-facing error text, and `main` already printed it in full. Replacing it with a
generic string would have been a UX regression this PR authored, not a fix; the
adjudication below has the measurements. Classifying which failures are safe to
show is ENG-6570's exception hierarchy and redacting them is ENG-6781; a comment
above the function says so, because this boundary is also not the only egress path
(`praetorian_cli/sdk/mcp_server.py` returns `str(e)` to its caller, and the SDK is
a public library surface).

`import traceback` and the `chariot` import are dropped — both were used only
by the block being replaced, and nothing re-imports `chariot` from this module
(all 23 importers take only `cli_handler` / `praetorian_only` / `list_params` /
`pagination`). `error` stays; `praetorian_only` still uses it. `upgrade_check`
is untouched — its bare-except narrowing belongs to ENG-6643, which rewrites
that function.

One comment elsewhere changed and no code with it: the inline
`from praetorian_cli.sdk.chariot import Chariot` in `handlers/chariot.py` cited a
circular import that no longer exists (verified: `sdk/chariot.py` imports nothing
from `handlers`, and both import orders succeed). The import stays deferred — at
module scope it would make `guard --help` eagerly import the whole SDK — but the
comment now states the real reason and points at ENG-6585.

### Why each pass-through arm is there

The new generic arm is the reason all four exist: it catches anything deriving
from `Exception`, and Click's own control-flow exceptions do. Each was verified
by ablation — delete the arm, re-measure:

| arm removed | case | what breaks |
| --- | --- | --- |
| `ClickException` | `raise UsageError(...)` | exit **1** instead of 2, and the usage text is replaced by the generic arm's rendering |
| `ClickException` | `raise ClickException(...)` | the command's message is re-wrapped and gains a spurious `--debug` hint |
| `Abort` | `raise click.Abort()` | `Aborted!` is replaced by `Abort` + hint |
| `Exit` | `ctx.exit(0)` | exit **1** and an error message on a deliberate **success** exit |
| `Exit` | `ctx.exit(3)` | exit **1** instead of 3 |
| `CancelledError` | `raise CancelledError()` | swallowed into a `ClickException` |

The ablation exit codes were measured at `b725dd8`, before the message change.
That change alters only the text the generic arm emits, never which exceptions
reach it, so every row still holds — the message column is restated for the
current rendering.

The `CancelledError` arm is `concurrent.futures.CancelledError`, which — unlike
`asyncio.CancelledError` — derives from `Exception` (MRO
`CancelledError → Error → Exception`), so it genuinely needs the arm.

`Abort` and `Exit` are additions beyond what the audit branch had. Both are
regressions **this diff would author**: on `main` the old blanket handler
returned 0 for everything, so nothing regressed; the moment the generic arm
starts raising, an un-passed-through `Abort` loses its message and a
`ctx.exit(0)` turns a success into a failure. The `Exit` case is latent today —
no `cli_handler` command calls `ctx.exit()` (`handlers/report.py:88` uses
`sys.exit`, a `BaseException`, which passes through untouched; measured
`sys.exit(7)` → exit 7 before and after) — but the dynamic script commands
under `praetorian_cli/scripts/commands/` also wear `cli_handler` and are where
a `ctx.exit()` would plausibly appear.

## Premise review — PROCEED (re-run at round 1)

Trigger fired: this changes behavior on every command's error path.

**Right fix at the right layer, and narrowly so.** `handle_error` is the single
shared boundary every command already routes through, so the exit-code contract
belongs there rather than in each command; the diff replaces one block in one
file and adds no new abstraction. The alternative — fixing exit codes at each
call site — would be the wrong layer and a far larger diff.

**Re-run, because round 1 changed a premise-relevant input.** The original
verdict graded the exit-code contract and never addressed the *message* policy,
which the first draft silently decided by substituting a generic string for the
exception's own message. A reviewer challenged exactly that. Since the challenged
decision was authored in the same session that would have re-graded it, the
re-entry ran **decorrelated**: a fresh-context domain lead briefed with the diff,
the ticket, the finding and the cited code — no prior verdicts, no justifications,
no transcript.

Its frame verdict, and this one: **PROCEED on the exit-code contract; the message
policy as first drafted was at the wrong layer.** A boundary with nothing to
discriminate on cannot decide what is safe to show — there are zero domain
exception classes in production code, so "redact everything" was the only policy
expressible here, and it removed detail the shipped CLI already gave on every
command. Message *preservation* is the frame-correct choice for this ticket:
ENG-6641 asked for exit codes and traceback suppression, and both are delivered
without touching what the user reads. Classification (ENG-6570) then redaction
(ENG-6781) own the message content, in that order, and the generic `except
Exception` arm this PR ships survives verbatim underneath ENG-6570's new arm.

**Ordering consequence, ruled on by the same blind adjudicator:** ENG-6641 →
ENG-6570 stays valid *under message-preservation, and only under it.* Had the
generic string shipped, ENG-6781 would have had to remove a redaction authority
installed at a layer that cannot hold it — the dependency inverts, and the
design's own rationale ("we cannot tell safe from unsafe, so redact everything")
is an argument that classification is a prerequisite rather than a follow-up.

One nuance recorded rather than blocking: re-raising `CancelledError` surfaces
it as a raw traceback at exit 1. That satisfies AC 1's non-zero half but not
its non-traceback-message half. Deliberate — masking a cancellation signal
would hide task teardown, and `KeyboardInterrupt` (a `BaseException`) already
passes through with its own traceback, so re-raising is the consistent
treatment for cancellation. Flagging it because it is a knowing partial on a
stated acceptance criterion, not an oversight.

## Scope

In: the `handle_error` except chain, the `_error_message` helper and the
`DEBUG_HINT` constant, the imports the rewrite orphans, and one stale comment in
`handlers/chariot.py`.

Out: the SDK exception hierarchy (ENG-6570, which adds an
`except PraetorianError` arm ahead of the generic one — it composes cleanly and
nothing in this chain constrains its placement); redacting error-message content
(ENG-6781, which needs ENG-6570's taxonomy to know what is safe to drop);
systematic lazy SDK loading (ENG-6585); update-check behavior (ENG-6643, which
owns `upgrade_check`). This PR is ordered **before** ENG-6570 deliberately: on
the audit branch, ENG-6570's commit replaced the blanket handler with *only*
`except PraetorianError`, which would have shipped a partial ENG-6641 fix and
left the CLI printing raw tracebacks until the next PR landed.

## Verification

Diff vs merge-base `dd1f5403` (re-measured after ENG-6571 / #273 merged and was
merged into this branch): **3 files, 641 insertions / 7 deletions** — the
`handle_error` rewrite, a new `praetorian_cli/sdk/test/test_cli_errors.py`, and a
comment-only change in `handlers/chariot.py`.

```
M  praetorian_cli/handlers/chariot.py            3   1
M  praetorian_cli/handlers/cli_decorators.py    40   6
A  praetorian_cli/sdk/test/test_cli_errors.py  598   0
```

Exit codes are measured as **real process exit codes**. Each case runs as its own
subprocess through a Click group that mirrors the real root callback (`--debug` as
a root flag that sets `chariot.is_debug`), loading each variant's `cli_decorators`
source side by side with the baseline extracted from `origin/main` — so the two
columns differ only in that one file. The `this branch` column was re-measured at
`245de8d`.

| case | `main` | this branch |
| --- | --- | --- |
| SDK 404 (`[404] Request failed` + JSON body) | **0** — `ERROR: ` + both lines | **1** — same two lines, then the `--debug` hint |
| `KeyError('profile')` | **0** — `ERROR: 'profile'` | **1** — `Error: 'profile'` + hint |
| same, with `--debug` | **0** — traceback on **stdout** | **1** — traceback on **stderr**, exception identity preserved |
| `click.Abort()` | **0** — `ERROR: ` (empty message) | **1** — `Aborted!` |
| `UsageError('bad usage')` | **0** — `ERROR: bad usage`, no usage block | **2** — usage block + `Error: bad usage` |
| `ClickException(...)` | **0** — `ERROR: plain click error` | **1** — `Error: plain click error`, no hint |
| `CancelledError()` | **0** — `ERROR: ` (empty message) | **1** — re-raised (traceback; see the premise note) |
| `ctx.exit(0)` | **0**, but prints `ERROR: 0` | **0**, silent |
| `ctx.exit(3)` | **0** — prints `ERROR: 3` and exits **0** | **3**, silent |
| `sys.exit(7)` | 7 | **7** |
| success | 0 | **0** |
| `utils.error(...)` (handled, user-facing) | 1 | **1**, text unchanged |

**Message content is unchanged from `main`** on every row that carries one — the
first two rows are the ones to read for that. Only the exit code, the stream, and
Click's `Error: ` prefix (was `ERROR: `) differ, plus the appended hint. The
generic-message draft that reviewers saw at `b725dd8` did change content; `85ae993`
reverts that.

Two rows are worse on `main` than a bare "exits 0", which is worth naming
explicitly. `click.exceptions.Exit` is a `RuntimeError`, so `ctx.exit(3)` is
swallowed by the blanket `except Exception`: the code is discarded *and* the
exit value is rendered as a message — `ERROR: 3` at exit 0. `UsageError` loses
its usage block by the same mechanism. Passing Click's control-flow exceptions
through untouched restores both.

**Test counts**, `-m "not coherence and not cli and not tui"
--ignore=praetorian_cli/sdk/test/ui`:

| | passed | deselected |
| --- | --- | --- |
| this branch, new test file `--ignore`d | 229 | 144 |
| this branch | 255 | 144 |
| the new test file alone | 26 | — |

`255 − 229 == 26` — exactly the new tests and nothing else. The deselected count
is unmoved at 144, so no pre-existing test changed marker classification or was
silently skipped past the filter. The baseline is **unmoved across both rounds**: the
message-policy change and round 2's added case both added tests without
disturbing any existing one.

Round 1 replaced three tests with six. The three removed
(`test_ordinary_exception_is_redacted_in_normal_mode_and_chained`,
`test_real_process_normal_mode_hides_unexpected_traceback_and_message`,
`test_unexpected_error_message_is_a_module_constant`) were exactly the tests
asserting the generic string and the constant that carried it — they pinned the
regression as the contract, so they could not survive the fix. What replaced them
asserts the message survives (SDK API failure, SDK validation failure, ordinary
exception, real-subprocess rendering), the blank-message fallback to the type
name, and that the hint is appended exactly once and never in `--debug` mode. No
test references the hint text literally; all five assertion sites import
`DEBUG_HINT`.

Round 2 added one parametrized case and no new test function: a message ending in
a newline, which a real HTTP response body can. It is the only one of the five
cases that reddens if the boundary stops trimming — so before it existed, the trim
could have been deleted outright and this file would still have gone green. The
round-2 adjudication comment has the discriminator output.

The 229 baseline is measured **on this branch** with only the new file ignored,
not in a separate `main` checkout. That is deliberate: it keeps every production
change applied while removing only the new tests, which is the stronger claim
(pre-existing tests still pass *with* the rewritten error boundary in place),
and it cannot be fooled by a stale local `main`.

`import praetorian_cli.main` succeeds; `--help` exits 0 on both `main` and
`guard_main` (the real entry point per `setup.cfg`); `guard_main list --help`
exits 0, exercising a `cli_handler`-decorated subtree.

The `coherence` / `cli` / `tui` suites were **not** executed — they create,
modify and delete real entities in a real backend account.

One caveat on all of the above: **this repo has no test CI.** `.github/workflows/`
contains only the three reviewer workflows and a graph job, so every number here
is a local measurement that CI will not re-check. **ENG-6574** owns adding it,
and it is worth pulling forward so the remaining PRs in this series land under a
real gate.

