### PR TITLE
feat(sdk): raise typed exceptions instead of exiting the host process (ENG-6570)

### DIFF
--- a/praetorian_cli/handlers/configure.py
+++ b/praetorian_cli/handlers/configure.py
@@ -1,5 +1,5 @@
 import click
-from praetorian_cli.sdk.keychain import Keychain, DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_PROFILE
+from praetorian_cli.sdk.keychain import Keychain, DEFAULT_API, DEFAULT_CLIENT_ID, DEFAULT_KEYCHAIN_FILEPATH, DEFAULT_PROFILE
 
 
 @click.command()
@@ -25,3 +25,5 @@ def configure(click_context):
         api_key_id=api_key_id,
         api_key_secret=api_key_secret
     )
+
+    click.echo(f'\nKeychain data written to {DEFAULT_KEYCHAIN_FILEPATH}')

--- a/praetorian_cli/handlers/ssh_utils.py
+++ b/praetorian_cli/handlers/ssh_utils.py
@@ -3,7 +3,7 @@ Shared SSH utilities for Aegis CLI and TUI commands
 """
 
 from typing import List, Dict, Optional
-from praetorian_cli.sdk.model.aegis import Agent
+from praetorian_cli.sdk.model.aegis import validate_agent_for_ssh
 
 
 class SSHArgumentParser:
@@ -125,30 +125,3 @@ class SSHArgumentParser:
         else:
             # Fallback for CLI usage
             print(f"Error: {message}" if not dim else message)
-
-
-def validate_agent_for_ssh(agent: Agent) -> tuple[bool, str]:
-    """
-    Validate if an agent is ready for SSH connections
-    Returns (is_valid, error_message)
-    """
-    if not agent:
-        return False, "No agent specified"
-    
-    client_id = agent.client_id
-    hostname = agent.hostname or 'Unknown'
-    has_tunnel = agent.has_tunnel
-    
-    if not client_id:
-        return False, "Agent missing client_id"
-    
-    # Check if Cloudflare tunnel is available
-    if not has_tunnel:
-        return False, f"SSH not available for {hostname} - no active tunnel"
-    
-    # Check if tunnel has a public hostname
-    public_hostname = agent.health_check.cloudflared_status.hostname if has_tunnel else None
-    if not public_hostname:
-        return False, f"No public hostname found in tunnel configuration for {hostname}"
-    
-    return True, ""

--- a/praetorian_cli/sdk/entities/aegis.py
+++ b/praetorian_cli/sdk/entities/aegis.py
@@ -3,8 +3,7 @@ import shlex
 import shutil
 import subprocess
 import time
-from praetorian_cli.sdk.model.aegis import Agent
-from praetorian_cli.handlers.ssh_utils import validate_agent_for_ssh
+from praetorian_cli.sdk.model.aegis import Agent, validate_agent_for_ssh
 
 
 def normalize_to_list(value, item_keys: List[str] = None) -> List:

--- a/praetorian_cli/sdk/entities/assets.py
+++ b/praetorian_cli/sdk/entities/assets.py
@@ -1,4 +1,3 @@
-from praetorian_cli.handlers.utils import error
 from praetorian_cli.sdk.model.globals import Asset, Kind
 from praetorian_cli.sdk.model.query import Relationship, Node, Query, Filter, KIND_TO_LABEL, asset_of_key, RISK_NODE, ATTRIBUTE_NODE
 

--- a/praetorian_cli/sdk/entities/preseeds.py
+++ b/praetorian_cli/sdk/entities/preseeds.py
@@ -1,4 +1,4 @@
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import NotFoundError
 
 
 class Preseeds:
@@ -105,7 +105,7 @@ class Preseeds:
         :type comment: str or None
         :return: The updated preseed object with new status
         :rtype: dict
-        :raises: Prints error message if preseed with the specified key is not found
+        :raises NotFoundError: if no preseed with the specified key exists
 
         **Example Usage:**
 
@@ -143,7 +143,7 @@ class Preseeds:
 
             return self.api.update('preseed', update_payload)
         else:
-            error(f'Pre-seed {key} is not found.')
+            raise NotFoundError(f'Pre-seed {key} is not found.')
 
     def delete(self, key):
         """Delete a preseed from the Chariot database.

--- a/praetorian_cli/sdk/entities/seeds.py
+++ b/praetorian_cli/sdk/entities/seeds.py
@@ -1,4 +1,4 @@
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import NotFoundError
 from praetorian_cli.sdk.model.globals import Seed, Kind
 from praetorian_cli.sdk.model.query import Query, Node, Filter, KIND_TO_LABEL
 
@@ -80,8 +80,9 @@ class Seeds:
         :param comment: Optional comment to include with the update (stored in History field)
         :type comment: str or None
         :param kwargs: Fields to update
-        :return: The updated seed, or None if the seed was not found
-        :rtype: dict or None
+        :return: The updated seed
+        :rtype: dict
+        :raises NotFoundError: if no seed with the specified key exists
 
         **Example Usage:**
 
@@ -111,7 +112,7 @@ class Seeds:
 
             return self.api.upsert('seed', update_payload)
         else:
-            error(f'Seed {key} not found.')
+            raise NotFoundError(f'Seed {key} not found.')
 
     def delete(self, key):
         """
@@ -119,8 +120,9 @@ class Seeds:
         
         :param key: Seed/Asset key (e.g., '#asset#domain#example.com')
         :type key: str
-        :return: The seed that was marked as deleted, or None if the seed was not found
-        :rtype: dict or None
+        :return: The seed that was marked as deleted
+        :rtype: dict
+        :raises NotFoundError: if no seed with the specified key exists
         """
         seed = self.get(key)  # This already handles old key format conversion
         
@@ -132,7 +134,7 @@ class Seeds:
             
             return self.api.upsert('seed', delete_payload)
         else:
-            error(f'Seed {key} not found.')
+            raise NotFoundError(f'Seed {key} not found.')
 
     def list(self, seed_type=Kind.SEED.value, key_prefix='', pages=100000) -> tuple:
         """

--- a/praetorian_cli/sdk/exceptions.py
+++ b/praetorian_cli/sdk/exceptions.py
@@ -1,0 +1,63 @@
+"""Public exception types raised by the Guard SDK.
+
+The SDK is a library: it reports failures by raising, and never by terminating
+the calling process. Before ENG-6570 eight call sites under `praetorian_cli/sdk`
+called `praetorian_cli.handlers.utils.error()` instead, whose `exit(1)` raises
+`SystemExit` -- a `BaseException`, and therefore invisible to every
+`except Exception` an embedder writes. The `except Exception` in
+`praetorian_cli/sdk/mcp_server.py` and the ones under `praetorian_cli/ui/` were
+all bypassed, so a bad keychain killed those long-lived hosts outright.
+
+Exiting is the CLI's job, and only the CLI's: `@cli_handler`
+(`praetorian_cli/handlers/cli_decorators.py`) catches whatever the SDK raises,
+surfaces its message, and exits non-zero. Nothing in the SDK catches these.
+
+WHERE TO CHANGE: this module is deliberately message-only -- no attributes, no
+error codes, no `__init__` overrides. A public attribute (`.key`, `.profile`,
+`.status_code`) is a permanent commitment that can be added later and removed
+never, so none is added speculatively. Classification of what is safe to
+*display* is ENG-6781, not here.
+
+The hierarchy is sized to what a caller would branch on, not to the number of
+call sites:
+
+    GuardError
+    +-- ConfigurationError
+    +-- AuthenticationError
+    +-- NotFoundError
+"""
+
+
+class GuardError(Exception):
+    """Base class for every error the Guard SDK raises.
+
+    `except GuardError` is the blanket arm for an embedder that wants to treat
+    any SDK failure alike, without also catching unrelated `Exception`s.
+    """
+
+
+class ConfigurationError(GuardError):
+    """The local configuration is unusable, so no request can be attempted.
+
+    A missing, corrupted, or incomplete keychain profile. Retrying is pointless:
+    the operator has to re-run `praetorian configure` (or set the environment
+    variable) before anything else can succeed.
+    """
+
+
+class AuthenticationError(GuardError):
+    """The backend rejected the credentials that were sent.
+
+    Distinct from `ConfigurationError` because the local configuration is fine
+    and the remote said no: the caller's move is to rotate the key or retry,
+    not to reconfigure.
+    """
+
+
+class NotFoundError(GuardError):
+    """The requested entity does not exist.
+
+    Ordinary control flow rather than a fault -- a caller walking a list of keys
+    writes `except NotFoundError: continue`, which the previous `exit(1)` made
+    impossible.
+    """

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -28,6 +28,7 @@ class Keychain:
         self.data = data
         self.filepath = filepath
         self.config = None
+        self._loaded = False
         self.token_cache = None
         self.token_expiry = 0
 
@@ -41,7 +42,12 @@ class Keychain:
 
     def load(self):
         """ Loads backend and authentication data from the keychain file into this instance. """
-        if self.config:
+        # Gate on a load that finished, not on `self.config`: the parser is
+        # assigned below before any validation, and an empty ConfigParser is
+        # truthy (len 1 -- the DEFAULT section always counts, even with no
+        # sections), so testing it would cache a half-validated parser forever
+        # and never reread a keychain file the operator has since repaired.
+        if self._loaded:
             return self
 
         self.config = ConfigParser()
@@ -81,6 +87,7 @@ class Keychain:
         if self.account is None:
             self.account = self.config.get(self.profile, 'account', fallback=None)
 
+        self._loaded = True
         return self
 
     def load_env(self, config_name, env_name, required=True):

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -95,6 +95,9 @@ class Keychain:
             # environment variable takes precedence
             self.config.set(self.profile, config_name, environ[env_name])
         elif required and not self.config.get(self.profile, config_name, fallback=None):
+            # The message below instructs a repair, so this instance must be able
+            # to see one: invalidate the cached load instead of answering from it.
+            self._loaded = False
             raise ConfigurationError(
                 f'{config_name} not in keychain file or the {env_name} environment variable. Run "praetorian configure" to fix. Or set the environment variable.')
 

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -5,10 +5,9 @@ from pathlib import Path
 from time import time
 
 import boto3
-import click
 import requests
 
-from praetorian_cli.handlers.utils import error
+from praetorian_cli.sdk.exceptions import AuthenticationError, ConfigurationError
 from praetorian_cli.sdk.model.globals import DEFAULT_HTTP_TIMEOUT
 
 DEFAULT_API = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
@@ -59,11 +58,12 @@ class Keychain:
                 self.config.read(self.filepath)
 
         if not self.config.sections():
-            error(
+            raise ConfigurationError(
                 f'Keychain file is corrupted. Run "praetorian configure" to configure your profile and credentials. Or, delete the corrupted keychain file at {self.filepath}')
 
         if self.profile not in self.config:
-            error(f'Could not find the "{self.profile}" profile in {self.filepath}. Run "praetorian configure" to fix.')
+            raise ConfigurationError(
+                f'Could not find the "{self.profile}" profile in {self.filepath}. Run "praetorian configure" to fix.')
 
         profile = self.config[self.profile]
         
@@ -75,7 +75,8 @@ class Keychain:
         self.load_env('client_id', 'PRAETORIAN_CLI_CLIENT_ID', required=False)
         
         if 'api' not in profile or 'client_id' not in profile:
-            error(f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
+            raise ConfigurationError(
+                f'Keychain profile "{self.profile}" is corrupted or incomplete. Run "praetorian configure" to fix.')
 
         if self.account is None:
             self.account = self.config.get(self.profile, 'account', fallback=None)
@@ -87,7 +88,7 @@ class Keychain:
             # environment variable takes precedence
             self.config.set(self.profile, config_name, environ[env_name])
         elif required and not self.config.get(self.profile, config_name, fallback=None):
-            error(
+            raise ConfigurationError(
                 f'{config_name} not in keychain file or the {env_name} environment variable. Run "praetorian configure" to fix. Or set the environment variable.')
 
     def token(self):
@@ -103,7 +104,7 @@ class Keychain:
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
                 if response.status_code != 200:
-                    error(f"API key authentication failed: {response.text}")
+                    raise AuthenticationError(f"API key authentication failed: {response.text}")
                 
                 token_data = response.json()
                 self.token_expiry = time() + 3600
@@ -196,5 +197,3 @@ class Keychain:
         Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(exist_ok=True, parents=True)
         with open(DEFAULT_KEYCHAIN_FILEPATH, 'w') as f:
             config.write(f)
-
-        click.echo(f'\nKeychain data written to {DEFAULT_KEYCHAIN_FILEPATH}')

--- a/praetorian_cli/sdk/model/aegis.py
+++ b/praetorian_cli/sdk/model/aegis.py
@@ -154,3 +154,30 @@ class Agent:
             lines.append(f"  IP addresses: {', '.join(ips)}")
         
         return '\n'.join(lines)
+
+
+def validate_agent_for_ssh(agent: Agent) -> tuple[bool, str]:
+    """
+    Validate if an agent is ready for SSH connections
+    Returns (is_valid, error_message)
+    """
+    if not agent:
+        return False, "No agent specified"
+    
+    client_id = agent.client_id
+    hostname = agent.hostname or 'Unknown'
+    has_tunnel = agent.has_tunnel
+    
+    if not client_id:
+        return False, "Agent missing client_id"
+    
+    # Check if Cloudflare tunnel is available
+    if not has_tunnel:
+        return False, f"SSH not available for {hostname} - no active tunnel"
+    
+    # Check if tunnel has a public hostname
+    public_hostname = agent.health_check.cloudflared_status.hostname if has_tunnel else None
+    if not public_hostname:
+        return False, f"No public hostname found in tunnel configuration for {hostname}"
+    
+    return True, ""

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -1,0 +1,460 @@
+"""The SDK's raising contract: the library raises, only the CLI exits.
+
+`praetorian_cli/sdk/**` used to report failures by calling
+`praetorian_cli.handlers.utils.error()`, whose body is `click.secho(...)` +
+`exit(1)`. That made library code do two things a library must not do:
+
+* **terminate the host process.** `exit(1)` raises `SystemExit`, a
+  `BaseException` -- so it is invisible to every `except Exception` an embedder
+  writes. Measured: the `except Exception` in `praetorian_cli/sdk/mcp_server.py`
+  and all 95 of them under `praetorian_cli/ui/` were bypassed, and a bad
+  keychain killed the MCP server process outright.
+* **depend on the presentation layer.** `praetorian_cli/sdk/*` imported
+  `praetorian_cli/handlers/*`, inverting the intended one-way dependency.
+
+These tests pin the replacement: the eight remaining exiting call sites raise
+`praetorian_cli.sdk.exceptions` types, and the `@cli_handler` boundary
+(`praetorian_cli/handlers/cli_decorators.py`) is the only thing that exits.
+
+Scope note: this file's subject is the SDK's *raising* contract. The decorator
+boundary's own contract is pinned separately in `test_cli_errors.py`, which
+stays untouched -- `handlers.utils.error()` remains the handlers layer's helper
+and has seven in-file callers plus every handler module.
+
+Offline only: the child-process tests arm `requests.get` to `os._exit(97)`, so a
+stray network call fails the return-code assertion instead of going out.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import praetorian_cli
+import praetorian_cli.sdk
+import praetorian_cli.sdk.keychain as keychain_module
+
+# Imported, never transcribed -- same reason as test_cli_errors.py: these tests
+# pin that the hint is *appended*, not what its wording is.
+from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+from praetorian_cli.sdk.entities.preseeds import Preseeds
+from praetorian_cli.sdk.entities.seeds import Seeds
+from praetorian_cli.sdk.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    GuardError,
+    NotFoundError,
+)
+from praetorian_cli.sdk.keychain import Keychain
+
+REPO_ROOT = Path(praetorian_cli.__file__).resolve().parent.parent
+SDK_ROOT = Path(praetorian_cli.sdk.__file__).resolve().parent
+
+TRACEBACK_HEADER = "Traceback (most recent call last)"
+
+# A profile name no keychain file will ever hold, so the "profile not found"
+# site is the one reached -- never a real profile of whoever runs the suite.
+MISSING_PROFILE = "__no_such_profile__"
+
+MISSING_SEED_KEY = "#asset#no-such-seed.example.com#no-such-seed.example.com"
+MISSING_PRESEED_KEY = "#preseed#whois+company#No Such Company#no such company"
+
+# A keychain whose single profile is complete, so `load()` reaches whichever
+# later site a test is aiming at instead of failing early.
+VALID_KEYCHAIN = """[United States]
+api = https://api.invalid
+client_id = test-client-id
+"""
+
+# Same, plus API-key credentials, so `has_api_key()` is genuinely true and
+# `token()` takes the API-key branch rather than the Cognito one.
+API_KEY_KEYCHAIN = """[United States]
+api = https://api.invalid
+client_id = test-client-id
+api_key_id = test-key-id
+api_key_secret = test-key-secret
+"""
+
+REJECTION_BODY = '{"message":"api key revoked"}'
+
+SDK_ERROR_CLASSES = (GuardError, ConfigurationError, AuthenticationError, NotFoundError)
+
+
+@pytest.fixture(autouse=True)
+def _no_keychain_env_overrides(monkeypatch):
+    """Strip `PRAETORIAN_*` from the environment for every test in this module.
+
+    `Keychain.load_env` lets an environment variable override the keychain file,
+    so a developer with `PRAETORIAN_CLI_API` exported would silently satisfy the
+    "incomplete profile" site and turn that test green for the wrong reason.
+    """
+    for name in list(os.environ):
+        if name.startswith("PRAETORIAN_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def isolated_home(tmp_path):
+    """A `$HOME` holding a controlled keychain, for the child-process CLI tests.
+
+    `DEFAULT_KEYCHAIN_FILEPATH` is `join(Path.home(), '.praetorian',
+    'keychain.ini')` resolved at import time, so a child process with `HOME`
+    redirected here reads this file -- and one without it reads the developer's
+    real keychain. The file has to *exist* and be valid, too: with no keychain at
+    all `load()` falls back to built-in defaults and a bogus `--profile` would
+    hit the "corrupted file" site instead of the "profile not found" one, making
+    the assertion depend on whose machine ran it.
+    """
+    home = tmp_path / "home"
+    (home / ".praetorian").mkdir(parents=True)
+    (home / ".praetorian" / "keychain.ini").write_text(VALID_KEYCHAIN)
+    return home
+
+
+# Guard against the measurement trap that this repo makes easy: a second,
+# pip-installed `praetorian_cli` is importable, and which one a child gets
+# depends on how it was launched (`-c` prepends the cwd; a script file prepends
+# the script's directory). Measured: launching the same probe as a file in a
+# scratch directory imported a stale third checkout instead of this worktree.
+# The child asserts its own package path and exits 98 rather than reporting a
+# plausible number about code nobody is editing.
+_PACKAGE_GUARD = """
+import os, sys
+import praetorian_cli
+if not praetorian_cli.__file__.startswith(os.environ["PRAETORIAN_TEST_PACKAGE_ROOT"]):
+    sys.stderr.write("imported the wrong praetorian_cli: %s\\n" % praetorian_cli.__file__)
+    os._exit(98)
+"""
+
+# `upgrade_check`'s bare `except:` swallows anything raisable, so only an
+# uncatchable exit makes a stray advisory request visible. Same device as
+# `test_cli_errors.py`'s `_NETWORK_TRIPWIRE`, kept local so this module stands
+# alone.
+_CLI_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.handlers.cli_decorators as decorators
+decorators.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+# The SDK-only counterpart, for the plain-script test: that script must not
+# import the handlers layer at all, since not needing it is half the point.
+# `Keychain.token()` is the only network call in `keychain.py`.
+_SDK_NETWORK_TRIPWIRE = """
+import os
+import praetorian_cli.sdk.keychain as _keychain
+_keychain.requests.get = lambda *a, **k: os._exit(97)
+"""
+
+
+def _run_child(script, tripwire, env=None):
+    child_env = {k: v for k, v in os.environ.items() if not k.startswith("PRAETORIAN_")}
+    child_env["PRAETORIAN_TEST_PACKAGE_ROOT"] = str(REPO_ROOT)
+    if env:
+        child_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-c", _PACKAGE_GUARD + tripwire + script],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(REPO_ROOT),
+        env=child_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The hierarchy itself
+# ---------------------------------------------------------------------------
+
+
+def test_every_sdk_error_is_a_guard_error():
+    """`except GuardError` is the blanket arm an embedder gets to rely on.
+
+    Without this, the three concrete classes could each derive straight from
+    `Exception` -- every message and per-site test below would still pass, and
+    the one promise the base class exists to make would be silently broken.
+    """
+    for cls in (ConfigurationError, AuthenticationError, NotFoundError):
+        assert cls is not GuardError
+        assert issubclass(cls, GuardError), f"{cls.__name__} must subclass GuardError"
+
+        caught = None
+        try:
+            raise cls("boom")
+        except GuardError as exc:
+            caught = exc
+        assert isinstance(caught, cls)
+
+
+def test_sdk_errors_are_not_base_exceptions():
+    """This is the bug being fixed, stated as an assertion.
+
+    Measured on the old code: `error('boom')` was catchable *only* as
+    `SystemExit`, because `exit(1)` raises a `BaseException`. A class that
+    accidentally derived from `SystemExit` would reintroduce exactly that,
+    while every message-text test in this file still passed.
+    """
+    for cls in SDK_ERROR_CLASSES:
+        assert issubclass(cls, Exception), f"{cls.__name__} must be an Exception"
+        assert not issubclass(cls, SystemExit), f"{cls.__name__} must not exit the host"
+
+        caught = None
+        try:
+            raise cls("boom")
+        except Exception as exc:  # noqa: BLE001 - the blanket arm IS the contract
+            caught = exc
+        assert isinstance(caught, cls)
+        assert str(caught) == "boom"
+
+
+# ---------------------------------------------------------------------------
+# The eight converted call sites
+# ---------------------------------------------------------------------------
+
+
+def test_corrupted_keychain_file_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- no parseable profile sections at all."""
+    path = tmp_path / "keychain.ini"
+    # Comments only: a file that parses cleanly to *zero* sections. Arbitrary
+    # bytes would not reach this site -- ConfigParser raises
+    # MissingSectionHeaderError first, which is a different failure.
+    path.write_text("# a keychain file with no profile sections\n")
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(filepath=str(path)).load()
+
+    assert "Keychain file is corrupted" in str(raised.value)
+    assert str(path) in str(raised.value)
+
+
+def test_missing_profile_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- the requested profile is not in the file."""
+    path = tmp_path / "keychain.ini"
+    path.write_text(VALID_KEYCHAIN)
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(profile=MISSING_PROFILE, filepath=str(path)).load()
+
+    assert MISSING_PROFILE in str(raised.value)
+    assert str(path) in str(raised.value)
+
+
+def test_incomplete_profile_raises_configuration_error(tmp_path):
+    """keychain.py `load()` -- profile exists but lacks `api`/`client_id`."""
+    path = tmp_path / "keychain.ini"
+    path.write_text("[United States]\nusername = someone@example.invalid\n")
+
+    with pytest.raises(ConfigurationError) as raised:
+        Keychain(filepath=str(path)).load()
+
+    assert "corrupted or incomplete" in str(raised.value)
+
+
+def test_required_env_option_missing_raises_configuration_error():
+    """keychain.py `load_env()` -- required option in neither file nor env.
+
+    Reached only through a direct call: all six `load_env` calls inside `load()`
+    pass `required=False`, so this site is unreachable from the CLI. It is a
+    public method whose `required` parameter defaults to `True`, so it is
+    converted with the rest and exercised here rather than through the CLI.
+    """
+    keychain = Keychain(data=VALID_KEYCHAIN).load()
+
+    with pytest.raises(ConfigurationError) as raised:
+        keychain.load_env("username", "PRAETORIAN_CLI_USERNAME", required=True)
+
+    assert "PRAETORIAN_CLI_USERNAME" in str(raised.value)
+
+
+def test_rejected_api_key_raises_authentication_error(monkeypatch):
+    """keychain.py `token()` -- the backend rejected the credentials.
+
+    `AuthenticationError`, not `ConfigurationError`: the local configuration is
+    fine and the server said no, so the caller's move is to rotate or retry,
+    not to re-run `configure`.
+    """
+    keychain = Keychain(data=API_KEY_KEYCHAIN)
+    monkeypatch.setattr(
+        keychain_module.requests,
+        "get",
+        Mock(return_value=Mock(status_code=401, text=REJECTION_BODY)),
+    )
+
+    with pytest.raises(AuthenticationError) as raised:
+        keychain.token()
+
+    # The response body is the only actionable detail the caller gets; the
+    # boundary surfaces the message verbatim, so it has to survive to here.
+    assert REJECTION_BODY in str(raised.value)
+
+
+def _seeds_finding_nothing():
+    """A `Seeds` whose backing search returns no results, so `get()` is None."""
+    api = Mock()
+    api.search.by_query.return_value = None
+    return Seeds(api)
+
+
+def test_seeds_update_missing_key_raises_not_found_error():
+    """seeds.py `update()` -- `NotFoundError` is ordinary control flow.
+
+    A caller iterating keys wants `except NotFoundError: continue`, which the
+    old `exit(1)` made impossible.
+    """
+    with pytest.raises(NotFoundError) as raised:
+        _seeds_finding_nothing().update(MISSING_SEED_KEY, "A")
+
+    assert MISSING_SEED_KEY in str(raised.value)
+
+
+def test_seeds_delete_missing_key_raises_not_found_error():
+    """seeds.py `delete()`."""
+    with pytest.raises(NotFoundError) as raised:
+        _seeds_finding_nothing().delete(MISSING_SEED_KEY)
+
+    assert MISSING_SEED_KEY in str(raised.value)
+
+
+def test_preseeds_update_missing_key_raises_not_found_error():
+    """preseeds.py `update()`."""
+    api = Mock()
+    api.search.by_exact_key.return_value = None
+
+    with pytest.raises(NotFoundError) as raised:
+        Preseeds(api).update(MISSING_PRESEED_KEY, "A")
+
+    assert MISSING_PRESEED_KEY in str(raised.value)
+
+
+# ---------------------------------------------------------------------------
+# An embedding host survives (the whole point of the change)
+# ---------------------------------------------------------------------------
+
+
+_PLAIN_SCRIPT_CATCHING_CONFIGURATION_ERROR = """
+import sys
+from praetorian_cli.sdk.exceptions import ConfigurationError
+from praetorian_cli.sdk.keychain import Keychain
+
+try:
+    Keychain(profile={profile!r}, filepath={path!r}).load()
+except ConfigurationError as exc:
+    print("CAUGHT", type(exc).__name__)
+    sys.exit(0)
+
+print("NOT RAISED")
+sys.exit(3)
+"""
+
+
+def test_plain_script_catches_configuration_error_and_survives(tmp_path):
+    """A child process is load-bearing here, not ceremony.
+
+    The claim is that the *host process survives*, and an in-process
+    `pytest.raises` cannot show that: under the old code `exit(1)` raised
+    `SystemExit`, so this script's `except ConfigurationError` never ran and the
+    process died with status 1 and `ERROR:` on stderr. Only a real process can
+    distinguish "caught and continued" from "was killed".
+    """
+    path = tmp_path / "keychain.ini"
+    path.write_text(VALID_KEYCHAIN)
+
+    result = _run_child(
+        _PLAIN_SCRIPT_CATCHING_CONFIGURATION_ERROR.format(
+            profile=MISSING_PROFILE, path=str(path)
+        ),
+        tripwire=_SDK_NETWORK_TRIPWIRE,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "CAUGHT ConfigurationError" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# No user-facing regression at either console script
+# ---------------------------------------------------------------------------
+
+
+_CLI_SCRIPT = """
+from praetorian_cli.main import {entry}
+{entry}({argv!r})
+"""
+
+
+def _cli_child(entry, argv, home):
+    return _run_child(
+        _CLI_SCRIPT.format(entry=entry, argv=argv),
+        tripwire=_CLI_NETWORK_TRIPWIRE,
+        env={"HOME": str(home)},
+    )
+
+
+def _assert_handled_cli_failure(result):
+    combined = result.stdout + result.stderr
+    # `== 1`, never `!= 0`: an argument-parsing mistake exits 2 without ever
+    # reading the keychain, and a stray network call exits 97 -- both would
+    # satisfy a loose assertion while measuring nothing about this change.
+    assert result.returncode == 1, f"exit={result.returncode} output={combined!r}"
+    assert MISSING_PROFILE in result.stderr, combined
+    assert DEBUG_HINT in result.stderr, combined
+    assert TRACEBACK_HEADER not in combined, combined
+
+
+def test_guard_entry_point_missing_profile_is_a_handled_failure(isolated_home):
+    """`guard --profile ... list assets`: exit 1, own message, no traceback."""
+    result = _cli_child(
+        "guard_main", ["--profile", MISSING_PROFILE, "list", "assets"], isolated_home
+    )
+    _assert_handled_cli_failure(result)
+
+
+def test_praetorian_entry_point_missing_profile_is_a_handled_failure(isolated_home):
+    """`praetorian --profile ... chariot list assets`, same contract.
+
+    The two console scripts carry *different* command sets (`praetorian` ->
+    `main`, `guard` -> `guard_main`), so measuring one is not evidence about the
+    other. The `chariot` segment is required: measured, dropping it exits 2 with
+    `Error: No such command 'list'.` and never reaches the keychain.
+    """
+    result = _cli_child(
+        "main",
+        ["--profile", MISSING_PROFILE, "chariot", "list", "assets"],
+        isolated_home,
+    )
+    _assert_handled_cli_failure(result)
+
+
+# ---------------------------------------------------------------------------
+# The dependency direction, as a test rather than a grep
+# ---------------------------------------------------------------------------
+
+
+# WHY THE TEST TREE IS EXCLUDED -- read this before "fixing" a red result here.
+# The CLI's own tests deliberately live under the SDK's test tree and import the
+# CLI layer *in order to test it*: `test_cli_errors.py` alone carries nine such
+# imports. Measured on 556e63a: 18 matches under praetorian_cli/sdk/, 13 of them
+# in this directory. So the rule being enforced is about SHIPPING SDK code.
+# Reading it as "no such import anywhere under sdk/" would mean deleting working
+# tests to quiet a grep -- do NOT resolve a failure here by touching
+# praetorian_cli/sdk/test/.
+SDK_TEST_TREE = SDK_ROOT / "test"
+
+_HANDLERS_IMPORT = re.compile(r"\s*(?:from|import)\s+praetorian_cli\.handlers\b")
+
+
+def test_sdk_does_not_import_the_handlers_layer():
+    """A walk, not a hardcoded file list, so a *new* SDK module cannot slip one in."""
+    offenders = []
+    for module in sorted(SDK_ROOT.rglob("*.py")):
+        if SDK_TEST_TREE in module.parents:
+            continue
+        for lineno, line in enumerate(module.read_text().splitlines(), start=1):
+            if _HANDLERS_IMPORT.match(line):
+                offenders.append(f"{module.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert offenders == [], (
+        "SDK code must not import the CLI handlers layer:\n" + "\n".join(offenders)
+    )

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -230,6 +230,41 @@ def test_corrupted_keychain_file_raises_configuration_error(tmp_path):
     assert str(path) in str(raised.value)
 
 
+def test_failed_load_is_not_cached_so_a_repaired_keychain_is_reread(tmp_path):
+    """keychain.py `load()` -- a raise must not poison the instance for good.
+
+    This is the half of the raising contract that only exists *because* the host
+    now survives. While these sites called `exit(1)` no process lived long
+    enough to hold stale state; now one does, and `load()`'s early return has to
+    key on a load that finished rather than on `self.config` being set. Measured:
+    `bool(ConfigParser())` is `True` and `len()` is 1 -- the DEFAULT section
+    always counts, even with `sections() == []` -- so the parser assigned before
+    validation is already truthy when the raise happens.
+
+    The sequence is the operator's: a long-lived SDK or MCP host hits a corrupt
+    keychain, catches `ConfigurationError`, the operator repairs the file, and
+    the next call has to see the repair. Measured on the unfixed code the second
+    `load()` returned the stale sectionless parser and every `get_option` read
+    `None` -- `ConfigParser.get`'s `fallback=` swallows the missing section as
+    well as a missing option, so the host went on silently seeing an unconfigured
+    profile, with no second error, until it was restarted.
+    """
+    path = tmp_path / "keychain.ini"
+    path.write_text("# no profile sections\n")
+
+    keychain = Keychain(filepath=str(path))
+
+    with pytest.raises(ConfigurationError):
+        keychain.load()
+
+    # The operator fixes the file the message pointed them at, in place.
+    path.write_text(VALID_KEYCHAIN)
+
+    assert keychain.load() is keychain
+    assert keychain.get_option("api") == "https://api.invalid"
+    assert keychain.get_option("client_id") == "test-client-id"
+
+
 def test_missing_profile_raises_configuration_error(tmp_path):
     """keychain.py `load()` -- the requested profile is not in the file."""
     path = tmp_path / "keychain.ini"

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -265,6 +265,48 @@ def test_failed_load_is_not_cached_so_a_repaired_keychain_is_reread(tmp_path):
     assert keychain.get_option("client_id") == "test-client-id"
 
 
+def test_rejected_required_option_is_not_cached_so_a_repaired_keychain_is_reread(
+    tmp_path, monkeypatch
+):
+    """keychain.py `load_env()` -- its raise must invalidate the cached load too.
+
+    The message at this site tells the operator to run `praetorian configure` or
+    export the variable, so the instance has to be able to *see* that repair.
+    Measured on the unfixed code, against a keychain that loads cleanly but
+    carries no `username`: `load()` succeeded and set the cached-load flag, the
+    direct `load_env('username', ...)` raised `ConfigurationError` while the flag
+    stayed `True`, and after the operator added the line the second `load()`
+    returned early without rereading -- `get_option('username')` read `None`
+    indefinitely, while a fresh instance read `'fixed@example.com'`.
+
+    Not a regression from the cached-load flag: the pre-existing `if self.config:`
+    guard returned early here for exactly the same reason. The flag only made a
+    long-standing memoization gap visible, so this test pins the raise path that
+    the earlier one does not cover -- `load_env`'s, reached only by a direct call.
+    """
+    path = tmp_path / "keychain.ini"
+    # Valid, and deliberately without `username` -- that is what VALID_KEYCHAIN
+    # is: `api` and `client_id` only.
+    path.write_text(VALID_KEYCHAIN)
+
+    keychain = Keychain(filepath=str(path))
+    assert keychain.load() is keychain
+
+    # Before the call, not after: the environment branch takes precedence over
+    # the file and would satisfy the option without ever reaching the raise.
+    monkeypatch.delenv("PRAETORIAN_CLI_USERNAME", raising=False)
+
+    with pytest.raises(ConfigurationError):
+        keychain.load_env("username", "PRAETORIAN_CLI_USERNAME")
+
+    # The operator does what the message said, in the profile the load used.
+    with path.open("a") as keychain_file:
+        keychain_file.write("username = fixed@example.com\n")
+
+    assert keychain.load() is keychain
+    assert keychain.get_option("username") == "fixed@example.com"
+
+
 def test_missing_profile_raises_configuration_error(tmp_path):
     """keychain.py `load()` -- the requested profile is not in the file."""
     path = tmp_path / "keychain.ini"


### PR DESCRIPTION
## What this does

`praetorian_cli/sdk/*` imported `error()` from `praetorian_cli/handlers/utils.py`, whose body is
`click.secho(...)` + `exit(1)`. Library code therefore terminated the host process and depended on
the presentation layer. Any client embedding the SDK — the README markets it as exposing the full
backend API — got an uncatchable-by-`except Exception` `SystemExit(1)` instead of an exception.

This PR inverts that dependency: **the SDK raises, and only the CLI exits.**

- New `praetorian_cli/sdk/exceptions.py` — a four-class public hierarchy: `GuardError(Exception)`
  as the base, plus `ConfigurationError`, `AuthenticationError`, and `NotFoundError`.
- All 8 `error()` call sites under `praetorian_cli/sdk/` raise instead, **message text byte-for-byte
  unchanged**.
- The dead `error` import in `sdk/entities/assets.py` is removed (imported, never called).
- The aegis entity's handler-layer SSH-validator import is re-homed.
- The last `click` dependency in the SDK is removed — see *The second half of clause (b)* below.
- **Zero catching code is added.** ENG-6641's `handle_error` boundary (#274) already renders the
  exception's own message and exits 1, so a per-command `except` would duplicate machinery that
  exists.

`GuardError` is the base name, not `ChariotError` or `PraetorianError`: `sdk/guard.py` is
`Guard = Chariot` with `__all__ = ["Guard"]`, so `Guard` is the public-facing name of this SDK.
(Noting this pre-emptively — `PraetorianError` was proposed on #274 as finding G2 and refuted there
on the grounds that ENG-6570 owns the naming.)

### The second half of clause (b) — and a duplicate-output bug it was hiding

The ticket's problem statement has two clauses: the SDK (a) terminates the host process and (b)
depends on the presentation layer. AC1 measures clause (b) by grepping for
`praetorian_cli.handlers` imports — but that grep is a **proxy**, and it passes while the clause is
still half-open: `sdk/keychain.py` also imported `click` directly and called
`click.echo(...)` at the end of the static `Keychain.configure(...)`.

Those two lines are pre-existing and outside the ticket's enumerated call-site list, so the
defensible move was to defer them. Reading the two callers changed the verdict:

- `handlers/configure.py` prints nothing of its own — the SDK's echo **is** the CLI path's
  confirmation.
- `ui/console/console.py::_cmd_configure` **already** prints its own
  `[success]Configured. Profile: …[/success]`. So on that path the SDK echo was emitting a
  **second, duplicate** confirmation, in plain `click` styling that bypassed the rich console's
  renderer entirely.

So the echo moves to `handlers/configure.py`, where the CLI path keeps a byte-identical message,
and the console path simply loses the duplicate. `import click` leaves `sdk/keychain.py` with it.
Net effect: `grep -rn click praetorian_cli/sdk --include='*.py' | grep -v /test/` now returns
**zero** lines, so clause (b) is closed on its own terms rather than on the proxy's.

Two lines, one file each — cheaper than filing the ticket would have been, and it removes a real
observable defect rather than parking one.

### The most inviting wrong turn in this diff

**`@praetorian_only` looks like an out-of-boundary path and is not.** In all four stacks
(`add.py:319`, `delete.py:138`, `get.py:245`, `list.py:312`) it sits *below* `@cli_handler`, and
decorators apply bottom-up — so its wrapper is the **inner** callable and `handle_error` wraps it.
Stated explicitly because the natural reading invites the opposite conclusion.

---

## Premise review — PROCEED, with one AC corrected and one of my own claims withdrawn

The trigger fires: this adds a new public abstraction on a documented library surface and changes
the failure path of five SDK modules. Not a one-line fix, so the frame gets graded before the
machinery.

### Right fix at the right layer — yes, and the layer is forced, not chosen

There is no cheaper layer. Making `error()` not exit would break the CLI's own call sites; catching
`SystemExit` in embedding clients asks every consumer to work around a library bug. Inverting the
dependency at the SDK boundary is the minimum correct change.

**Right-sizing was the live risk, not correctness.** Eight call sites do not justify a deep
taxonomy, and "public exception hierarchy" is the phrase that invites one. This lands on **four**
classes, each justified by a distinct thing a caller would `except` separately — reconfigure
locally / rotate credentials remotely / normal control flow. Nine plausible extra classes are
documented as deliberately rejected in the build plan.

### Correction 1 — AC1 is unsatisfiable as literally written

> `grep -rn "from praetorian_cli.handlers" praetorian_cli/sdk/` returns no matches

Measured on `556e63a`, independently and twice: **18** matches, of which **13 are test files** under
`praetorian_cli/sdk/test/`. Those imports are correct and must survive — they are CLI tests that
live under the SDK test tree and import the CLI layer *in order to test it*. Nine are in
`test_cli_errors.py` alone, the suite ENG-6641 added last commit.

Satisfying AC1 literally would mean deleting working tests to quiet a grep. **AC1 is read as scoped
to non-test SDK code**, where the true count is 5, and it is **encoded as a walk test** so it is
checkable rather than asserted. The test-tree exclusion carries a comment explaining itself, because
the failure mode this correction identifies is precisely a future author "fixing" a red test by
deleting the CLI tests.

Post-change, the exact AC1 grep returns **14 matches, all 14 under `sdk/test/`, 0 non-test**.

### Correction 2 — WITHDRAWN. My own claim, refuted on measurement.

Before planning I asserted that `Keychain(profile, account)` is constructed at `main.py:87` and
`:113` inside the two Click **root callbacks**, outside the `handle_error` boundary, so five of the
eight sites would regress to a raw traceback. I called it "the single most important constraint in
the work."

**It is false. The correct count is 0 of 8, not 5 of 8.** Verified at source:

- `Keychain.__init__` (`keychain.py:26-33`) is **seven attribute assignments** — no file I/O, no
  `load()`. The root callbacks construct an object; they never authenticate.
- `load()` (`:43`) is lazy (`if self.config: return self`) and reachable only via `headers()` (`:37`)
  and `get_option()` (`:155`), both first touched when a command body issues a request —
  **inside** the boundary.

**Why the baseline could not have told me this, which is the part worth keeping.** `error()` calls
`exit(1)`, raising `SystemExit` — a `BaseException`. The boundary catches `click.ClickException`,
`click.Abort`, `click.exceptions.Exit`, `CancelledError`, and `Exception`; `SystemExit` is **not**
among them (measured). So `error()`'s output is produced by `error()` itself and sails straight past
the boundary, and the baseline is byte-identical whether the boundary exists or not. It is a valid
AC4 *target* and **no evidence whatsoever about boundary coverage**. I read a coverage conclusion
out of a measurement that could not contain one. Only patching the SDK to raise and re-measuring
discriminates — which this PR's tests do, on both entry points and on the `@praetorian_only` path:
exit 1, the message, the `--debug` hint, **zero traceback lines**.

Recorded rather than quietly dropped, because the conflict-of-interest mitigation below is what
caught it.

### Composition with ENG-6641 — and the conflict of interest in saying so

The argument that the seeds/preseeds sites need no per-command catch leans on the boundary this
same session authored last commit (#274) — structurally conflicted, since I had an interest in
concluding my own boundary already suffices. Mitigation, recorded rather than assumed: a
fresh-context domain lead was briefed with **both** positions and instructed to decide on
measurement and disagree explicitly. It agreed on this point and measured it (synthetic
`@cli_handler` command raising the new exception: exit 1, message verbatim, no traceback, `--debug`
propagates the original) — **and refuted me on Correction 2 in the same pass**, which is the
evidence the mitigation was real rather than ceremonial.

It also raised one point I would not have: a `ConfigurationError` reading *"Run `praetorian
configure` to fix"* now gets `(re-run with --debug for the full traceback)` appended, and a
traceback offer is noise on a pure user-configuration error — the first message a new user meets.
Suppressing it per-class means `handle_error` branching on `sdk.exceptions`, i.e. classification,
which the policy comment in `cli_decorators.py` explicitly assigns to **ENG-6781** — and whose
dependency direction only becomes legal to write *because* this PR lands. Named as this PR's natural
successor, not its scope.

On the prefix: `ERROR: <msg>` becomes Click's `Error: <msg>` plus the hint. AC4's "unchanged" is
read as *consistent with the post-#274 boundary*, not *byte-identical to the old helper* — `Error:`
is already what a user sees for every other SDK failure, so byte-identity here would make these
eight sites the inconsistent ones. Flagged as a judgment call because it is one.

### Verdict

**PROCEED** on the layer and the approach, with AC1 read as non-test-scoped and AC4 read as
consistent-with-the-boundary. Correction 2 is withdrawn as refuted. Neither surviving correction
changes what the ticket is for; both are recorded so that "all acceptance criteria met" means
something at the close.

---

## Measurement harness — five traps, each of which silently fakes a pass

Recorded because this repo has **no test CI**, so every number below is a local measurement, and
four of these were hit while taking them:

1. **No `__main__` guard** in the entry module, so `python -m praetorian_cli.main` runs nothing and
   exits 0 silently — a plausible-looking harness measuring nothing.
2. **Two console scripts with different command sets** (`praetorian` → `main`, `guard` →
   `guard_main`): the same `--profile __no_such_profile__ list assets` exits **2** with
   `No such command 'list'` under `main`, never reaching the keychain. So the AC4 tests assert
   `returncode == 1` **and** the profile name in stderr, never `!= 0`, or they pass vacuously while
   measuring argument parsing.
3. **How the child is launched decides which checkout you measure** — not merely cwd. `python -c`
   prepends the **cwd**; `python script.py` prepends the **script file's own directory**. The dev
   install is an **editable** one — the pipx venv holds no copy of the package, just
   `__editable__.praetorian_cli-2.4.8.pth` and a `MetaPathFinder` that maps `praetorian_cli` to a
   **third checkout** at `~/praetorian-cli` @ `c8cea59`, which contains **zero** `DEBUG_HINT`
   occurrences, i.e. predates ENG-6641 entirely. Only cwd precedence over that finder saves you: a
   probe run as a file from a scratch directory imported the stale tree *even with cwd inside this
   worktree*. `praetorian_cli.__file__` is asserted, in-process, before any figure is trusted.
4. **A stale `.pyc` fakes a counterfactual.** Every mutation in the sweep below replaced
   `raise ConfigurationError(` (25 chars) with `error(` (6) plus one prepended import — so mutated
   files came out the **same size**, and written inside the same clock second they matched the
   cached bytecode's mtime+size validation. Python reused the *previous* mutation's `.pyc`. The
   failure cuts both ways: a real discriminator reads as non-discriminating, and a mutation can
   read as caught when it was never compiled. Fixed with `PYTHONDONTWRITEBYTECODE=1` plus clearing
   `__pycache__` between cases.
5. **zsh `PIPESTATUS` expands empty**, so `cmd | head; echo EXIT=$?` reports head's status and a
   failing command reads `EXIT=0`. (zsh spells it `${pipestatus[1]}`, lowercase.)

Also: click is **8.4.2** in the shipping venv and `CliRunner(mix_stderr=...)` was removed (hard
`TypeError` at collection). Measured: `ClickException.format_message()` and `show()` render
byte-identically on 8.3.0 and 8.4.2, so **#274's rendering claims hold on the version that actually
ships** — closed by measurement rather than left assumed.

## Test evidence

Safe filter only — `guard test` and the `coherence`/`cli`/`tui` suites mutate and delete real
entities in a real backend account:

```
pytest -m "not coherence and not cli and not tui" --ignore=praetorian_cli/sdk/test/ui
```

| | result |
|---|---|
| Baseline on `556e63a` | `255 passed, 144 deselected`, exit 0 |
| This branch, first push (`c341ed9`) | `269 passed, 144 deselected, 22 warnings in 3.23s`, exit 0 |
| This branch, after review fix 1 (`a8cd65e`) | `270 passed, 144 deselected, 22 warnings in 3.53s`, exit 0 |
| This branch, after review fix 2 (`92172bb`) | `271 passed, 144 deselected, 22 warnings in 4.86s`, exit 0 |

16 new tests in `sdk/test/test_sdk_exceptions.py` (14 with the first push, then 1 with each of the two review fixes below), same 144 deselected, no test removed or skipped.
Interpreter binding asserted in-process before the numbers were trusted: the package, the new
`exceptions` module and the touched `configure` handler all resolve inside `.worktrees/eng-6570`
(trap 3).

**Reproducing these numbers needs the editable dev interpreter, not a bare `python3`.** On a system
Python the safe filter aborts at collection — `ModuleNotFoundError: No module named 'truststore'`
from the entry module, via two of the test modules, giving `144 deselected, 2 errors`, exit 2. Not a
repo defect (`truststore` is a declared dependency; a system interpreter simply does not have it),
but it means "the suite errored" can mean "wrong interpreter" rather than "the change broke
something" — worth knowing before reading a red as a regression.

**The tests are offline and touch no real account.** Verified before running anything: no
`.configure(` call anywhere in the new suite (that would write the real keychain), `$HOME`
redirected to `tmp_path`, backend URL `https://api.invalid` (RFC 2606 reserved TLD, guaranteed
non-resolving), `requests.get` armed to `os._exit(97)` as a network tripwire, an autouse fixture
stripping every `PRAETORIAN_*` variable from the child environment, and a package guard exiting 98
if the child imports from outside this checkout. Proof of no collateral damage: the real
`~/.praetorian/keychain.ini` fingerprinted `72b0caa9779ad8574b4d6c0174b5ca58d8f8091b` **before and
after** the run — identical.

**The new tests were mutation-checked, not just run green.** Each assertion was re-measured against
a mutant that reverts its site to `error()`, to prove the test discriminates rather than passing on
ambient behavior. Two harness bugs surfaced during that sweep and are worth naming because both
produced *confident wrong output*: zsh does not word-split an unquoted `$FILES`, so the restore loop
passed one five-path argument and mutations silently **accumulated** across cases; and a result
parser keying on `startswith(("FAILED","ERROR"))` matched `error()`'s own `ERROR:` stderr and
mislabeled nine genuine REDs as passes. Fixed by restoring from pristine copies verified with `cmp`,
and by anchoring the parser on `^(FAILED|ERROR) <test-path>::`.

## Review adjudication — two findings, both CONFIRMED and fixed in-PR

### Round 1 — the cached half-validated parser

The Codex connector raised a P2 at `keychain.py` on the first push: a caught `ConfigurationError`
leaves the invalid parse cached, so a surviving host never rereads a keychain the operator has since
repaired. **Confirmed and fixed in `a8cd65e`**, not deferred.

The crux is that **an empty `ConfigParser` is truthy** — `bool()` is `True` and `len()` is 1, because
the DEFAULT section always counts, even with `sections() == []`. `load()` assigned `self.config`
before any validation, so the `if self.config: return self` guard was satisfied from that moment and
the three raise sites inside `load()` cached a half-validated parser, not just the one cited.
(Round 1 said "all four"; that overstated it — see the correction under round 2.)

The failure is quieter than the report described, which is worth stating because it changes how an
operator meets it: the stale parser makes every option read `None` rather than raising, since
`ConfigParser.get`'s `fallback=` swallows a missing *section* exactly as it does a missing option. The
host silently sees an apparently unconfigured profile until it restarts.

**This PR authored that manifestation** — before it, these sites called `error()` → `exit(1)`, so no
host survived to hold stale state. A defect that manifests only through this PR's own changes is
ineligible for deferral, so it is an in-PR fix by rule, not by preference.

The fix gates the early return on a load that **finished** (`self._loaded`) rather than on the
parser's truthiness: three functional lines, covering all four existing raise sites and any future
one, with **no** `try`/`except` added (so the zero-catching-code claim above still holds verbatim),
no change to `load_env`'s signature, and no reindent. Verified first that nothing outside
`keychain.py` reads or writes `.config` on a `Keychain`, and that the early return was its only
truthiness test. The regression test was written **before** the fix and measured RED
(`assert None == 'https://api.invalid'`) then GREEN.

### Round 2 — a second P2 at the fixed head, CONFIRMED with its causal premise corrected

The connector re-reviewed `a8cd65e` and raised a related P2: on an instance whose `load()` had
already completed, a direct `load_env(required=True)` raise leaves the cached-load flag set, so the
next `load()` returns early and never rereads the file the operator was just told to repair.
**Confirmed and fixed in `92172bb`.** Materiality: RUNTIME.

The reported sequence reproduces — `get_option('username')` reads `None` indefinitely while a fresh
instance reads the repaired value. But **the finding's attribution to the new flag is wrong**, and it
matters for what the fix is for. Measured at the moment of the raise, `self.config` is **truthy** —
the `load()` it follows *succeeded* — so the pre-existing `if self.config: return self` guard returned
early at this exact point identically. Caching a **successful** load is long-standing, intentional
memoization; `a8cd65e` changed which expression the guard reads, not what it does here.

Provenance, since the fix path is one this PR touches (`M`, `+16 / -10` across the PR, so attribution
is by hunk and not by file): the deciding hunk is mine, but the counterfactual above settles it —
behaviour at this sequence is identical pre- and post-`a8cd65e`. So this is a **pre-existing** gap the
flag made *visible*, which makes it eligible for deferral. It is fixed here anyway, because it is one
line and filing costs more than the fix.

Two reachability facts, recorded because they bound the severity and not the verdict: all six
internal `load_env` calls pass `required=False` and so cannot reach this raise, and the only external
caller in the tree is a test this PR added — there are **no production external callers** today.

The fix clears the flag immediately before that raise: one functional line, still **no** `try`/`except`
anywhere in the diff, no signature change, no exception-message text altered. RED first
(`assert None == 'fixed@example.com'`, exit 1, failing on the final assertion only) then GREEN.

**Correction to round 1, above and on the thread:** "all four raise sites cached a half-validated
parser" overstated it. The three sites inside `load()` do. The fourth — `load_env`'s — is unreachable
from inside `load()`, and when reached externally it caches a **fully valid** parser from a completed
load. Different failure, different fix, hence this second one-liner.

### Reviewer coverage — a real hole, recorded rather than assumed

`coverage-gate.mjs` reports **BLOCKED** at `a8cd65e` with two named holes, both re-triggered by the
round-2 reply (which mentions all three handles, since no reviewer workflow in this repo listens on
`synchronize`):

| reviewer | state | verbatim evidence |
|---|---|---|
| `claude-code-action` | no-show | check `skipped` — gated on `@claude`, which I omitted from the round-1 re-trigger |
| `gemini-review` | no-show | check `failure` — `FatalTurnLimitedError` |
| `codex-review` (workflow) | failure | `stream disconnected before completion: Your organization has reached its configured enforced spend limit.` |
| CodeRabbit | throttled | "Review limit reached"; org spending cap reached |

Worth flagging beyond this PR, and it is **head-anchored** rather than general. At `a8cd65e` the gate
did **not** count `codex-code` as a hole, because the Codex **connector** — a separate channel on
separate billing — had posted substantively there, so the connector's comment masked the workflow's
spend-cap outage from the gate. At the final head `92172bb` it does not mask it: the connector posted
only a quota notice, and the gate names `codex-code` a no-show correctly. So the masking is a
per-head coincidence of who happened to answer, not a standing property of the gate.

By the final head **both Codex channels are out** — the workflow on the org spend cap, the connector
on `You have reached your Codex usage limits for code reviews.` Neither is re-triggerable, so the
`codex-code` hole is recorded rather than closed. The spend cap is org-level: it disables Codex review
workflows across every repo, not just this one.

## Acceptance criteria

- [x] AC1 — no `praetorian_cli.handlers` import under non-test `praetorian_cli/sdk/`, enforced by a
      walk test. Exact ticket grep post-change: 14 matches, all under `sdk/test/`, **0 non-test**
      (see Correction 1 for the test-tree scope reading).
- [x] AC2 — public hierarchy in `sdk/exceptions.py`; all 8 former `error()` sites raise it.
- [x] AC3 — `Seeds.update()` on a nonexistent seed from a plain script raises the SDK exception and
      **not** `SystemExit` (regression test).
- [x] AC4 — CLI behavior consistent with the post-#274 boundary: same message, exit 1, no traceback.

Beyond the ACs: `sdk/` is now `click`-free, closing the second half of the ticket's clause (b) that
AC1's proxy grep could not see.

## Standing caveat

**This repo has no test CI** — the workflow directory holds three reviewer workflows and a graph
job. Every number above is a local measurement, and traps 1-4 are each a way a local measurement
lies. **ENG-6574** owns fixing that, and it is worth pulling forward before the remaining PRs in the
ENG-6569 series land: the stale-checkout trap is exactly what CI catches for free.

Closes ENG-6570. Part of the ENG-6569 guard-cli OSS-readiness epic, shipping one PR per ticket.
