### PR TITLE
fix(cli): cache and gate the PyPI update check (ENG-6643)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,20 +154,33 @@ guard --account guard+example@praetorian.com get asset <ASSET_KEY>
 
 ## Update checks
 
-After a command succeeds, the CLI may check PyPI for a newer release of
+After a command finishes, the CLI may check PyPI for a newer release of
 `praetorian-cli` and print a one-line upgrade advisory to stderr. The check is
 deliberately quiet and infrequent:
 
-- **At most once every 24 hours.** The result is cached at
-  `${XDG_CACHE_HOME:-~/.cache}/praetorian-cli/update-check.json`. Between
-  refreshes the check reads that file and makes no network request at all, so it
-  adds no latency to the commands you run day to day.
-- **Only when a human is watching.** It is skipped when stderr is not a
-  terminal, so it never runs from CI, scripts, or a pipeline.
-- **Never after a failure.** A command that exits non-zero skips the check.
-- **Never blocking for long.** The one refresh per day is capped at 2 seconds,
-  and any failure — offline, DNS, timeout, throttling, a malformed cache — is
-  swallowed. An update check can never change your command's exit code.
+- **At most once every 24 hours.** Every attempt is recorded at
+  `${XDG_CACHE_HOME:-~/.cache}/praetorian-cli/update-check.json` *before* the
+  request is made, so a refresh that fails — offline, DNS, timeout, a malformed
+  response — is rate-limited exactly like one that succeeds, and keeps
+  advertising the last version it did learn. Between refreshes the check reads
+  that file and makes no network request at all. If the file cannot be written
+  at all (a read-only home, a cache directory owned by another user), the check
+  does not run: a probe whose rate we cannot limit is one we do not send.
+- **Only when a human is watching.** It is skipped unless **both** stdout and
+  stderr are a terminal, and skipped when `CI` or `GITHUB_ACTIONS` is set or
+  `TERM=dumb`. Piping either stream — `guard list assets | jq` — turns it off.
+  A script you launch by hand from your own terminal inherits your terminal, so
+  treat the opt-out below, not this gate, as the way to guarantee silence.
+- **Never in place of your command's work.** A command that raises skips the
+  check, and a group that is only delegating to a subcommand leaves the check to
+  the subcommand that does the work. A command that reports an error but still
+  exits `0` is the one case where an advisory can follow a visible error.
+- **Not on the path you run day to day.** The daily refresh passes a 2-second
+  timeout to `requests`, which bounds how long the server may go without
+  sending data — not total wall-clock, so DNS, TLS, redirects and a slow trickle
+  are outside it. Ordinary failures are swallowed and cannot change your exit
+  code; `Ctrl-C` and process-control exceptions raised during the check still
+  propagate, by design, so that interrupting the CLI always works.
 
 ### Disabling it
 
@@ -175,17 +188,18 @@ deliberately quiet and infrequent:
 export PRAETORIAN_CLI_DISABLE_UPDATE_CHECK=1
 ```
 
-Set to exactly `1`. Nothing is read or written — no request, no cache file.
+`1`, `true`, `yes` or `on` (any case). Nothing is read or written — no request,
+no cache file.
 
 ### Privacy
 
 A refresh is an unauthenticated `GET` to `https://pypi.org/pypi/praetorian-cli/json`.
 It sends no account, profile, command, or argument — only what any HTTPS request
 inherently reveals to the server: your IP address and the fact that some
-`praetorian-cli` install asked for the package index at that moment. Because the
-request happens at most once per day per machine and never from a non-interactive
-shell, it does not expose your usage cadence. If contacting pypi.org at all is
-unacceptable in your environment, set the variable above.
+`praetorian-cli` install asked for the package index at that moment. Because
+every attempt is recorded before it is made, that happens at most once per day
+per machine, so your per-command usage cadence is not exposed. If contacting
+pypi.org at all is unacceptable in your environment, set the variable above.
 
 # Operators
 

--- a/README.md
+++ b/README.md
@@ -163,19 +163,24 @@ deliberately quiet and infrequent:
   request is made, so a refresh that fails — offline, DNS, timeout, a malformed
   response — is rate-limited exactly like one that succeeds, and keeps
   advertising the last version it did learn. Between refreshes the check reads
-  that file and makes no network request at all. Commands that start at the same
-  instant are excluded by a marker file created beside that record, so eight
+  that file and makes no network request at all — as long as the record is a
+  plain file that belongs to you and is no larger than 64 KiB. Anything else at
+  that path is ignored as though it were absent, so the next invocation refreshes
+  and replaces it rather than trusting what it found. Commands that start at the
+  same instant are excluded by a marker file created beside that record, so eight
   concurrent invocations perform one refresh rather than eight — including when
   the request fails instantly, since the attempt is recorded before it is made.
   A process killed mid-refresh leaves the marker behind, which defers the next
-  refresh that is actually due by up to a minute rather than permitting an extra
-  one. A relative `XDG_CACHE_HOME` is
+  refresh that is actually due rather than permitting an extra one — by up to a
+  minute, or up to two if the clock steps backwards in between, since a marker
+  counts as held while its age is within a minute in *either* direction. A
+  relative `XDG_CACHE_HOME` is
   ignored in favour of `~/.cache`, as the base-directory spec requires —
   honouring it would put a separate cache in every working directory and so
-  defeat the limit outright. If the record cannot be written at all (a read-only
-  home, a cache directory owned by another user, or one reached through a
-  symlink), the check does not run: a probe whose rate we cannot limit is one we
-  do not send.
+  defeat the limit outright. If the cache directory cannot be written at all (a
+  read-only home, one owned by another user, or one reached through a symlink),
+  the check does not run: a probe whose rate we cannot limit is one we do not
+  send.
 - **Only when a human is watching.** It is skipped unless **both** stdout and
   stderr are a terminal, and skipped when `CI` or `GITHUB_ACTIONS` is set or
   `TERM=dumb`. Piping either stream — `guard list assets | jq` — turns it off.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ guard --account guard+example@praetorian.com get asset <ASSET_KEY>
 ## Update checks
 
 After a command finishes, the CLI may check PyPI for a newer release of
-`praetorian-cli` and print a one-line upgrade advisory to stderr. The check is
+`praetorian-cli` and print a three-line upgrade advisory to stderr. The check is
 deliberately quiet and infrequent:
 
 - **At most once every 24 hours.** Every attempt is recorded at
@@ -163,9 +163,19 @@ deliberately quiet and infrequent:
   request is made, so a refresh that fails — offline, DNS, timeout, a malformed
   response — is rate-limited exactly like one that succeeds, and keeps
   advertising the last version it did learn. Between refreshes the check reads
-  that file and makes no network request at all. If the file cannot be written
-  at all (a read-only home, a cache directory owned by another user), the check
-  does not run: a probe whose rate we cannot limit is one we do not send.
+  that file and makes no network request at all. Commands that start at the same
+  instant are excluded by a marker file created beside that record, so eight
+  concurrent invocations perform one refresh rather than eight — including when
+  the request fails instantly, since the attempt is recorded before it is made.
+  A process killed mid-refresh leaves the marker behind, which defers the next
+  refresh that is actually due by up to a minute rather than permitting an extra
+  one. A relative `XDG_CACHE_HOME` is
+  ignored in favour of `~/.cache`, as the base-directory spec requires —
+  honouring it would put a separate cache in every working directory and so
+  defeat the limit outright. If the record cannot be written at all (a read-only
+  home, a cache directory owned by another user, or one reached through a
+  symlink), the check does not run: a probe whose rate we cannot limit is one we
+  do not send.
 - **Only when a human is watching.** It is skipped unless **both** stdout and
   stderr are a terminal, and skipped when `CI` or `GITHUB_ACTIONS` is set or
   `TERM=dumb`. Piping either stream — `guard list assets | jq` — turns it off.
@@ -197,8 +207,10 @@ A refresh is an unauthenticated `GET` to `https://pypi.org/pypi/praetorian-cli/j
 It sends no account, profile, command, or argument — only what any HTTPS request
 inherently reveals to the server: your IP address and the fact that some
 `praetorian-cli` install asked for the package index at that moment. Because
-every attempt is recorded before it is made, that happens at most once per day
-per machine, so your per-command usage cadence is not exposed. If contacting
+every attempt is recorded before it is made and concurrent attempts are
+excluded, that happens at most once per day per user account on the machine —
+several users each get their own cache — so your per-command usage cadence is
+not exposed. If contacting
 pypi.org at all is unacceptable in your environment, set the variable above.
 
 # Operators

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
     - [Signing up](#signing-up)
     - [Authentication](#authentication)
 - [Using the CLI](#using-the-cli)
+    - [Update checks](#update-checks)
 - [Operators](#operators)
     - [Interactive Console](#interactive-console)
     - [Install local security tools (optional)](#install-local-security-tools-optional)
@@ -150,6 +151,41 @@ To get detailed information about a specific asset, run:
 ```zsh
 guard --account guard+example@praetorian.com get asset <ASSET_KEY>
 ```
+
+## Update checks
+
+After a command succeeds, the CLI may check PyPI for a newer release of
+`praetorian-cli` and print a one-line upgrade advisory to stderr. The check is
+deliberately quiet and infrequent:
+
+- **At most once every 24 hours.** The result is cached at
+  `${XDG_CACHE_HOME:-~/.cache}/praetorian-cli/update-check.json`. Between
+  refreshes the check reads that file and makes no network request at all, so it
+  adds no latency to the commands you run day to day.
+- **Only when a human is watching.** It is skipped when stderr is not a
+  terminal, so it never runs from CI, scripts, or a pipeline.
+- **Never after a failure.** A command that exits non-zero skips the check.
+- **Never blocking for long.** The one refresh per day is capped at 2 seconds,
+  and any failure — offline, DNS, timeout, throttling, a malformed cache — is
+  swallowed. An update check can never change your command's exit code.
+
+### Disabling it
+
+```zsh
+export PRAETORIAN_CLI_DISABLE_UPDATE_CHECK=1
+```
+
+Set to exactly `1`. Nothing is read or written — no request, no cache file.
+
+### Privacy
+
+A refresh is an unauthenticated `GET` to `https://pypi.org/pypi/praetorian-cli/json`.
+It sends no account, profile, command, or argument — only what any HTTPS request
+inherently reveals to the server: your IP address and the fact that some
+`praetorian-cli` install asked for the package index at that moment. Because the
+request happens at most once per day per machine and never from a non-interactive
+shell, it does not expose your usage cadence. If contacting pypi.org at all is
+unacceptable in your environment, set the variable above.
 
 # Operators
 

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,5 +1,7 @@
+import errno
 import json
 import os
+import stat
 import sys
 import tempfile
 import time
@@ -72,8 +74,10 @@ def handle_error(func):
 # private where the platform enforces POSIX modes: 0700 directory, 0600 file,
 # atomic same-directory replace.
 #
-# WHERE TO CHANGE: cadence, opt-out, endpoint, and timeout are the constants
-# below; the advisory itself is `_check_for_update`.
+# WHERE TO CHANGE: cadence, opt-out, endpoint, timeout, and the size a record may
+# reach before it is refused are the constants below; the advisory itself is
+# `_check_for_update`.
+UPDATE_CHECK_CACHE_MAX_BYTES = 64 * 1024
 UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
 UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
 UPDATE_CHECK_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -164,19 +168,25 @@ def _claim_update_refresh_marker(cache_path):
     record cannot deliver that on its own -- all N read the stale cache before
     any of them writes -- so the claim is an exclusive create. `O_EXCL` is
     atomic on POSIX and Windows alike, which is why it is the mechanism here
-    instead of `fcntl`/`flock`. Losing the claim skips the REFRESH only.
+    instead of `fcntl`/`flock`. Losing the claim skips the REFRESH only. A
+    marker counts as held only while its age is inside
+    +/-`UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`, which tolerates clock skew in
+    both directions: a marker stamped in the future ages out instead of wedging
+    refreshes for good, and a filesystem clock running seconds ahead of ours does
+    not reclaim a live holder's marker.
 
     WHERE TO CHANGE: the stale window is
-    `UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`. A marker older than that is
-    unlinked and the claim re-attempted exactly once, so a process killed while
-    holding one cannot wedge refreshes for good. Any `OSError` anywhere here
-    means "did not win".
+    `UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`. A marker whose age falls outside
+    that window in either direction is unlinked and the claim re-attempted
+    exactly once, so a process killed while holding one cannot wedge refreshes
+    for good. Any `OSError` anywhere here means "did not win".
     """
     marker_path = cache_path.with_name(cache_path.name + ".refresh")
     if _create_update_refresh_marker(marker_path):
         return marker_path
     try:
-        if time.time() - os.stat(marker_path).st_mtime <= UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS:
+        if -UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS <= time.time() - os.stat(marker_path).st_mtime \
+                <= UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS:
             return None
         os.unlink(marker_path)
     except OSError:
@@ -214,9 +224,42 @@ def _read_update_check_cache(cache_path):
     """`(checked_at, latest_version_or_None)`, or None when there is no usable record.
 
     A record with a null or unparseable version is still returned: it throttles.
+
+    POLICY: the record is opened by DESCRIPTOR and validated before a byte of it
+    is read. Nothing has vetted this path yet -- on a cold cache this is the
+    first thing in the module to touch it -- and a plain `open` here trusts
+    whatever is sitting at the path: it blocks in the kernel forever on a planted
+    FIFO, raising no `OSError` for either fail-open arm to catch, and hands
+    `json.load` an unbounded read of a device or an oversized file. `O_NONBLOCK`
+    refuses the FIFO, `O_NOFOLLOW` the symlink, `S_ISREG` a device reached any
+    other way, the size cap the oversized regular file, and the uid check a
+    record planted by another user. Every refusal is raised as an `OSError`, so
+    the arm below already reads it as "no usable record".
+
+    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_CACHE_MAX_BYTES`. On Windows
+    both flags degrade to 0 and the descriptor is text-mode (`O_BINARY` unset),
+    which is symmetric with the writer's `os.fdopen(fd, "w", encoding="utf-8")`
+    and JSON-insensitive; the type, size, and ownership checks still hold there.
     """
     try:
-        with open(cache_path, encoding="utf-8") as cache_file:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        fd = os.open(cache_path, flags)
+        # `os.fdopen` owns the descriptor only once it returns; until then this is
+        # the only reference to it, so every exit but success closes it here.
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISREG(info.st_mode):
+                raise OSError(errno.EINVAL, "cache record is not a regular file")
+            if info.st_size > UPDATE_CHECK_CACHE_MAX_BYTES:
+                raise OSError(errno.EFBIG, "cache record is too large")
+            geteuid = getattr(os, "geteuid", None)
+            if geteuid is not None and info.st_uid != geteuid():
+                raise OSError(errno.EPERM, "cache record is not owned by us")
+            cache_file = os.fdopen(fd, encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with cache_file:
             cache = json.load(cache_file)
         checked_at = cache["checked_at"]
         if isinstance(checked_at, bool) or not isinstance(checked_at, (int, float)):
@@ -235,6 +278,61 @@ def _update_check_cache_is_fresh(cached, now):
     return cached is not None and 0 <= now - cached[0] < UPDATE_CHECK_CACHE_TTL_SECONDS
 
 
+def _cache_dir_descriptor_supported():
+    """True when the leaf directory can be validated and re-moded through one descriptor.
+
+    POLICY: `O_NOFOLLOW` and `os.fchmod` are POSIX-only, and an unguarded
+    POSIX-only call has taken this advisory down once already, so their absence
+    selects the path-based arm instead of raising. `O_DIRECTORY` is POSIX-only
+    too but needs no guard of its own: the explicit `S_ISDIR` check is what the
+    decision rests on, on every platform.
+    """
+    return hasattr(os, "O_NOFOLLOW") and hasattr(os, "fchmod")
+
+
+def _open_update_check_cache_dir(cache_path):
+    """An open descriptor on the leaf cache directory, locked to 0700, or None.
+
+    POLICY: validate and re-mode ONE inode -- the one this descriptor addresses.
+    A path-based `is_symlink()` check followed by a path-based `chmod` resolves
+    the leaf twice, and swapping it for a symlink in between aims the 0700 repair
+    at a directory that is none of our business; `os.fstat` and `os.fchmod` cannot
+    be redirected that way. `O_NOFOLLOW` covers the FINAL component only, which is
+    exactly the leaf-only scope this module holds to: a symlinked `~/.cache`
+    ANCESTOR is a legitimate, common dotfile setup and keeps working. A directory
+    we do not own is refused rather than repaired.
+
+    WHERE TO CHANGE: the descriptor is the caller's to close, and a caller that
+    goes on to write inside the directory addresses its files with `dir_fd=`
+    rather than resolving the path a second time. Any `OSError` means None.
+    """
+    parent = cache_path.parent
+    try:
+        try:
+            parent.mkdir(parents=True, mode=0o700)
+        except FileExistsError:
+            pass
+        fd = os.open(parent, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return None
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISDIR(info.st_mode):
+            raise OSError(errno.ENOTDIR, "cache directory is not a directory")
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is not None and info.st_uid != geteuid():
+            raise OSError(errno.EPERM, "cache directory is not owned by us")
+        # mkdir's mode is masked by umask; the fchmod is what guarantees the mode.
+        os.fchmod(fd, 0o700)
+    except OSError:
+        os.close(fd)
+        return None
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
 def _prepare_update_check_cache_dir(cache_path):
     """Create the cache directory and lock it to 0700. True only when writing there is safe.
 
@@ -248,9 +346,17 @@ def _prepare_update_check_cache_dir(cache_path):
     WHERE TO CHANGE: this runs before the refresh marker is claimed (the marker
     needs a directory to be created in) and again inside
     `_write_update_check_cache`, which validates on its own terms rather than
-    trusting its caller.
+    trusting its caller -- and which keeps the descriptor this discards. The
+    path-based arm below is the fallback for platforms that cannot close the
+    two-resolution window at all.
     """
     try:
+        if _cache_dir_descriptor_supported():
+            dir_fd = _open_update_check_cache_dir(cache_path)
+            if dir_fd is None:
+                return False
+            os.close(dir_fd)
+            return True
         parent = cache_path.parent
         if parent.is_symlink():
             return False
@@ -270,17 +376,86 @@ def _prepare_update_check_cache_dir(cache_path):
         return False
 
 
+def _write_update_check_record_at(dir_fd, name, payload):
+    """Atomically write `payload` to `name` inside the directory `dir_fd` addresses.
+
+    POLICY: every step names the validated directory by descriptor, never by
+    path, so the destination cannot be swapped between the check and the write.
+    `os.rename` and not `os.replace`: measured, `os.replace` is absent from
+    `os.supports_dir_fd` on platforms where `os.open` and `os.rename` are
+    present, and a same-directory rename overwrites atomically either way.
+    `tempfile.mkstemp` has no `dir_fd`, so the temporary is created here --
+    `O_EXCL` against a random name, 0600 from the start as `mkstemp` does it,
+    and `os.fchmod` to hold that mode under any umask.
+    """
+    temp_name = f"{name}.{os.urandom(8).hex()}.tmp"
+    fd = os.open(temp_name, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600, dir_fd=dir_fd)
+    try:
+        # `os.fdopen` takes ownership of the descriptor only once it returns, so a
+        # failure inside it leaves the descriptor with no owner at all; the
+        # `finally` below reclaims the temporary's PATH, never a DESCRIPTOR.
+        # `BaseException`, because a KeyboardInterrupt landing here leaks
+        # identically.
+        try:
+            temp_file = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with temp_file:
+            os.fchmod(temp_file.fileno(), 0o600)
+            json.dump(payload, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.rename(temp_name, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    finally:
+        try:
+            os.unlink(temp_name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            pass
+
+
+def _write_update_check_record_by_path(cache_path, payload):
+    """Atomically write `payload` to `cache_path`, resolving it by path.
+
+    The fallback for platforms with no directory descriptor. `mkstemp` creates
+    the file 0600 regardless of umask (measured at `umask 0000`), which is why no
+    `os.fchmod` follows it: `os.fchmod` is POSIX-only, and on Windows its
+    AttributeError was swallowed by the fail-open arm -- taking the whole
+    advisory down with it, every run.
+    """
+    # Same directory as the destination, so `os.replace` is an atomic rename.
+    fd, temp_name = tempfile.mkstemp(dir=cache_path.parent)
+    temp_path = Path(temp_name)
+    try:
+        # As above: `os.fdopen` owns the descriptor only once it returns, and the
+        # `finally` reclaims the path rather than the descriptor.
+        try:
+            temp_file = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with temp_file:
+            json.dump(payload, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, cache_path)
+        cache_path.chmod(0o600)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 def _write_update_check_cache(cache_path, checked_at, latest_version):
     """Record an attempt. True on success, False when this environment cannot.
 
     The contract, spelled out because this one write is load-bearing for three
     unrelated properties:
 
-    * It VALIDATES THE DESTINATION before touching it, through
-      `_prepare_update_check_cache_dir`, whatever its caller already did.
-    * It lets NOTHING ESCAPE. No descriptor and no `mkstemp` leftover survives
-      any failure path, including a failure raised between `mkstemp` and
-      `os.fdopen`.
+    * It VALIDATES THE DESTINATION before touching it, whatever its caller
+      already did -- and on the descriptor arm it writes THROUGH the descriptor
+      it validated, so the directory it vetted is the directory it writes in.
+    * It lets NOTHING ESCAPE. No descriptor and no temporary file survives any
+      failure path, including a failure raised between the temporary's creation
+      and the `os.fdopen` that takes ownership of its descriptor.
     * It is NO PART of the exclusion between concurrent refreshes. That is
       `_claim_update_refresh_marker`, and `_check_for_update` claims it BEFORE
       calling this -- so reaching this function at all already means this
@@ -290,41 +465,22 @@ def _write_update_check_cache(cache_path, checked_at, latest_version):
       control-flow signal (stay off the network), not as an error to swallow.
     """
     try:
-        parent = cache_path.parent
+        payload = {
+            "checked_at": checked_at,
+            "latest_version": None if latest_version is None else str(latest_version),
+        }
+        if _cache_dir_descriptor_supported():
+            dir_fd = _open_update_check_cache_dir(cache_path)
+            if dir_fd is None:
+                return False
+            try:
+                _write_update_check_record_at(dir_fd, cache_path.name, payload)
+            finally:
+                os.close(dir_fd)
+            return True
         if not _prepare_update_check_cache_dir(cache_path):
             return False
-        # Same directory as the destination, so `os.replace` is an atomic rename.
-        # `mkstemp` creates the file 0600 regardless of umask (measured at
-        # `umask 0000`), which is why no `os.fchmod` follows it: `os.fchmod` is
-        # POSIX-only, and on Windows its AttributeError was swallowed by the
-        # fail-open arm -- taking the whole advisory down with it, every run.
-        fd, temp_name = tempfile.mkstemp(dir=parent)
-        temp_path = Path(temp_name)
-        try:
-            # `os.fdopen` takes ownership of the descriptor only once it returns,
-            # so a failure inside it leaves the descriptor with no owner at all;
-            # the `finally` below reclaims the path, never the descriptor.
-            # `BaseException`, because a KeyboardInterrupt landing here leaks
-            # identically.
-            try:
-                temp_file = os.fdopen(fd, "w", encoding="utf-8")
-            except BaseException:
-                os.close(fd)
-                raise
-            with temp_file:
-                json.dump(
-                    {
-                        "checked_at": checked_at,
-                        "latest_version": None if latest_version is None else str(latest_version),
-                    },
-                    temp_file,
-                )
-                temp_file.flush()
-                os.fsync(temp_file.fileno())
-            os.replace(temp_path, cache_path)
-            cache_path.chmod(0o600)
-        finally:
-            temp_path.unlink(missing_ok=True)
+        _write_update_check_record_by_path(cache_path, payload)
         return True
     except CancelledError:
         raise

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -78,6 +78,7 @@ UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
 UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
 UPDATE_CHECK_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
 UPDATE_CHECK_NON_INTERACTIVE_ENV = ("CI", "GITHUB_ACTIONS")
+UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS = 60
 UPDATE_CHECK_TIMEOUT_SECONDS = 2
 UPDATE_CHECK_URL = "https://pypi.org/pypi/praetorian-cli/json"
 
@@ -124,8 +125,71 @@ def _delegating_to_subcommand():
 
 def _update_check_cache_path():
     cache_home = os.environ.get("XDG_CACHE_HOME")
+    # POLICY: a relative `XDG_CACHE_HOME` is ignored, as the XDG base-directory
+    # spec requires. Honouring one resolves the cache against the current working
+    # directory, so every invocation from a different directory sees a cold cache
+    # and re-probes. An empty value is falsy and already falls back here.
+    if cache_home and not Path(cache_home).is_absolute():
+        cache_home = None
     base = Path(cache_home) if cache_home else Path.home() / ".cache"
     return base / "praetorian-cli" / "update-check.json"
+
+
+def _path_is_owned_by_effective_user(path):
+    """True when `path` belongs to us -- and on platforms that have no uids.
+
+    POLICY: `os.geteuid` is POSIX-only, so its absence must read as "owned"
+    rather than take the advisory down; an unguarded POSIX-only call has done
+    the latter here once already.
+    """
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return True
+    return path.stat().st_uid == geteuid()
+
+
+def _create_update_refresh_marker(marker_path):
+    """True only for the call that created the marker. Never raises."""
+    try:
+        os.close(os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+        return True
+    except OSError:
+        return False
+
+
+def _claim_update_refresh_marker(cache_path):
+    """The marker path when this invocation may refresh, otherwise None.
+
+    POLICY: exactly one of N simultaneous invocations refreshes. The throttle
+    record cannot deliver that on its own -- all N read the stale cache before
+    any of them writes -- so the claim is an exclusive create. `O_EXCL` is
+    atomic on POSIX and Windows alike, which is why it is the mechanism here
+    instead of `fcntl`/`flock`. Losing the claim skips the REFRESH only.
+
+    WHERE TO CHANGE: the stale window is
+    `UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`. A marker older than that is
+    unlinked and the claim re-attempted exactly once, so a process killed while
+    holding one cannot wedge refreshes for good. Any `OSError` anywhere here
+    means "did not win".
+    """
+    marker_path = cache_path.with_name(cache_path.name + ".refresh")
+    if _create_update_refresh_marker(marker_path):
+        return marker_path
+    try:
+        if time.time() - os.stat(marker_path).st_mtime <= UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS:
+            return None
+        os.unlink(marker_path)
+    except OSError:
+        return None
+    return marker_path if _create_update_refresh_marker(marker_path) else None
+
+
+def _release_update_refresh_marker(marker_path):
+    """Best-effort unlink. Never raises: every caller is already in a `finally`."""
+    try:
+        os.unlink(marker_path)
+    except OSError:
+        pass
 
 
 def _parse_version(raw):
@@ -162,17 +226,73 @@ def _read_update_check_cache(cache_path):
         return None
 
 
-def _write_update_check_cache(cache_path, checked_at, latest_version):
-    """Record an attempt. True on success, False when this environment cannot.
+def _update_check_cache_is_fresh(cached, now):
+    """True when `cached` is a usable record still inside the TTL.
 
-    Returns rather than raises: the caller treats a failed write as a
-    control-flow signal (stay off the network), not as an error to swallow.
+    POLICY: a `checked_at` in the future is stale, not fresh, so a bad clock
+    cannot pin a stale answer forever.
+    """
+    return cached is not None and 0 <= now - cached[0] < UPDATE_CHECK_CACHE_TTL_SECONDS
+
+
+def _prepare_update_check_cache_dir(cache_path):
+    """Create the cache directory and lock it to 0700. True only when writing there is safe.
+
+    POLICY: the LEAF directory only -- the `praetorian-cli` directory this
+    creates. A symlinked `~/.cache` is a legitimate, common dotfile setup and
+    must keep working, so do NOT widen this to ancestors. Following a symlinked
+    leaf would chmod and write inside whatever directory someone else pointed it
+    at, and a path we did not create is only ours to repair when it is a
+    directory we own.
+
+    WHERE TO CHANGE: this runs before the refresh marker is claimed (the marker
+    needs a directory to be created in) and again inside
+    `_write_update_check_cache`, which validates on its own terms rather than
+    trusting its caller.
     """
     try:
         parent = cache_path.parent
-        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if parent.is_symlink():
+            return False
+        try:
+            parent.mkdir(parents=True, mode=0o700)
+            created = True
+        except FileExistsError:
+            created = False
+        if not created and not (parent.is_dir() and _path_is_owned_by_effective_user(parent)):
+            return False
         # mkdir's mode is masked by umask; the chmod is what guarantees the mode.
         parent.chmod(0o700)
+        return True
+    except CancelledError:
+        raise
+    except Exception:
+        return False
+
+
+def _write_update_check_cache(cache_path, checked_at, latest_version):
+    """Record an attempt. True on success, False when this environment cannot.
+
+    The contract, spelled out because this one write is load-bearing for three
+    unrelated properties:
+
+    * It VALIDATES THE DESTINATION before touching it, through
+      `_prepare_update_check_cache_dir`, whatever its caller already did.
+    * It lets NOTHING ESCAPE. No descriptor and no `mkstemp` leftover survives
+      any failure path, including a failure raised between `mkstemp` and
+      `os.fdopen`.
+    * It is NO PART of the exclusion between concurrent refreshes. That is
+      `_claim_update_refresh_marker`, and `_check_for_update` claims it BEFORE
+      calling this -- so reaching this function at all already means this
+      invocation is the one refreshing.
+    * `False` means "this environment cannot be throttled, so do not probe".
+      Returns rather than raises: the caller treats a failed write as a
+      control-flow signal (stay off the network), not as an error to swallow.
+    """
+    try:
+        parent = cache_path.parent
+        if not _prepare_update_check_cache_dir(cache_path):
+            return False
         # Same directory as the destination, so `os.replace` is an atomic rename.
         # `mkstemp` creates the file 0600 regardless of umask (measured at
         # `umask 0000`), which is why no `os.fchmod` follows it: `os.fchmod` is
@@ -181,7 +301,17 @@ def _write_update_check_cache(cache_path, checked_at, latest_version):
         fd, temp_name = tempfile.mkstemp(dir=parent)
         temp_path = Path(temp_name)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+            # `os.fdopen` takes ownership of the descriptor only once it returns,
+            # so a failure inside it leaves the descriptor with no owner at all;
+            # the `finally` below reclaims the path, never the descriptor.
+            # `BaseException`, because a KeyboardInterrupt landing here leaks
+            # identically.
+            try:
+                temp_file = os.fdopen(fd, "w", encoding="utf-8")
+            except BaseException:
+                os.close(fd)
+                raise
+            with temp_file:
                 json.dump(
                     {
                         "checked_at": checked_at,
@@ -226,32 +356,57 @@ def _check_for_update():
         cache_path = _update_check_cache_path()
         cached = _read_update_check_cache(cache_path)
         latest = cached[1] if cached is not None else None
-        # A `checked_at` in the future is stale, not fresh, so a bad clock cannot
-        # pin a stale answer forever.
-        is_fresh = cached is not None and 0 <= now - cached[0] < UPDATE_CHECK_CACHE_TTL_SECONDS
-        if not is_fresh:
-            # Record the attempt BEFORE making it, so EVERY way a refresh can
-            # fail is throttled by the same record -- network and HTTP errors, an
-            # unparseable payload, and the environments where the cache cannot be
-            # written at all (a read-only filesystem, a cache directory owned by
-            # another user). A file-based cache written only on success cannot
-            # throttle the case where the file cannot be written, which is how
-            # this reached pypi.org on every single invocation. A cache write we
-            # cannot perform is therefore the signal to stay off the network
-            # entirely: an environment whose probe rate we cannot limit is one we
-            # must not probe. The previous known version rides along, so a failed
-            # refresh keeps advertising what we already knew.
-            if not _write_update_check_cache(cache_path, now, latest):
+        if not _update_check_cache_is_fresh(cached, now):
+            # The marker below is created IN the cache directory, so the directory
+            # has to exist and be trustworthy first. Failing to prepare it is the
+            # same signal a failed record write is: an environment whose probe
+            # rate we cannot limit is one we must not probe.
+            if not _prepare_update_check_cache_dir(cache_path):
                 return
-            try:
-                fetched = _fetch_latest_version()
-            except CancelledError:
-                raise
-            except Exception:
-                fetched = None
-            if fetched is not None:
-                latest = fetched
-                _write_update_check_cache(cache_path, now, latest)
+            # POLICY: the throttle record orders SEQUENTIAL invocations; it does
+            # nothing for simultaneous ones, which all read the stale cache before
+            # any of them writes. The marker is what makes exactly one of them
+            # refresh, and it is claimed BEFORE that record is written -- claimed
+            # after, the only record a late arrival could find would be its own,
+            # and it would refresh again. Losing the claim skips the REFRESH only:
+            # control falls through to the comparison below, so a version already
+            # known is still advertised.
+            marker_path = _claim_update_refresh_marker(cache_path)
+            if marker_path is not None:
+                try:
+                    # A peer that refreshed while we queued for the claim wrote
+                    # its record before fetching, so it is readable here and this
+                    # invocation stands down exactly as a lost claim does. The
+                    # clock is read again rather than reused: `now` was sampled
+                    # before the claim, so a peer record written after it would
+                    # score as a future timestamp and read as stale.
+                    refreshed = _read_update_check_cache(cache_path)
+                    if _update_check_cache_is_fresh(refreshed, time.time()):
+                        latest = refreshed[1]
+                    # Record the attempt BEFORE making it, so EVERY way a refresh
+                    # can fail is throttled by the same record -- network and HTTP
+                    # errors, an unparseable payload, and the environments where
+                    # the cache cannot be written at all (a read-only filesystem,
+                    # a cache directory owned by another user). A file-based cache
+                    # written only on success cannot throttle the case where the
+                    # file cannot be written, which is how this reached pypi.org
+                    # on every single invocation. The previous known version rides
+                    # along, so a failed refresh keeps advertising what we already
+                    # knew.
+                    elif not _write_update_check_cache(cache_path, now, latest):
+                        return
+                    else:
+                        try:
+                            fetched = _fetch_latest_version()
+                        except CancelledError:
+                            raise
+                        except Exception:
+                            fetched = None
+                        if fetched is not None:
+                            latest = fetched
+                            _write_update_check_cache(cache_path, now, latest)
+                finally:
+                    _release_update_refresh_marker(marker_path)
         if latest is None:
             return
         local = Version(version('praetorian-cli'))

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -1,6 +1,12 @@
+import json
+import os
+import sys
+import tempfile
+import time
 from concurrent.futures import CancelledError
 from functools import wraps
 from importlib.metadata import version
+from pathlib import Path
 
 import click
 import requests
@@ -58,22 +64,105 @@ def handle_error(func):
     return wrapper
 
 
+# POLICY: the update advisory is best-effort. It is skipped when stderr is not a
+# TTY and when the opt-out env var is set, reaches pypi.org at most once per TTL,
+# carries no command context (no argv, profile, account, or custom headers), and
+# fails open -- no command outcome depends on it. The cache is private by
+# construction: 0700 directory, 0600 file, atomic same-directory replace.
+#
+# WHERE TO CHANGE: cadence, opt-out, endpoint, and timeout are the constants
+# below; the advisory itself is `_check_for_update`.
+UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
+UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
+UPDATE_CHECK_TIMEOUT_SECONDS = 2
+UPDATE_CHECK_URL = "https://pypi.org/pypi/praetorian-cli/json"
+
+
+def _stderr_is_interactive():
+    try:
+        return bool(sys.stderr.isatty())
+    except Exception:
+        return False
+
+
+def _update_check_disabled():
+    return os.environ.get(UPDATE_CHECK_DISABLE_ENV) == "1"
+
+
+def _update_check_cache_path():
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    base = Path(cache_home) if cache_home else Path.home() / ".cache"
+    return base / "praetorian-cli" / "update-check.json"
+
+
+def _fresh_cached_version(cache_path, now):
+    try:
+        with open(cache_path, encoding="utf-8") as cache_file:
+            cache = json.load(cache_file)
+        age = now - cache["checked_at"]
+        # A `checked_at` in the future is stale, not fresh, so a bad clock cannot
+        # pin a stale answer forever.
+        if 0 <= age < UPDATE_CHECK_CACHE_TTL_SECONDS:
+            return cache["latest_version"]
+    except (KeyError, OSError, TypeError, ValueError):
+        return None
+    return None
+
+
+def _write_update_check_cache(cache_path, checked_at, latest_version):
+    parent = cache_path.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # mkdir's mode is masked by umask; the chmod is what guarantees the mode.
+    parent.chmod(0o700)
+    # Same directory as the destination, so `os.replace` is an atomic rename.
+    # `mkstemp` already creates the file 0600; the `fchmod` reinforces that.
+    fd, temp_name = tempfile.mkstemp(dir=parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+            os.fchmod(temp_file.fileno(), 0o600)
+            json.dump({"checked_at": checked_at, "latest_version": latest_version}, temp_file)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, cache_path)
+        cache_path.chmod(0o600)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _check_for_update():
+    try:
+        if not _stderr_is_interactive():
+            return
+        if _update_check_disabled():
+            return
+        now = time.time()
+        cache_path = _update_check_cache_path()
+        latest_version = _fresh_cached_version(cache_path, now)
+        if latest_version is None:
+            response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            latest_version = str(max(Version(r) for r in response.json()['releases']))
+            _write_update_check_cache(cache_path, now, latest_version)
+        pypi = Version(latest_version)
+        local = Version(version('praetorian-cli'))
+        if pypi > local:
+            click.echo(f'A new version of praetorian-cli is available: {pypi}', err=True)
+            click.echo(f'You are currently running {local}.', err=True)
+            click.echo('To upgrade, run "pip install --upgrade praetorian-cli".', err=True)
+    except CancelledError:
+        raise
+    # `Exception`, not a bare `except`: KeyboardInterrupt and SystemExit derive
+    # from BaseException, so they keep propagating instead of being swallowed.
+    except Exception:
+        pass
+
+
 def upgrade_check(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
-        try:
-            response = requests.get('https://pypi.org/pypi/praetorian-cli/json', timeout=3)
-            pypi = sorted([Version(v) for v in list(response.json()['releases'].keys())])[-1]
-            local = Version(version('praetorian-cli'))
-            if pypi > local:
-                click.echo(f'A new version of praetorian-cli is available: {pypi}', err=True)
-                click.echo(f'You are currently running {local}.', err=True)
-                click.echo('To upgrade, run "pip install --upgrade praetorian-cli".', err=True)
-        except:
-            # Silently fail if we can't check for updates
-            # This preserves the main functionality even if update checks fail
-            pass
+        _check_for_update()
         return result
 
     return wrapper

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import click
 import requests
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from praetorian_cli.handlers.utils import error
 
@@ -64,29 +64,62 @@ def handle_error(func):
     return wrapper
 
 
-# POLICY: the update advisory is best-effort. It is skipped when stderr is not a
-# TTY and when the opt-out env var is set, reaches pypi.org at most once per TTL,
+# POLICY: the update advisory is best-effort. It is skipped when the session is
+# not interactive, when the opt-out env var is set, and when a group callback is
+# merely delegating to a subcommand; it reaches pypi.org at most once per TTL,
 # carries no command context (no argv, profile, account, or custom headers), and
-# fails open -- no command outcome depends on it. The cache is private by
-# construction: 0700 directory, 0600 file, atomic same-directory replace.
+# fails open -- no ordinary failure of it changes a command outcome. The cache is
+# private where the platform enforces POSIX modes: 0700 directory, 0600 file,
+# atomic same-directory replace.
 #
 # WHERE TO CHANGE: cadence, opt-out, endpoint, and timeout are the constants
 # below; the advisory itself is `_check_for_update`.
 UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
 UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
+UPDATE_CHECK_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
+UPDATE_CHECK_NON_INTERACTIVE_ENV = ("CI", "GITHUB_ACTIONS")
 UPDATE_CHECK_TIMEOUT_SECONDS = 2
 UPDATE_CHECK_URL = "https://pypi.org/pypi/praetorian-cli/json"
 
 
-def _stderr_is_interactive():
+def _session_is_interactive():
+    """True only when a human is plausibly watching this invocation.
+
+    BOTH streams must be a terminal. An stderr-only gate does not hold: in
+    `guard list assets | jq` only stdout is redirected, so stderr stays a tty
+    and the advisory still fires -- the piped, scripted, high-volume case whose
+    cadence this is supposed to stop leaking. `CI`/`GITHUB_ACTIONS`/`TERM=dumb`
+    cover the runners that allocate a pty anyway.
+    """
     try:
-        return bool(sys.stderr.isatty())
+        if not (sys.stdout.isatty() and sys.stderr.isatty()):
+            return False
     except Exception:
         return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return not any(os.environ.get(name) for name in UPDATE_CHECK_NON_INTERACTIVE_ENV)
 
 
 def _update_check_disabled():
-    return os.environ.get(UPDATE_CHECK_DISABLE_ENV) == "1"
+    """Accept any conventional truthy value, not only `1`.
+
+    This is a privacy opt-out: a user who exports `=true` and still gets network
+    requests has been silently overruled by a parsing detail.
+    """
+    return os.environ.get(UPDATE_CHECK_DISABLE_ENV, "").strip().lower() in UPDATE_CHECK_DISABLE_VALUES
+
+
+def _delegating_to_subcommand():
+    """True when this callback is a group about to invoke a subcommand.
+
+    Click runs a group callback BEFORE its subcommand (measured), so an advisory
+    printed here precedes the work the user asked for, and still prints when that
+    subcommand goes on to fail. The leaf command runs its own check, so skipping
+    here loses nothing -- and it needs no hand-maintained command list.
+    """
+    ctx = click.get_current_context(silent=True)
+    return ctx is not None and ctx.invoked_subcommand is not None
 
 
 def _update_check_cache_path():
@@ -95,59 +128,135 @@ def _update_check_cache_path():
     return base / "praetorian-cli" / "update-check.json"
 
 
-def _fresh_cached_version(cache_path, now):
+def _parse_version(raw):
+    """A `Version`, or None when the value is absent or unparseable.
+
+    Returning None rather than raising is what keeps a malformed PyPI payload
+    from killing the advisory through the fail-open arm (measured: an
+    unparseable release key took the advisory from 0 to 1). It does not shorten
+    a blackout: a fresh entry short-circuits the refresh whether or not its
+    version parsed, and such an entry stays silent until its TTL expires -- at
+    which point it does recover.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
+
+
+def _read_update_check_cache(cache_path):
+    """`(checked_at, latest_version_or_None)`, or None when there is no usable record.
+
+    A record with a null or unparseable version is still returned: it throttles.
+    """
     try:
         with open(cache_path, encoding="utf-8") as cache_file:
             cache = json.load(cache_file)
-        age = now - cache["checked_at"]
-        # A `checked_at` in the future is stale, not fresh, so a bad clock cannot
-        # pin a stale answer forever.
-        if 0 <= age < UPDATE_CHECK_CACHE_TTL_SECONDS:
-            return cache["latest_version"]
+        checked_at = cache["checked_at"]
+        if isinstance(checked_at, bool) or not isinstance(checked_at, (int, float)):
+            return None
+        return checked_at, _parse_version(cache.get("latest_version"))
     except (KeyError, OSError, TypeError, ValueError):
         return None
-    return None
 
 
 def _write_update_check_cache(cache_path, checked_at, latest_version):
-    parent = cache_path.parent
-    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    # mkdir's mode is masked by umask; the chmod is what guarantees the mode.
-    parent.chmod(0o700)
-    # Same directory as the destination, so `os.replace` is an atomic rename.
-    # `mkstemp` already creates the file 0600; the `fchmod` reinforces that.
-    fd, temp_name = tempfile.mkstemp(dir=parent)
-    temp_path = Path(temp_name)
+    """Record an attempt. True on success, False when this environment cannot.
+
+    Returns rather than raises: the caller treats a failed write as a
+    control-flow signal (stay off the network), not as an error to swallow.
+    """
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
-            os.fchmod(temp_file.fileno(), 0o600)
-            json.dump({"checked_at": checked_at, "latest_version": latest_version}, temp_file)
-            temp_file.flush()
-            os.fsync(temp_file.fileno())
-        os.replace(temp_path, cache_path)
-        cache_path.chmod(0o600)
-    finally:
-        temp_path.unlink(missing_ok=True)
+        parent = cache_path.parent
+        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # mkdir's mode is masked by umask; the chmod is what guarantees the mode.
+        parent.chmod(0o700)
+        # Same directory as the destination, so `os.replace` is an atomic rename.
+        # `mkstemp` creates the file 0600 regardless of umask (measured at
+        # `umask 0000`), which is why no `os.fchmod` follows it: `os.fchmod` is
+        # POSIX-only, and on Windows its AttributeError was swallowed by the
+        # fail-open arm -- taking the whole advisory down with it, every run.
+        fd, temp_name = tempfile.mkstemp(dir=parent)
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+                json.dump(
+                    {
+                        "checked_at": checked_at,
+                        "latest_version": None if latest_version is None else str(latest_version),
+                    },
+                    temp_file,
+                )
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, cache_path)
+            cache_path.chmod(0o600)
+        finally:
+            temp_path.unlink(missing_ok=True)
+        return True
+    except CancelledError:
+        raise
+    except Exception:
+        return False
+
+
+def _fetch_latest_version():
+    """PyPI's own latest STABLE release, or None when the payload is unusable.
+
+    `info.version` rather than `max(Version(r) for r in releases)`: the max over
+    release keys ranks prereleases above stable ones (2.0.0rc1 over 1.0.0), and a
+    single unparseable key raises `InvalidVersion` into the fail-open arm.
+    """
+    response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return _parse_version(response.json()["info"]["version"])
 
 
 def _check_for_update():
     try:
-        if not _stderr_is_interactive():
-            return
         if _update_check_disabled():
+            return
+        if not _session_is_interactive():
+            return
+        if _delegating_to_subcommand():
             return
         now = time.time()
         cache_path = _update_check_cache_path()
-        latest_version = _fresh_cached_version(cache_path, now)
-        if latest_version is None:
-            response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS)
-            response.raise_for_status()
-            latest_version = str(max(Version(r) for r in response.json()['releases']))
-            _write_update_check_cache(cache_path, now, latest_version)
-        pypi = Version(latest_version)
+        cached = _read_update_check_cache(cache_path)
+        latest = cached[1] if cached is not None else None
+        # A `checked_at` in the future is stale, not fresh, so a bad clock cannot
+        # pin a stale answer forever.
+        is_fresh = cached is not None and 0 <= now - cached[0] < UPDATE_CHECK_CACHE_TTL_SECONDS
+        if not is_fresh:
+            # Record the attempt BEFORE making it, so EVERY way a refresh can
+            # fail is throttled by the same record -- network and HTTP errors, an
+            # unparseable payload, and the environments where the cache cannot be
+            # written at all (a read-only filesystem, a cache directory owned by
+            # another user). A file-based cache written only on success cannot
+            # throttle the case where the file cannot be written, which is how
+            # this reached pypi.org on every single invocation. A cache write we
+            # cannot perform is therefore the signal to stay off the network
+            # entirely: an environment whose probe rate we cannot limit is one we
+            # must not probe. The previous known version rides along, so a failed
+            # refresh keeps advertising what we already knew.
+            if not _write_update_check_cache(cache_path, now, latest):
+                return
+            try:
+                fetched = _fetch_latest_version()
+            except CancelledError:
+                raise
+            except Exception:
+                fetched = None
+            if fetched is not None:
+                latest = fetched
+                _write_update_check_cache(cache_path, now, latest)
+        if latest is None:
+            return
         local = Version(version('praetorian-cli'))
-        if pypi > local:
-            click.echo(f'A new version of praetorian-cli is available: {pypi}', err=True)
+        if latest > local:
+            click.echo(f'A new version of praetorian-cli is available: {latest}', err=True)
             click.echo(f'You are currently running {local}.', err=True)
             click.echo('To upgrade, run "pip install --upgrade praetorian-cli".', err=True)
     except CancelledError:
@@ -166,7 +275,6 @@ def upgrade_check(func):
         return result
 
     return wrapper
-
 
 def cli_handler(func):
     func = click.pass_obj(func)

--- a/praetorian_cli/handlers/cli_decorators.py
+++ b/praetorian_cli/handlers/cli_decorators.py
@@ -4,6 +4,7 @@ import os
 import stat
 import sys
 import tempfile
+import threading
 import time
 from concurrent.futures import CancelledError
 from functools import wraps
@@ -68,21 +69,34 @@ def handle_error(func):
 
 # POLICY: the update advisory is best-effort. It is skipped when the session is
 # not interactive, when the opt-out env var is set, and when a group callback is
-# merely delegating to a subcommand; it reaches pypi.org at most once per TTL,
-# carries no command context (no argv, profile, account, or custom headers), and
-# fails open -- no ordinary failure of it changes a command outcome. The cache is
-# private where the platform enforces POSIX modes: 0700 directory, 0600 file,
-# atomic same-directory replace.
+# merely delegating to a subcommand; it carries no command context (no argv,
+# profile, account, or custom headers), bounds its network refresh to
+# `UPDATE_CHECK_DEADLINE_SECONDS` of wall clock, and fails open -- no ordinary
+# failure of it changes a command outcome. The cache is private where the
+# platform enforces POSIX modes: 0700 directory, 0600 file, atomic
+# same-directory replace.
 #
-# WHERE TO CHANGE: cadence, opt-out, endpoint, timeout, and the size a record may
-# reach before it is refused are the constants below; the advisory itself is
+# POLICY: the throttle record orders SEQUENTIAL invocations only. N truly
+# simultaneous ones all read the stale record before any of them writes, so each
+# may probe once -- an accepted tradeoff: all of them then write the record, so
+# the next TTL is quiet, and the gates above already exclude non-interactive and
+# CI sessions, which leaves simultaneous interactive invocations rare. Do NOT
+# reintroduce a claim held BY PATH to close it: a claim that cannot identify its
+# own holder unlinks a live peer's claim and defeats the rate limit it was built
+# to guarantee (measured), and a duplicate refresh costs one CDN-backed GET
+# against an already-atomic record write.
+#
+# WHERE TO CHANGE: cadence, opt-out, endpoint, per-socket timeout, total
+# wall-clock deadline, and the sizes a record and a response body may reach
+# before they are refused are the constants below; the advisory itself is
 # `_check_for_update`.
 UPDATE_CHECK_CACHE_MAX_BYTES = 64 * 1024
 UPDATE_CHECK_CACHE_TTL_SECONDS = 24 * 60 * 60
+UPDATE_CHECK_DEADLINE_SECONDS = 3
 UPDATE_CHECK_DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
 UPDATE_CHECK_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
 UPDATE_CHECK_NON_INTERACTIVE_ENV = ("CI", "GITHUB_ACTIONS")
-UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS = 60
+UPDATE_CHECK_RESPONSE_MAX_BYTES = 1024 * 1024
 UPDATE_CHECK_TIMEOUT_SECONDS = 2
 UPDATE_CHECK_URL = "https://pypi.org/pypi/praetorian-cli/json"
 
@@ -152,56 +166,6 @@ def _path_is_owned_by_effective_user(path):
     return path.stat().st_uid == geteuid()
 
 
-def _create_update_refresh_marker(marker_path):
-    """True only for the call that created the marker. Never raises."""
-    try:
-        os.close(os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
-        return True
-    except OSError:
-        return False
-
-
-def _claim_update_refresh_marker(cache_path):
-    """The marker path when this invocation may refresh, otherwise None.
-
-    POLICY: exactly one of N simultaneous invocations refreshes. The throttle
-    record cannot deliver that on its own -- all N read the stale cache before
-    any of them writes -- so the claim is an exclusive create. `O_EXCL` is
-    atomic on POSIX and Windows alike, which is why it is the mechanism here
-    instead of `fcntl`/`flock`. Losing the claim skips the REFRESH only. A
-    marker counts as held only while its age is inside
-    +/-`UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`, which tolerates clock skew in
-    both directions: a marker stamped in the future ages out instead of wedging
-    refreshes for good, and a filesystem clock running seconds ahead of ours does
-    not reclaim a live holder's marker.
-
-    WHERE TO CHANGE: the stale window is
-    `UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS`. A marker whose age falls outside
-    that window in either direction is unlinked and the claim re-attempted
-    exactly once, so a process killed while holding one cannot wedge refreshes
-    for good. Any `OSError` anywhere here means "did not win".
-    """
-    marker_path = cache_path.with_name(cache_path.name + ".refresh")
-    if _create_update_refresh_marker(marker_path):
-        return marker_path
-    try:
-        if -UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS <= time.time() - os.stat(marker_path).st_mtime \
-                <= UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS:
-            return None
-        os.unlink(marker_path)
-    except OSError:
-        return None
-    return marker_path if _create_update_refresh_marker(marker_path) else None
-
-
-def _release_update_refresh_marker(marker_path):
-    """Best-effort unlink. Never raises: every caller is already in a `finally`."""
-    try:
-        os.unlink(marker_path)
-    except OSError:
-        pass
-
-
 def _parse_version(raw):
     """A `Version`, or None when the value is absent or unparseable.
 
@@ -236,10 +200,20 @@ def _read_update_check_cache(cache_path):
     record planted by another user. Every refusal is raised as an `OSError`, so
     the arm below already reads it as "no usable record".
 
-    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_CACHE_MAX_BYTES`. On Windows
-    both flags degrade to 0 and the descriptor is text-mode (`O_BINARY` unset),
-    which is symmetric with the writer's `os.fdopen(fd, "w", encoding="utf-8")`
-    and JSON-insensitive; the type, size, and ownership checks still hold there.
+    POLICY: the `fstat` size check is the cheap first line of defence, not the
+    enforcement -- it describes the file as of the stat, and the read that
+    follows is a separate syscall on the same descriptor. So the read is bounded
+    too: at most `UPDATE_CHECK_CACHE_MAX_BYTES + 1` bytes, and one byte over the
+    ceiling is refused as `EFBIG` for the arm below (measured: an unbounded
+    `json.load` on a descriptor whose file grew after the stat yielded 8 MiB
+    against a 64 KiB cap).
+
+    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_CACHE_MAX_BYTES`, and it counts
+    BYTES -- the descriptor is read in binary and `json.loads` decodes UTF-8
+    itself, so a multi-byte record cannot spend more than the ceiling. On Windows
+    both `os.open` flags degrade to 0 and `O_BINARY` stays unset, which is
+    JSON-insensitive (the writer emits no newlines); the type, size, and
+    ownership checks still hold there.
     """
     try:
         flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
@@ -255,12 +229,15 @@ def _read_update_check_cache(cache_path):
             geteuid = getattr(os, "geteuid", None)
             if geteuid is not None and info.st_uid != geteuid():
                 raise OSError(errno.EPERM, "cache record is not owned by us")
-            cache_file = os.fdopen(fd, encoding="utf-8")
+            cache_file = os.fdopen(fd, "rb")
         except BaseException:
             os.close(fd)
             raise
         with cache_file:
-            cache = json.load(cache_file)
+            record = cache_file.read(UPDATE_CHECK_CACHE_MAX_BYTES + 1)
+        if len(record) > UPDATE_CHECK_CACHE_MAX_BYTES:
+            raise OSError(errno.EFBIG, "cache record is too large")
+        cache = json.loads(record)
         checked_at = cache["checked_at"]
         if isinstance(checked_at, bool) or not isinstance(checked_at, (int, float)):
             return None
@@ -343,7 +320,7 @@ def _prepare_update_check_cache_dir(cache_path):
     at, and a path we did not create is only ours to repair when it is a
     directory we own.
 
-    WHERE TO CHANGE: this runs before the refresh marker is claimed (the marker
+    WHERE TO CHANGE: this runs before the throttle record is written (the record
     needs a directory to be created in) and again inside
     `_write_update_check_cache`, which validates on its own terms rather than
     trusting its caller -- and which keeps the descriptor this discards. The
@@ -456,10 +433,11 @@ def _write_update_check_cache(cache_path, checked_at, latest_version):
     * It lets NOTHING ESCAPE. No descriptor and no temporary file survives any
       failure path, including a failure raised between the temporary's creation
       and the `os.fdopen` that takes ownership of its descriptor.
-    * It is NO PART of the exclusion between concurrent refreshes. That is
-      `_claim_update_refresh_marker`, and `_check_for_update` claims it BEFORE
-      calling this -- so reaching this function at all already means this
-      invocation is the one refreshing.
+    * It is NO PART of any exclusion between concurrent refreshes -- there is
+      none, by policy (see the module POLICY block). Simultaneous invocations
+      each reach this function and each write; the write is an atomic
+      same-directory rename, so the record a reader sees is always one writer's
+      whole record.
     * `False` means "this environment cannot be throttled, so do not probe".
       Returns rather than raises: the caller treats a failed write as a
       control-flow signal (stay off the network), not as an error to swallow.
@@ -494,10 +472,73 @@ def _fetch_latest_version():
     `info.version` rather than `max(Version(r) for r in releases)`: the max over
     release keys ranks prereleases above stable ones (2.0.0rc1 over 1.0.0), and a
     single unparseable key raises `InvalidVersion` into the fail-open arm.
+
+    POLICY: the GET asks for no compression and the body is bounded by the RAW
+    bytes read off the socket, so raw and decoded are the same bytes. The cap has
+    to hold on EVERY urllib3 the `requests` pin permits, and only the raw read is
+    bounded on all of them: `decode_content=True` bounds DECODED bytes on urllib3
+    >= 2, but on 1.26.x it reads that many ENCODED bytes and then decompresses
+    without any bound -- a wire-bytes cap, which a gzip bomb walks straight
+    through (measured, 55 KiB of wire peaking 131x past this 1 MiB ceiling). A
+    server that ignores the header and compresses anyway is still capped at the
+    raw read, and `json.loads` then raises on the compressed bytes into the
+    fail-open arm -- no advisory, which is the intended outcome, so a
+    `Content-Encoding` check would add a branch and change no behaviour.
+    `Content-Length` cannot stand in for the cap either: measured, this endpoint
+    answers `Content-Length: 28568` for a body of 117712 bytes when it gzips, and
+    a header describes what a server claims it will send, not what arrives.
+
+    WHERE TO CHANGE: the ceiling is `UPDATE_CHECK_RESPONSE_MAX_BYTES`, it counts
+    RAW bytes, and the oversize arm must return BEFORE parsing. The real payload
+    is 115 KiB across 64 releases (~1.8 KiB per release), so the 1 MiB ceiling
+    keeps ~8.9x of headroom that grows with the release count. `json.loads` takes
+    the undecoded `bytes` and detects UTF-8 itself, so no decoding step belongs
+    here. The response is closed on every path: `stream=True` holds the
+    connection open until it is.
     """
-    response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS)
-    response.raise_for_status()
-    return _parse_version(response.json()["info"]["version"])
+    response = requests.get(UPDATE_CHECK_URL, timeout=UPDATE_CHECK_TIMEOUT_SECONDS, stream=True,
+                            headers={"Accept-Encoding": "identity"})
+    with response:
+        response.raise_for_status()
+        body = response.raw.read(UPDATE_CHECK_RESPONSE_MAX_BYTES + 1, decode_content=False)
+    if len(body) > UPDATE_CHECK_RESPONSE_MAX_BYTES:
+        return None
+    return _parse_version(json.loads(body)["info"]["version"])
+
+
+def _fetch_latest_version_within_deadline():
+    """`_fetch_latest_version`'s answer, or None when it does not land in time.
+
+    POLICY: the refresh gets a hard WALL-CLOCK bound. `requests`' `timeout`
+    bounds each individual socket operation and never the total -- measured, a
+    `timeout=2` GET against a server dribbling one header byte every 1.5s
+    returned after 64.7 seconds, and the real CLI sat alive 10.1s past its own
+    last line of output. So the fetch runs on a thread and a thread still alive
+    after the join is ABANDONED, its result discarded. `daemon=True` is
+    load-bearing: the interpreter must not wait for an abandoned fetch at exit.
+    For the same reason this is a bare thread and NOT a
+    `concurrent.futures.ThreadPoolExecutor`, whose `atexit` handler joins its
+    workers and would reinstate exactly the wait this removes.
+
+    WHERE TO CHANGE: the bound is `UPDATE_CHECK_DEADLINE_SECONDS`; the per-socket
+    `UPDATE_CHECK_TIMEOUT_SECONDS` still applies inside the thread and still
+    helps the common case -- this is the outer guarantee, not its replacement.
+    """
+    fetched = [None]
+
+    def fetch():
+        # Nothing may escape a thread nobody is waiting for any more: an
+        # exception here would reach the interpreter's excepthook and print over
+        # the command's own output.
+        try:
+            fetched[0] = _fetch_latest_version()
+        except BaseException:
+            pass
+
+    thread = threading.Thread(target=fetch, daemon=True)
+    thread.start()
+    thread.join(UPDATE_CHECK_DEADLINE_SECONDS)
+    return None if thread.is_alive() else fetched[0]
 
 
 def _check_for_update():
@@ -513,56 +554,33 @@ def _check_for_update():
         cached = _read_update_check_cache(cache_path)
         latest = cached[1] if cached is not None else None
         if not _update_check_cache_is_fresh(cached, now):
-            # The marker below is created IN the cache directory, so the directory
+            # The record below is written IN the cache directory, so the directory
             # has to exist and be trustworthy first. Failing to prepare it is the
             # same signal a failed record write is: an environment whose probe
             # rate we cannot limit is one we must not probe.
             if not _prepare_update_check_cache_dir(cache_path):
                 return
-            # POLICY: the throttle record orders SEQUENTIAL invocations; it does
-            # nothing for simultaneous ones, which all read the stale cache before
-            # any of them writes. The marker is what makes exactly one of them
-            # refresh, and it is claimed BEFORE that record is written -- claimed
-            # after, the only record a late arrival could find would be its own,
-            # and it would refresh again. Losing the claim skips the REFRESH only:
-            # control falls through to the comparison below, so a version already
-            # known is still advertised.
-            marker_path = _claim_update_refresh_marker(cache_path)
-            if marker_path is not None:
-                try:
-                    # A peer that refreshed while we queued for the claim wrote
-                    # its record before fetching, so it is readable here and this
-                    # invocation stands down exactly as a lost claim does. The
-                    # clock is read again rather than reused: `now` was sampled
-                    # before the claim, so a peer record written after it would
-                    # score as a future timestamp and read as stale.
-                    refreshed = _read_update_check_cache(cache_path)
-                    if _update_check_cache_is_fresh(refreshed, time.time()):
-                        latest = refreshed[1]
-                    # Record the attempt BEFORE making it, so EVERY way a refresh
-                    # can fail is throttled by the same record -- network and HTTP
-                    # errors, an unparseable payload, and the environments where
-                    # the cache cannot be written at all (a read-only filesystem,
-                    # a cache directory owned by another user). A file-based cache
-                    # written only on success cannot throttle the case where the
-                    # file cannot be written, which is how this reached pypi.org
-                    # on every single invocation. The previous known version rides
-                    # along, so a failed refresh keeps advertising what we already
-                    # knew.
-                    elif not _write_update_check_cache(cache_path, now, latest):
-                        return
-                    else:
-                        try:
-                            fetched = _fetch_latest_version()
-                        except CancelledError:
-                            raise
-                        except Exception:
-                            fetched = None
-                        if fetched is not None:
-                            latest = fetched
-                            _write_update_check_cache(cache_path, now, latest)
-                finally:
-                    _release_update_refresh_marker(marker_path)
+            # Record the attempt BEFORE making it, so EVERY way a refresh can
+            # fail is throttled by the same record -- network and HTTP errors, an
+            # unparseable payload, a body over the size ceiling, a fetch
+            # abandoned at the deadline, and the environments where the cache
+            # cannot be written at all (a read-only filesystem, a cache directory
+            # owned by another user). A file-based cache written only on success
+            # cannot throttle the case where the file cannot be written, which is
+            # how this reached pypi.org on every single invocation. The previous
+            # known version rides along, so a failed refresh keeps advertising
+            # what we already knew.
+            if not _write_update_check_cache(cache_path, now, latest):
+                return
+            try:
+                fetched = _fetch_latest_version_within_deadline()
+            except CancelledError:
+                raise
+            except Exception:
+                fetched = None
+            if fetched is not None:
+                latest = fetched
+                _write_update_check_cache(cache_path, now, latest)
         if latest is None:
             return
         local = Version(version('praetorian-cli'))
@@ -579,10 +597,25 @@ def _check_for_update():
 
 
 def upgrade_check(func):
+    # POLICY: the advisory is an epilogue to work whose output has ALREADY been
+    # produced, and this decorator composes OUTERMOST -- outside `handle_error`
+    # -- so anything escaping here becomes the command's exit status. A Ctrl-C
+    # during the advisory therefore must not turn a completed command into
+    # `Aborted!` and exit 1: a non-zero exit for work that already succeeded
+    # invites an unsafe retry of a mutating command (measured: 968 rows
+    # delivered, then exit 1).
+    #
+    # WHERE TO CHANGE: `CancelledError` is deliberately NOT caught here, and the
+    # asymmetry with `KeyboardInterrupt` is not an oversight -- a cancelled async
+    # task must still observe its cancellation, so it keeps propagating exactly
+    # as `_check_for_update`'s own `except CancelledError: raise` arm sends it.
     @wraps(func)
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
-        _check_for_update()
+        try:
+            _check_for_update()
+        except KeyboardInterrupt:
+            pass
         return result
 
     return wrapper

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -24,8 +24,11 @@ the process exited 0 on every failure. These tests pin the replacement contract:
 Message *redaction* is deliberately out of scope here: it needs the SDK exception
 hierarchy (ENG-6570) to classify what is safe to show, and is owned by ENG-6781.
 
-Offline only: every command raises before `upgrade_check` can reach the network,
-and each test arms `requests.get` to fail loudly if that ever stops being true.
+Offline only. Most tests here raise before `upgrade_check` can reach the network
+and arm `requests.get` to fail loudly if that ever stops being true; the final
+group deliberately lets the advisory run, with `requests.get` replaced and
+`XDG_CACHE_HOME` redirected at `tmp_path`, to pin that its failures cannot change
+a command's outcome.
 """
 
 import asyncio
@@ -109,6 +112,38 @@ def _debug_root(command):
     return root
 
 
+def _successful_command():
+    """A `@cli_handler` command that succeeds, so `upgrade_check` actually runs."""
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        return "done"
+
+    return command
+
+
+def _force_update_request(monkeypatch, tmp_path, side_effect):
+    """The inverse of `_disable_update_request`: let the advisory reach the network.
+
+    Two forces are needed and both are load-bearing. `CliRunner` replaces stderr
+    with a non-tty buffer, so `_stderr_is_interactive()` returns False inside any
+    `invoke` and the advisory returns at its very first gate -- a test that did
+    not patch it would assert against a check that never ran. `XDG_CACHE_HOME` is
+    redirected at `tmp_path` so nothing reads or writes the real user cache, and
+    an empty cache is what guarantees the network branch is the one taken.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.delenv("PRAETORIAN_CLI_DISABLE_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(decorators, "_stderr_is_interactive", lambda: True)
+    request = Mock(side_effect=side_effect)
+    monkeypatch.setattr(decorators.requests, "get", request)
+    return request
+
+
 def _disable_update_request(monkeypatch):
     import praetorian_cli.handlers.cli_decorators as decorators
 
@@ -117,9 +152,10 @@ def _disable_update_request(monkeypatch):
     return request
 
 
-# `upgrade_check`'s bare `except:` swallows anything raisable, so an in-process
-# guard cannot make a stray network call visible in a child process. `os._exit`
-# cannot be caught: if the advisory ever runs, the child's status is 97 and the
+# `_check_for_update`'s `except Exception: pass` arm swallows every ordinary
+# exception -- an in-process `AssertionError` included -- so an in-process guard
+# cannot make a stray network call visible in a child process. `os._exit` cannot
+# be caught: if the advisory ever runs, the child's status is 97 and the
 # return-code assertion fails instead of the request silently going out.
 _NETWORK_TRIPWIRE = """
 import os
@@ -596,3 +632,65 @@ def test_handled_user_facing_error_is_unchanged(monkeypatch):
     assert "ERROR: profile 'staging' is not configured" in result.stderr
     assert "Error:" not in result.output
     request.assert_not_called()
+
+
+# --- the update advisory on a SUCCESSFUL command --------------------------------
+#
+# The cases above all raise, so `upgrade_check` never reaches `_check_for_update`.
+# These pin the other half: when the command succeeds the advisory does run, and
+# its own failures must not be able to change the outcome the user already earned
+# -- except for the process-control exceptions, which are the deliberate
+# exceptions to that rule and must keep propagating.
+
+
+def test_ordinary_update_advisory_failure_remains_fail_open(monkeypatch, tmp_path):
+    """An ordinary advisory failure is swallowed; the command still succeeds."""
+    request = _force_update_request(monkeypatch, tmp_path, RuntimeError("advisory unavailable"))
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "advisory unavailable" not in result.output
+    request.assert_called_once()
+
+
+def test_update_keyboard_interrupt_keeps_click_abort_semantics(monkeypatch, tmp_path):
+    """Ctrl-C during the advisory still aborts, rather than being swallowed.
+
+    `KeyboardInterrupt` derives from `BaseException`, so `except Exception: pass`
+    leaves it alone and Click's standalone mode renders it as `Aborted!`. A bare
+    `except:` in `_check_for_update` would swallow it and report success.
+    """
+    request = _force_update_request(monkeypatch, tmp_path, KeyboardInterrupt())
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 1
+    assert "Aborted!" in result.output
+    assert "Error:" not in result.output
+    request.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("exception", "exit_code"),
+    [(SystemExit(73), 73), (FutureCancelledError("cancelled"), 1)],
+    ids=["system-exit", "future-cancelled"],
+)
+def test_update_process_control_exceptions_propagate(monkeypatch, tmp_path, exception, exit_code):
+    """Process-control exceptions raised by the advisory are not swallowed.
+
+    `SystemExit` is a `BaseException` and so passes through `except Exception`
+    untouched, keeping its own status. `concurrent.futures.CancelledError` is
+    `Exception`-derived on this runtime, so it would be swallowed on the fail-open
+    path -- the dedicated `except CancelledError: raise` arm is what makes it
+    propagate instead.
+    """
+    assert issubclass(FutureCancelledError, Exception)
+    request = _force_update_request(monkeypatch, tmp_path, exception)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == exit_code
+    assert result.exception is exception
+    request.assert_called_once()

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -34,6 +34,7 @@ a command's outcome.
 import asyncio
 import subprocess
 import sys
+import threading
 from concurrent.futures import CancelledError as FutureCancelledError
 from unittest.mock import Mock
 
@@ -46,6 +47,10 @@ from click.testing import CliRunner
 # from the suite's silently -- and would turn a deliberate re-wording into a
 # spurious test failure here.
 from praetorian_cli.handlers.cli_decorators import DEBUG_HINT
+
+# Imported for the same reason: the deadline test asserts the join was handed the
+# module's own budget, so a re-tuned budget must not need a matching edit here.
+from praetorian_cli.handlers.cli_decorators import UPDATE_CHECK_DEADLINE_SECONDS
 
 # The exact shape `Chariot.process_failure` raises on a failed API call
 # (praetorian_cli/sdk/chariot.py). Both halves -- the status line and the response
@@ -644,9 +649,13 @@ def test_handled_user_facing_error_is_unchanged(monkeypatch):
 #
 # The cases above all raise, so `upgrade_check` never reaches `_check_for_update`.
 # These pin the other half: when the command succeeds the advisory does run, and
-# its own failures must not be able to change the outcome the user already earned
-# -- except for the process-control exceptions, which are the deliberate
-# exceptions to that rule and must keep propagating.
+# its own failures must not be able to change the outcome the user already earned.
+#
+# That holds for a Ctrl-C too, which is the correction ENG-6643 makes: the
+# advisory is a trailing informational courtesy, so an interrupt arriving during
+# it cannot retroactively fail work the user has already been handed. Process
+# control that the *process itself* initiated -- `sys.exit()`, a cancelled task --
+# is the deliberate exception and still reaches the exit status.
 
 
 def test_ordinary_update_advisory_failure_remains_fail_open(monkeypatch, tmp_path):
@@ -661,21 +670,101 @@ def test_ordinary_update_advisory_failure_remains_fail_open(monkeypatch, tmp_pat
     request.assert_called_once()
 
 
-def test_update_keyboard_interrupt_keeps_click_abort_semantics(monkeypatch, tmp_path):
-    """Ctrl-C during the advisory still aborts, rather than being swallowed.
+def _interrupt_the_deadline_wait(monkeypatch, exception):
+    """Raise `exception` in the main thread, where a real Ctrl-C would surface.
 
-    `KeyboardInterrupt` derives from `BaseException`, so `except Exception: pass`
-    leaves it alone and Click's standalone mode renders it as `Aborted!`. A bare
-    `except:` in `_check_for_update` would swallow it and report success.
+    The advisory's fetch runs on a worker thread and the main thread waits it out
+    in `Thread.join(UPDATE_CHECK_DEADLINE_SECONDS)`, so that join -- not
+    `requests.get` -- is where an interrupt during the advisory actually lands:
+    CPython delivers SIGINT to the main thread only, and a worker parked in a
+    socket read never receives it. Injecting at `requests.get` instead would put
+    the exception inside the worker, whose `except BaseException: pass` discards
+    it, and the test would pass for the wrong reason.
+
+    The real `join` runs FIRST, before the exception is raised, so the worker has
+    already finished and its `requests.get` call is recorded by the time control
+    returns -- otherwise the call assertion would race the worker.
+
+    `threading` is referenced exactly once in the module under test (that join),
+    so shimming the module attribute reaches that one call and nothing else.
+    Returns the list of timeouts the shim observed, so a test can prove the seam
+    fired rather than passing because it was never reached.
     """
-    request = _force_update_request(monkeypatch, tmp_path, KeyboardInterrupt())
+    import praetorian_cli.handlers.cli_decorators as decorators
 
-    result = CliRunner().invoke(_successful_command(), obj=object())
+    joined_with = []
 
-    assert result.exit_code == 1
-    assert "Aborted!" in result.output
+    class _InterruptedJoin(threading.Thread):
+        def join(self, timeout=None):
+            super().join(timeout)
+            joined_with.append(timeout)
+            raise exception
+
+    class _ThreadingShim:
+        Thread = _InterruptedJoin
+
+    monkeypatch.setattr(decorators, "threading", _ThreadingShim)
+    return joined_with
+
+
+def test_update_keyboard_interrupt_leaves_the_finished_command_successful(monkeypatch, tmp_path):
+    """A Ctrl-C during the trailing advisory must not fail a command that already succeeded.
+
+    This is the corrected contract (ENG-6643, finding R4-3). The command's own
+    work is complete and its output already delivered before `upgrade_check`
+    calls the advisory; letting a `KeyboardInterrupt` from that trailing courtesy
+    become `Aborted!` and exit 1 tells the user their command failed when it did
+    not -- and invites whoever wrote `guard list assets && next-step` to re-run
+    work that already succeeded. Measured on the real CLI before the fix: 968
+    asset rows and the pagination hint were printed, the process then sat alive
+    10.1s past its own output, and Ctrl-C there produced `Aborted!` and exit 1.
+
+    `upgrade_check`'s `except KeyboardInterrupt: pass` is what closes that, and it
+    is deliberately narrow: it wraps only the advisory call, so a Ctrl-C during
+    the command's own body still aborts (pinned by
+    `test_keyboard_interrupt_keeps_click_abort_semantics_and_skips_update`), and
+    it names `KeyboardInterrupt` alone, so `SystemExit` and cancellation still
+    propagate (pinned directly below).
+
+    The interrupt is injected at the deadline wait rather than at `requests.get`
+    -- see `_interrupt_the_deadline_wait` for why that is the only reachable
+    seam. `joined_with` is asserted first because every other assertion here
+    would also hold if the shim were never installed; without it a green run
+    would prove nothing.
+    """
+    request = _force_update_request(monkeypatch, tmp_path, TimeoutError("fetch still in flight"))
+    joined_with = _interrupt_the_deadline_wait(monkeypatch, KeyboardInterrupt())
+    command = _command_calling(lambda: click.echo("delivered-before-the-interrupt"))
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert joined_with == [UPDATE_CHECK_DEADLINE_SECONDS]
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "Aborted!" not in result.output
     assert "Error:" not in result.output
+    assert result.output == "delivered-before-the-interrupt\n"
     request.assert_called_once()
+
+
+def _raise_from_the_throttle_write(monkeypatch, exception):
+    """Raise `exception` from the throttle-record write, on the main thread.
+
+    `_check_for_update` writes the throttle record *before* it goes anywhere near
+    the network, so this is the earliest main-thread step of the advisory that can
+    fail -- and it is reached through the real `_write_update_check_cache`, so that
+    function's own arms (`except CancelledError: raise`, then
+    `except Exception: return False`) are exercised rather than replaced.
+
+    It also makes the fetch provably unreached, which is what the
+    `request.assert_not_called()` in the caller records.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    def raise_during_the_write(*_args, **_kwargs):
+        raise exception
+
+    monkeypatch.setattr(decorators.json, "dump", raise_during_the_write)
 
 
 @pytest.mark.parametrize(
@@ -684,19 +773,30 @@ def test_update_keyboard_interrupt_keeps_click_abort_semantics(monkeypatch, tmp_
     ids=["system-exit", "future-cancelled"],
 )
 def test_update_process_control_exceptions_propagate(monkeypatch, tmp_path, exception, exit_code):
-    """Process-control exceptions raised by the advisory are not swallowed.
+    """Process control raised by the advisory still reaches the exit status.
 
-    `SystemExit` is a `BaseException` and so passes through `except Exception`
-    untouched, keeping its own status. `concurrent.futures.CancelledError` is
-    `Exception`-derived on this runtime, so it would be swallowed on the fail-open
-    path -- the dedicated `except CancelledError: raise` arm is what makes it
-    propagate instead.
+    `KeyboardInterrupt` is now absorbed (above); these two are not, and the
+    distinction is the point. A `SystemExit` means something in the process asked
+    to exit with that status, and a `CancelledError` means the surrounding task
+    was cancelled -- neither is "the user interrupted a courtesy message", so
+    neither may be reported as a clean success. `SystemExit` is a `BaseException`
+    and passes through `except Exception` untouched, keeping its own status;
+    `concurrent.futures.CancelledError` is `Exception`-derived on this runtime, so
+    the fail-open arm *would* swallow it and the dedicated
+    `except CancelledError: raise` arm is what makes it propagate instead.
+
+    Anchored at the throttle write, a main-thread step, rather than at
+    `requests.get`: the fetch now runs on a worker thread whose body is
+    `except BaseException: pass`, so nothing raised there reaches the main thread
+    at all. `request.assert_not_called()` is the negative half of that -- control
+    never got as far as the network.
     """
     assert issubclass(FutureCancelledError, Exception)
-    request = _force_update_request(monkeypatch, tmp_path, exception)
+    request = _force_update_request(monkeypatch, tmp_path, AssertionError("must not be reached"))
+    _raise_from_the_throttle_write(monkeypatch, exception)
 
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == exit_code
     assert result.exception is exception
-    request.assert_called_once()
+    request.assert_not_called()

--- a/praetorian_cli/sdk/test/test_cli_errors.py
+++ b/praetorian_cli/sdk/test/test_cli_errors.py
@@ -127,18 +127,24 @@ def _successful_command():
 def _force_update_request(monkeypatch, tmp_path, side_effect):
     """The inverse of `_disable_update_request`: let the advisory reach the network.
 
-    Two forces are needed and both are load-bearing. `CliRunner` replaces stderr
-    with a non-tty buffer, so `_stderr_is_interactive()` returns False inside any
-    `invoke` and the advisory returns at its very first gate -- a test that did
-    not patch it would assert against a check that never ran. `XDG_CACHE_HOME` is
-    redirected at `tmp_path` so nothing reads or writes the real user cache, and
-    an empty cache is what guarantees the network branch is the one taken.
+    Two forces are needed and both are load-bearing. `_session_is_interactive()`
+    requires BOTH `sys.stdout.isatty()` and `sys.stderr.isatty()`, and `CliRunner`
+    replaces both with non-tty buffers, so the gate is closed inside any `invoke`
+    and the advisory returns before it does anything -- a test that did not force
+    it would assert against a check that never ran, and would keep passing if the
+    advisory stopped running altogether. Forcing the whole predicate rather than
+    one stream is what keeps that hole shut. `XDG_CACHE_HOME` is redirected at
+    `tmp_path` so nothing reads or writes the real user cache, and an empty cache
+    is what guarantees the network branch is the one taken.
+
+    The predicate's own behaviour is pinned in test_update_check.py, which drives
+    the real `_session_is_interactive` instead of replacing it.
     """
     import praetorian_cli.handlers.cli_decorators as decorators
 
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     monkeypatch.delenv("PRAETORIAN_CLI_DISABLE_UPDATE_CHECK", raising=False)
-    monkeypatch.setattr(decorators, "_stderr_is_interactive", lambda: True)
+    monkeypatch.setattr(decorators, "_session_is_interactive", lambda: True)
     request = Mock(side_effect=side_effect)
     monkeypatch.setattr(decorators.requests, "get", request)
     return request

--- a/praetorian_cli/sdk/test/test_sdk_exceptions.py
+++ b/praetorian_cli/sdk/test/test_sdk_exceptions.py
@@ -130,8 +130,8 @@ if not praetorian_cli.__file__.startswith(os.environ["PRAETORIAN_TEST_PACKAGE_RO
     os._exit(98)
 """
 
-# `upgrade_check`'s bare `except:` swallows anything raisable, so only an
-# uncatchable exit makes a stray advisory request visible. Same device as
+# `_check_for_update`'s `except Exception: pass` arm swallows every ordinary
+# exception, so only an uncatchable exit makes a stray advisory request visible. Same device as
 # `test_cli_errors.py`'s `_NETWORK_TRIPWIRE`, kept local so this module stands
 # alone.
 _CLI_NETWORK_TRIPWIRE = """
@@ -462,10 +462,37 @@ from praetorian_cli.main import {entry}
 
 
 def _cli_child(entry, argv, home):
+    """Spawn a console-script child under the fake `$HOME`, deps still importable.
+
+    The `HOME` override is load-bearing -- `DEFAULT_KEYCHAIN_FILEPATH` derives
+    from it -- but it also relocates the *user* site-packages, whose location is
+    `$HOME`-relative. That is where `pip install --user` puts this package's own
+    dependencies, so overriding `HOME` alone takes them with it: measured on a
+    stock developer machine, the child died on `ModuleNotFoundError: No module
+    named 'click'` inside `cli_decorators` before reaching any behaviour under
+    test, and both tests below failed for that reason rather than on their own
+    assertions. The suite only passed where the deps happened to live outside
+    `$HOME`, i.e. in a virtualenv -- an unstated assumption about how the package
+    was installed.
+
+    Exporting the parent's own `sys.path` fixes it without weakening the
+    isolation (`Path.home()` in the child still resolves to the fake home), and
+    is correct under a venv too, where hardcoding the user-site path would not
+    be. `cwd` is `REPO_ROOT` and `-c` puts the cwd ahead of `PYTHONPATH`, so this
+    cannot shift which `praetorian_cli` the child imports -- `_PACKAGE_GUARD`
+    keeps measuring that.
+
+    The `if p` filter is load-bearing: `sys.path` carries an empty entry meaning
+    "the current directory", and an empty `PYTHONPATH` component would put the
+    child's cwd on its import path implicitly rather than by the `cwd` argument.
+    """
     return _run_child(
         _CLI_SCRIPT.format(entry=entry, argv=argv),
         tripwire=_CLI_NETWORK_TRIPWIRE,
-        env={"HOME": str(home)},
+        env={
+            "HOME": str(home),
+            "PYTHONPATH": os.pathsep.join(p for p in sys.path if p),
+        },
     )
 
 

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -28,7 +28,10 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from praetorian_cli.handlers.cli_decorators import UPDATE_CHECK_CACHE_TTL_SECONDS
+from praetorian_cli.handlers.cli_decorators import (
+    UPDATE_CHECK_CACHE_TTL_SECONDS,
+    UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS,
+)
 
 
 UPDATE_URL = "https://pypi.org/pypi/praetorian-cli/json"
@@ -53,9 +56,60 @@ posix_modes_only = pytest.mark.skipif(
     os.name != "posix", reason="POSIX mode bits are not enforced on this platform"
 )
 
+# Creating a *directory* symlink needs a privilege or developer mode off POSIX, so
+# the symlink cases are skipped there rather than deleted -- the rejection they
+# pin is what keeps a hostile pre-created cache directory from being written to.
+symlinks_only = pytest.mark.skipif(
+    os.name != "posix", reason="creating a directory symlink is not unprivileged off POSIX"
+)
+
+# `/dev/fd` is how this process's open descriptors are counted. Linux and macOS
+# both have it; elsewhere there is nothing to count, so the leak test is skipped.
+fd_counting_only = pytest.mark.skipif(
+    not os.path.isdir("/dev/fd"), reason="descriptor counting needs /dev/fd"
+)
+
 
 def _cache_path(cache_root: Path) -> Path:
     return cache_root / "praetorian-cli" / "update-check.json"
+
+
+def _refresh_marker_path(cache_root: Path) -> Path:
+    """The exclusive-create marker that serialises concurrent refreshes.
+
+    Derived here the same way the module derives it -- a sibling of the cache
+    record -- so a test can pre-create it (another invocation holds the claim) or
+    assert its absence (the claim was released).
+    """
+    cache_path = _cache_path(cache_root)
+    return cache_path.with_name(cache_path.name + ".refresh")
+
+
+def _write_cache_record(cache_path: Path, checked_at, latest_version) -> None:
+    """Leave the cache record a previous invocation -- or a peer -- would have left."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps({"checked_at": checked_at, "latest_version": latest_version}),
+        encoding="utf-8",
+    )
+
+
+def _symlinked_leaf_cache(tmp_path: Path):
+    """A cache root whose `praetorian-cli` leaf is a pre-created symlink.
+
+    Returns `(cache_root, victim)`. The target is a directory this user owns and
+    can write, so nothing but the leaf-symlink rejection stands between the
+    refresh and writing into it -- and it is world-readable and non-empty, so both
+    its mode and its contents are observable afterwards.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    victim.chmod(0o755)
+    (victim / "keepme").write_bytes(b"not ours")
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    _cache_path(cache_root).parent.symlink_to(victim, target_is_directory=True)
+    return cache_root, victim
 
 
 def _response(latest: str = "1.1.0", releases=None) -> Mock:
@@ -1102,3 +1156,518 @@ def test_update_check_advisory_is_silent_when_local_version_is_current(
     assert result.output == ""
     for fragment in ADVISORY_FRAGMENTS:
         assert fragment not in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Concurrent refresh exclusion.
+#
+# One exclusive-create marker beside the cache record elects one refresher out of
+# N simultaneous invocations. Real concurrency cannot be scheduled deterministically
+# in one process, so these tests drive the two halves of the race separately: the
+# LOSER's half by pre-creating the marker, and the WINNER-that-arrived-late half by
+# letting a peer land its record between the claim and the re-read.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "marker_age",
+    [0, UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS],
+    ids=["just-claimed", "at-the-staleness-boundary"],
+)
+def test_update_check_lost_refresh_claim_makes_no_request(
+    monkeypatch, tmp_path, marker_age
+):
+    """Whoever loses the claim does not fetch: N invocations, one probe.
+
+    Both ages are held by another invocation. The boundary case is the one an
+    off-by-one reclaim would get wrong: a marker exactly at the staleness constant
+    is *not* yet stale, so treating the comparison as `<` instead of `<=` would let
+    a second invocation reclaim it and probe concurrently with the holder.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    # Stale, so the refresh branch is the one taken and the claim is attempted.
+    _write_cache_record(cache_path, 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"")
+    os.utime(marker, (CHECKED_AT - marker_age, CHECKED_AT - marker_age))
+    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+
+
+def test_update_check_lost_refresh_claim_still_advises(monkeypatch, tmp_path):
+    """Losing the claim skips the REFRESH, not the whole check.
+
+    The cached version is still compared against the local one and still printed.
+    An implementation that returned early on a lost claim would silence the
+    advisory for every invocation that happens to collide with a refresh -- and
+    under a shell that runs several `guard` commands at once, that is most of them.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"")
+    os.utime(marker, (CHECKED_AT, CHECKED_AT))
+    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+def test_update_check_lost_refresh_claim_leaves_the_holders_marker(monkeypatch, tmp_path):
+    """The loser does not release a marker it never claimed.
+
+    This is the whole exclusion: a loser that unlinked the holder's marker in its
+    own `finally` would hand the claim straight back to the next arrival, and N
+    invocations would probe N times again -- with the added hazard that the holder
+    is still mid-fetch and will release a marker that by then belongs to someone
+    else.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"held")
+    os.utime(marker, (CHECKED_AT, CHECKED_AT))
+    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert marker.exists()
+    assert marker.read_bytes() == b"held"
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+def test_update_check_stale_refresh_marker_is_reclaimed(monkeypatch, tmp_path):
+    """A marker left behind by a killed invocation cannot wedge refreshes forever.
+
+    One second past the staleness constant is enough: the marker is only an
+    election, so the recovery window is deliberately short compared to the cache
+    TTL. Without the reclaim, a single `SIGKILL` during a fetch would suppress
+    every future refresh for the lifetime of the cache directory.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"")
+    abandoned_at = CHECKED_AT - (UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS + 1)
+    os.utime(marker, (abandoned_at, abandoned_at))
+    assert UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS < UPDATE_CHECK_CACHE_TTL_SECONDS
+    request = Mock(return_value=_response("1.8.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 1.8.0" in result.output
+
+
+def test_update_check_refresh_marker_is_released_when_the_fetch_raises(
+    monkeypatch, tmp_path
+):
+    """The claim is released on the failure paths too, not only on success.
+
+    The release lives in a `finally`, which is what this asserts: a marker left
+    behind by a raising fetch would suppress refreshes until it aged out of the
+    staleness window, turning one unreachable index into a stall on every
+    invocation in that window.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(_cache_path(tmp_path), 0, None)
+    marker = _refresh_marker_path(tmp_path)
+    request = Mock(side_effect=OSError("name or service not known"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert not marker.exists()
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert request.call_count == 1
+
+
+def test_update_check_released_marker_lets_the_next_stale_invocation_refresh(
+    monkeypatch, tmp_path
+):
+    """The consequence of the release: the next stale invocation can still refresh.
+
+    The TTL throttle is deliberately stepped over between the two invocations, so
+    the only thing that could stop the second refresh is a marker the first one
+    failed to release -- and under the frozen clock any leftover marker is inside
+    the staleness window, so the claim would be lost and the request count would
+    stay at one.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    _write_cache_record(cache_path, 0, None)
+    request = Mock(side_effect=OSError("name or service not known"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    first = CliRunner().invoke(_successful_command(), obj=object())
+    assert first.exit_code == 0
+    assert request.call_count == 1
+
+    # Age the throttle record back out of the TTL window, so the second
+    # invocation reaches the claim at all.
+    _write_cache_record(cache_path, 0, None)
+    request.side_effect = None
+    request.return_value = _response("1.9.0")
+
+    second = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert request.call_count == 2
+    assert second.exit_code == 0
+    assert "A new version of praetorian-cli is available: 1.9.0" in second.output
+
+
+def _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, peer_at, peer_version):
+    """Win the claim, then let a peer land `peer_version` before the re-read.
+
+    This is the late-arrival half of the race: two invocations read the same stale
+    record, one wins the claim and fetches, and the other wins it *afterwards* --
+    by which point the answer it needs is already on disk. Patching the claim is
+    the only deterministic seam for it, because the peer's write has to land
+    strictly between this invocation's claim and its re-read.
+    """
+    real_claim = decorators._claim_update_refresh_marker
+
+    def claim_then_peer_refreshes(path):
+        claimed = real_claim(path)
+        _write_cache_record(cache_path, peer_at, peer_version)
+        return claimed
+
+    monkeypatch.setattr(
+        decorators, "_claim_update_refresh_marker", claim_then_peer_refreshes
+    )
+
+
+def test_update_check_claim_winner_stands_down_for_a_peers_fresh_record(
+    monkeypatch, tmp_path
+):
+    """A claim won *after* a peer refreshed makes ZERO requests.
+
+    Without the re-read inside the claim, the exclusion only narrows the race
+    window instead of closing it: every invocation that queues up behind the
+    holder claims the marker in turn the moment it is released, and each one
+    fetches on the strength of the stale record it read before it ever waited.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    _write_cache_record(cache_path, 0, "1.2.0")
+    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, CHECKED_AT, "1.5.0")
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    request.assert_not_called()
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert not _refresh_marker_path(tmp_path).exists()
+
+
+def test_update_check_claim_winner_advises_the_peers_version(monkeypatch, tmp_path):
+    """Standing down still advises -- with the PEER's version, not the stale one.
+
+    The invocation read 1.2.0 at entry and the peer replaced it with 1.5.0 while
+    the claim was being taken. Serving the entry-time value would advertise a
+    version the process already knows to be superseded, and would keep doing so
+    for as long as invocations kept colliding.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    _write_cache_record(cache_path, 0, "1.2.0")
+    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, CHECKED_AT, "1.5.0")
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert "A new version of praetorian-cli is available: 1.5.0" in result.output
+    assert "1.2.0" not in result.output
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+def test_update_check_peer_record_freshness_is_judged_by_the_clock_read_after_the_claim(
+    monkeypatch, tmp_path
+):
+    """The re-read samples the clock AGAIN; it must not reuse the pre-claim `now`.
+
+    Time passes while an invocation waits for the claim, so the peer's record can
+    carry a timestamp *later* than the `now` this invocation captured on entry.
+    Judged against that stale `now`, the age is negative, the future-timestamp rule
+    scores the peer's record as stale, and the invocation refetches -- which is the
+    exact stampede the re-read exists to prevent, restored in the one case where
+    contention is highest. Judged against a fresh reading, the age is positive and
+    the invocation stands down.
+
+    The clock is keyed on whether the peer has written rather than on call order,
+    so the discrimination does not depend on how many times `time.time()` happens
+    to be consulted.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    _write_cache_record(cache_path, 0, "1.2.0")
+    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    peer_written = []
+    monkeypatch.setattr(
+        decorators.time, "time", lambda: CHECKED_AT + 10 if peer_written else CHECKED_AT
+    )
+
+    real_claim = decorators._claim_update_refresh_marker
+
+    def claim_then_peer_refreshes(path):
+        claimed = real_claim(path)
+        # Written 5s after this invocation's entry -- ahead of the pre-claim `now`,
+        # behind the clock as it reads once the claim has been taken.
+        _write_cache_record(cache_path, CHECKED_AT + 5, "1.5.0")
+        peer_written.append(True)
+        return claimed
+
+    monkeypatch.setattr(
+        decorators, "_claim_update_refresh_marker", claim_then_peer_refreshes
+    )
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    request.assert_not_called()
+    assert "A new version of praetorian-cli is available: 1.5.0" in result.output
+    assert result.exit_code == 0
+    # The peer's record is left exactly as the peer wrote it: standing down writes
+    # nothing, so the peer's timestamp is not walked backwards to this
+    # invocation's older `now`.
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT + 5,
+        "latest_version": "1.5.0",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# `XDG_CACHE_HOME` that is not an absolute path.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "cache_home",
+    ["relative-cache", "./relative-cache", ""],
+    ids=["relative", "dot-relative", "empty"],
+)
+def test_update_check_non_absolute_xdg_cache_home_falls_back_to_the_home_cache(
+    monkeypatch, tmp_path, cache_home
+):
+    """A non-absolute `XDG_CACHE_HOME` is ignored, per the XDG base-directory spec.
+
+    Honouring it would resolve the cache against the *current working directory*,
+    so `guard` would scatter a cache directory into whatever tree the user happened
+    to be standing in -- and, worse, would read a throttle record written by
+    whoever else can write there. The empty value is the case that was already
+    correct and is easy to break, since it is falsey rather than non-absolute.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    working_dir = tmp_path / "cwd"
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("XDG_CACHE_HOME", cache_home)
+    request = Mock(return_value=_response("2.0.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    resolved = decorators._update_check_cache_path()
+
+    assert resolved.is_absolute()
+    assert resolved == fake_home / ".cache" / "praetorian-cli" / "update-check.json"
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert "A new version of praetorian-cli is available: 2.0.0" in result.output
+    assert json.loads(resolved.read_text(encoding="utf-8"))["latest_version"] == "2.0.0"
+    # Nothing was resolved against the working directory.
+    assert list(working_dir.iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
+# A cache directory that is a symlink.
+# --------------------------------------------------------------------------- #
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_directory_stays_off_the_network(
+    monkeypatch, tmp_path
+):
+    """A cache directory that is a symlink is refused, so ZERO requests are made.
+
+    This is the consequence that actually matters: the write is the throttle, so a
+    cache directory that cannot be written is an environment whose probe rate
+    cannot be limited -- and it must not be probed at all, not once per invocation.
+    Three invocations, because a rejection that failed to stop the fetch would show
+    up as a request every time rather than only on the first.
+    """
+    cache_root, _victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(side_effect=AssertionError("a symlinked cache directory must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert ADVISORY_LEAD not in result.output
+
+    request.assert_not_called()
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_directory_writes_nothing_into_the_target(
+    monkeypatch, tmp_path
+):
+    """Nothing is created inside the symlink target -- not the record, not a temp file.
+
+    A pre-created symlink is how an attacker who can write the cache path but not
+    the target aims a privileged write somewhere else; `mkstemp` plus `os.replace`
+    would follow the link and land both files in the target directory.
+    """
+    cache_root, victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(side_effect=AssertionError("a symlinked cache directory must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert sorted(p.name for p in victim.iterdir()) == ["keepme"]
+    assert (victim / "keepme").read_bytes() == b"not ours"
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+@symlinks_only
+@posix_modes_only
+def test_update_check_symlinked_cache_directory_keeps_the_targets_mode(
+    monkeypatch, tmp_path
+):
+    """The target's mode is unchanged: the 0700 repair does not follow the link.
+
+    The directory preparation deliberately *repairs* a too-permissive mode, which
+    is exactly why the symlink case has to be refused before it runs -- otherwise
+    the repair reaches through the link and re-modes a directory that is none of
+    its business.
+    """
+    cache_root, victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    request = Mock(return_value=_response("2.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    assert result.exit_code == 0
+
+
+@symlinks_only
+def test_update_check_write_to_a_symlinked_cache_directory_reports_failure(
+    monkeypatch, tmp_path
+):
+    """`_write_update_check_cache` reports the refusal, rather than claiming success.
+
+    The return value is what the caller reads to decide whether to fetch, so a
+    refusal reported as success would restore the unthrottled probe -- the network
+    assertion above is downstream of this one.
+    """
+    cache_root, _victim = _symlinked_leaf_cache(tmp_path)
+    decorators = _configure_update_check(monkeypatch, cache_root)
+
+    assert not decorators._write_update_check_cache(
+        _cache_path(cache_root), CHECKED_AT, "1.2.0"
+    )
+
+
+@symlinks_only
+def test_update_check_symlinked_cache_ancestor_still_works(monkeypatch, tmp_path):
+    """The rejection is scoped to the leaf: a symlinked ANCESTOR still works.
+
+    A symlinked `~/.cache` is a normal dotfile-manager or shared-cache-volume
+    setup, and rejecting it would silently disable the advisory for those users.
+    The leaf is the component the module creates itself, so it is the only one it
+    can hold to having not been pre-created by somebody else.
+    """
+    real_cache = tmp_path / "real-cache"
+    real_cache.mkdir()
+    linked_cache = tmp_path / "linked-cache"
+    linked_cache.symlink_to(real_cache, target_is_directory=True)
+    decorators = _configure_update_check(monkeypatch, linked_cache)
+    request = Mock(return_value=_response("2.1.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 2.1.0" in result.output
+    assert json.loads(
+        _cache_path(real_cache).read_text(encoding="utf-8")
+    )["latest_version"] == "2.1.0"
+
+
+# --------------------------------------------------------------------------- #
+# Descriptor accounting on the cache-write failure path.
+# --------------------------------------------------------------------------- #
+
+
+@fd_counting_only
+def test_update_check_leaks_no_descriptor_when_fdopen_raises(monkeypatch, tmp_path):
+    """`mkstemp` hands back a raw descriptor, and a failed `os.fdopen` must not orphan it.
+
+    Only `os.fdopen` succeeding transfers ownership of that descriptor to a file
+    object the `with` block can close; if it raises, nothing else will ever close
+    it. The count is taken across 200 induced failures because one leak is
+    invisible -- and a long-lived process on a `guard` install that hits this path
+    every invocation is exactly where it stops being invisible.
+
+    The path-only assertion is the one that missed this bug: the old code removed
+    the temp file and leaked its descriptor, so `iterdir()` looked spotless while
+    the process bled descriptors. Both are asserted here for that reason.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    request = Mock(side_effect=AssertionError("a cache that cannot be written must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def refuse_to_wrap(*_args, **_kwargs):
+        raise OSError("too many open files")
+
+    monkeypatch.setattr(decorators.os, "fdopen", refuse_to_wrap)
+
+    # One failing invocation before the baseline, so any one-time allocation on
+    # this path is counted as setup rather than as a leak.
+    warm_up = CliRunner().invoke(_successful_command(), obj=object())
+    assert warm_up.exit_code == 0
+    baseline = len(os.listdir("/dev/fd"))
+
+    for _ in range(200):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    assert len(os.listdir("/dev/fd")) == baseline
+    request.assert_not_called()
+    # No `mkstemp` leftover, and no cache record: the write never completed.
+    assert list(cache_path.parent.iterdir()) == []

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -1,0 +1,365 @@
+"""Contract for the best-effort update advisory in `@cli_handler`.
+
+Offline only: every test redirects `XDG_CACHE_HOME` at `tmp_path` and replaces
+`requests.get`, so no test reaches pypi.org or the real user cache directory.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from praetorian_cli.handlers.cli_decorators import UPDATE_CHECK_CACHE_TTL_SECONDS
+
+
+UPDATE_URL = "https://pypi.org/pypi/praetorian-cli/json"
+DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
+CHECKED_AT = 1_700_000_000.0
+
+# The three lines the advisory prints when pypi is ahead of the local install.
+ADVISORY_FRAGMENTS = (
+    "A new version of praetorian-cli is available",
+    "You are currently running",
+    'pip install --upgrade praetorian-cli',
+)
+
+
+def _cache_path(cache_root: Path) -> Path:
+    return cache_root / "praetorian-cli" / "update-check.json"
+
+
+def _response(latest: str = "1.1.0") -> Mock:
+    response = Mock()
+    response.json.return_value = {"releases": {latest: {}}}
+    return response
+
+
+def _configure_update_check(monkeypatch, cache_root: Path, interactive: bool = True):
+    """Pin every input the advisory reads: cache root, opt-out, clock, version, TTY.
+
+    The TTY force is the load-bearing part. `CliRunner` replaces stderr with a
+    non-tty buffer, so `_stderr_is_interactive()` returns False inside *any*
+    `CliRunner.invoke` and the advisory returns at its first gate. Without this,
+    every test below would pass because the check never ran -- including the two
+    that assert the request is *not* made, which would then prove nothing at all.
+    """
+    import praetorian_cli.handlers.cli_decorators as decorators
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
+    monkeypatch.delenv(DISABLE_ENV, raising=False)
+    monkeypatch.setattr(decorators, "version", lambda _package: "1.0.0")
+    monkeypatch.setattr(decorators.time, "time", lambda: CHECKED_AT)
+    monkeypatch.setattr(decorators, "_stderr_is_interactive", lambda: interactive)
+    return decorators
+
+
+def _successful_command(events=None):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        if events is not None:
+            events.append("command")
+        return "done"
+
+    return command
+
+
+def test_update_check_runs_after_success(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    events = []
+    request = Mock(
+        side_effect=lambda *args, **kwargs: (
+            events.append("request"),
+            _response(),
+        )[1]
+    )
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(events), obj=object())
+
+    assert result.exit_code == 0
+    assert events == ["command", "request"]
+
+
+def test_update_check_skips_unsuccessful_command(monkeypatch, tmp_path):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=AssertionError("update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    @click.command()
+    @cli_handler
+    def command(_sdk):
+        raise click.ClickException("command failed")
+
+    result = CliRunner().invoke(command, obj=object())
+
+    assert result.exit_code == 1
+    assert "command failed" in result.output
+    request.assert_not_called()
+
+
+def test_update_check_disabled_by_explicit_environment_switch(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, "1")
+    request = Mock(side_effect=AssertionError("disabled update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_not_called()
+
+
+def test_update_check_uses_fresh_cached_result_without_network(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    request = Mock(side_effect=AssertionError("fresh cache must avoid network"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+    request.assert_not_called()
+
+
+def test_update_check_refreshes_stale_cached_result_once_with_short_timeout(
+    monkeypatch, tmp_path
+):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    request = Mock(return_value=_response("1.3.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["latest_version"] == "1.3.0"
+
+
+def test_update_check_timeout_failure_is_fail_open(monkeypatch, tmp_path):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=TimeoutError("version service unavailable"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+
+
+def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_path):
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response())
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    @click.command()
+    @click.argument("target")
+    @click.option("--profile")
+    @click.option("--account")
+    @cli_handler
+    def command(_sdk, target, profile, account):
+        return target, profile, account
+
+    sentinels = ["SECRET_TARGET", "SECRET_PROFILE", "SECRET_ACCOUNT"]
+    result = CliRunner().invoke(
+        command,
+        [sentinels[0], "--profile", sentinels[1], "--account", sentinels[2]],
+        obj=object(),
+    )
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    request_repr = repr(request.call_args)
+    assert all(sentinel not in request_repr for sentinel in sentinels)
+
+
+def test_update_check_cached_payload_is_private_and_atomically_replaced(
+    monkeypatch, tmp_path
+):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(mode=0o755)
+    cache_path.write_text("malformed", encoding="utf-8")
+    cache_path.chmod(0o644)
+    request = Mock(return_value=_response("1.4.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    real_replace = os.replace
+    replacements = []
+
+    def record_replace(source, destination):
+        replacements.append((Path(source), Path(destination)))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", record_replace)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert len(replacements) == 1
+    temporary_path, destination = replacements[0]
+    assert destination == cache_path
+    assert temporary_path.parent == cache_path.parent
+    assert temporary_path != cache_path
+    assert not temporary_path.exists()
+    assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert set(payload) == {"checked_at", "latest_version"}
+    assert isinstance(payload["checked_at"], (int, float))
+    assert payload["latest_version"] == "1.4.0"
+
+
+def test_update_check_malformed_cache_and_network_failure_preserve_success(
+    monkeypatch, tmp_path
+):
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text("not-json", encoding="utf-8")
+    request = Mock(side_effect=OSError("offline"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+
+
+def test_update_check_skipped_when_stderr_is_not_interactive(monkeypatch, tmp_path):
+    """The advisory never runs for a command whose stderr is not a terminal.
+
+    ENG-6643's "never runs where it is inappropriate" criterion: a piped or
+    redirected stderr (a script, a cron job, a `2>` capture) must get no network
+    call and no cache file -- the advisory is for humans at a terminal only.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path, interactive=False)
+    request = Mock(side_effect=AssertionError("non-interactive stderr must not check"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    # Not merely no *fresh* cache: the check returns before the cache path is
+    # even computed, so nothing under XDG_CACHE_HOME is created or read.
+    assert not _cache_path(tmp_path).exists()
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+def test_update_check_future_timestamp_is_treated_as_stale(monkeypatch, tmp_path):
+    """A `checked_at` in the future is stale, so a bad clock cannot pin an answer.
+
+    One hour ahead is the mutant-killing value: it is *inside* the TTL window in
+    absolute terms, so a freshness test written as `age < TTL` without the
+    `0 <= age` lower bound would read this entry as fresh and serve it forever.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT + 3600, "latest_version": "9.9.9"}),
+        encoding="utf-8",
+    )
+    assert 3600 < UPDATE_CHECK_CACHE_TTL_SECONDS
+    request = Mock(return_value=_response("1.5.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    # The future-dated entry was neither served to the user nor left in place.
+    assert "9.9.9" not in result.output
+    assert "1.5.0" in result.output
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload == {"checked_at": CHECKED_AT, "latest_version": "1.5.0"}
+
+
+def test_update_check_write_failure_leaves_no_temporary_file(monkeypatch, tmp_path):
+    """A failed cache write is swallowed, and leaves no debris behind.
+
+    `_write_update_check_cache` creates its temp file with `mkstemp` in the
+    destination directory; the `finally: temp_path.unlink(missing_ok=True)` is
+    what keeps a mid-write failure from accumulating a temp file per invocation
+    in the user's cache directory.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    # Stale, so the network path runs and a write is attempted.
+    original_bytes = json.dumps({"checked_at": 0, "latest_version": "1.0.0"}).encode()
+    cache_path.write_bytes(original_bytes)
+    request = Mock(return_value=_response("1.6.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def failing_dump(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(decorators.json, "dump", failing_dump)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    # Fail open: the write failure never reaches the user or the exit status.
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    # No temp entry left in the destination directory, and the previous cache
+    # file is byte-for-byte intact -- the aborted write replaced nothing.
+    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
+    assert cache_path.read_bytes() == original_bytes
+
+
+@pytest.mark.parametrize(
+    "remote_version",
+    ["1.0.0", "0.9.0"],
+    ids=["remote-equals-local", "remote-older-than-local"],
+)
+def test_update_check_advisory_is_silent_when_local_version_is_current(
+    monkeypatch, tmp_path, remote_version
+):
+    """No advisory unless pypi is strictly ahead: `>`, not `!=` and not `>=`.
+
+    The local version is pinned at 1.0.0, so an equal remote is the boundary case
+    a `>=` comparison would get wrong, and an older remote is what a `!=`
+    comparison would get wrong -- both would nag a user who is already current.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response(remote_version))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    # `output` is the interleaved stdout+stderr stream and the command itself
+    # prints nothing, so total emptiness is assertable -- a stronger claim than
+    # the absence of the three fragments alone.
+    assert result.output == ""
+    for fragment in ADVISORY_FRAGMENTS:
+        assert fragment not in result.output

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -33,7 +33,8 @@ from click.testing import CliRunner
 from praetorian_cli.handlers.cli_decorators import (
     UPDATE_CHECK_CACHE_MAX_BYTES,
     UPDATE_CHECK_CACHE_TTL_SECONDS,
-    UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS,
+    UPDATE_CHECK_DEADLINE_SECONDS,
+    UPDATE_CHECK_RESPONSE_MAX_BYTES,
 )
 
 
@@ -51,6 +52,30 @@ ADVISORY_FRAGMENTS = (
 # The one fragment that appears exactly once per advisory, so counting it counts
 # advisories.
 ADVISORY_LEAD = ADVISORY_FRAGMENTS[0]
+
+# The exact call `_fetch_latest_version` makes. Asserted in full rather than as
+# "the URL, with some timeout", because three of these four arguments are
+# load-bearing and each was added for a measured reason: `stream=True` is what
+# leaves the body unread until the size cap has been applied to it, and
+# `Accept-Encoding: identity` is what makes a cap on RAW bytes a cap on the bytes
+# that actually get parsed -- a compressed body is capped on the wire and then
+# expanded without any bound at all, which a gzip bomb walks straight through
+# (measured: 55 KiB of wire peaking 131x past the 1 MiB ceiling). A call
+# assertion naming only the URL and the timeout would let any of them be dropped
+# again in silence.
+FETCH_ARGS = (UPDATE_URL,)
+FETCH_KWARGS = {
+    "timeout": 2,
+    "stream": True,
+    "headers": {"Accept-Encoding": "identity"},
+}
+
+
+def _assert_fetched_once(request):
+    """Exactly one fetch, made with the whole documented request shape."""
+    assert request.call_count == 1
+    assert request.call_args.args == FETCH_ARGS
+    assert request.call_args.kwargs == FETCH_KWARGS
 
 # The 0700/0600 guarantees are POSIX mode bits. Windows has no equivalent, and
 # `Path.chmod` there is close to a no-op -- so these are skipped rather than
@@ -111,17 +136,6 @@ def _cache_path(cache_root: Path) -> Path:
     return cache_root / "praetorian-cli" / "update-check.json"
 
 
-def _refresh_marker_path(cache_root: Path) -> Path:
-    """The exclusive-create marker that serialises concurrent refreshes.
-
-    Derived here the same way the module derives it -- a sibling of the cache
-    record -- so a test can pre-create it (another invocation holds the claim) or
-    assert its absence (the claim was released).
-    """
-    cache_path = _cache_path(cache_root)
-    return cache_path.with_name(cache_path.name + ".refresh")
-
-
 def _write_cache_record(cache_path: Path, checked_at, latest_version) -> None:
     """Leave the cache record a previous invocation -- or a peer -- would have left."""
     cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -163,7 +177,72 @@ def _symlinked_leaf_cache(tmp_path: Path):
     return cache_root, victim
 
 
-def _response(latest: str = "1.1.0", releases=None) -> Mock:
+class _RawBody:
+    """`response.raw`: the byte source `_fetch_latest_version` reads under a cap.
+
+    Every read is recorded, so a test can assert the body is read ONCE, bounded at
+    one byte PAST the ceiling -- which is the only way "over the ceiling" is
+    detectable at all -- and with decoding switched off.
+    """
+
+    def __init__(self, body: bytes):
+        self._remaining = body
+        self.reads = []
+
+    def read(self, amt=None, decode_content=None):
+        self.reads.append((amt, decode_content))
+        if amt is None:
+            chunk, self._remaining = self._remaining, b""
+        else:
+            chunk, self._remaining = self._remaining[:amt], self._remaining[amt:]
+        return chunk
+
+
+class _FakeResponse:
+    """The part of `requests.Response` that `_fetch_latest_version` actually uses.
+
+    Hand-written rather than a `Mock`, and that is the point of it: the fetch uses
+    the response as a CONTEXT MANAGER and reads BYTES off `.raw`, and a mock fakes
+    both shapes without holding them to anything -- `MagicMock.__enter__` hands
+    back another mock, and `raw.read(...)` hands back a mock whose `len()` raises
+    `TypeError` from inside the fail-open arm. So a mock turns "the fetch no
+    longer calls `.json()`" into either a vacuous pass or an unrelated failure,
+    while this fake turns it into a `TypeError` on the first shape that does not
+    match. `closed` is recorded because `stream=True` holds the connection open
+    until the response is closed, which makes leaking one a real defect rather
+    than a detail of the fake.
+    """
+
+    def __init__(self, body: bytes, status_error=None):
+        self.body = body
+        self.raw = _RawBody(body)
+        self.status_error = status_error
+        self.closed = False
+        self.entered = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, *_exception):
+        self.close()
+        return False
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        if self.status_error is not None:
+            raise self.status_error
+
+    def json(self):
+        raise AssertionError(
+            "the fetch must not call response.json(): it reads and decodes the "
+            "whole body, which is exactly what the size cap exists to prevent"
+        )
+
+
+def _payload(latest: str, releases=None) -> dict:
     """A PyPI payload whose `releases` block is a decoy for `info.version`.
 
     The default decoy carries a prerelease that outranks `info.version` and a key
@@ -172,34 +251,45 @@ def _response(latest: str = "1.1.0", releases=None) -> Mock:
     `InvalidVersion` into the fail-open arm -- and every test that uses this
     fixture notices, not just the one that names the behaviour.
     """
-    response = Mock()
     if releases is None:
         releases = ["0.9.0", latest, "9.9.9rc1", "not-a-version"]
-    response.json.return_value = {
+    return {
         "info": {"version": latest},
         "releases": {key: [] for key in releases},
     }
-    return response
 
 
-def _response_without_info() -> Mock:
+def _response(latest: str = "1.1.0", releases=None, padded_to=None) -> _FakeResponse:
+    """The successful response for `latest`, as a real streamed-body response.
+
+    `padded_to` pads the encoded body out to exactly that many bytes with JSON
+    whitespace, which is how the size-cap boundary cases differ from an ordinary
+    payload in byte count and in nothing else.
+    """
+    body = json.dumps(_payload(latest, releases)).encode()
+    if padded_to is not None:
+        assert len(body) <= padded_to, "payload already exceeds the requested size"
+        body += b" " * (padded_to - len(body))
+        assert len(body) == padded_to
+    return _FakeResponse(body)
+
+
+def _response_without_info() -> _FakeResponse:
     """The payload shape that raises `KeyError` inside `_fetch_latest_version`."""
-    response = Mock()
-    response.json.return_value = {"releases": {"9.9.9": []}}
-    return response
+    return _FakeResponse(json.dumps({"releases": {"9.9.9": []}}).encode())
 
 
-def _error_response() -> Mock:
+def _error_response() -> _FakeResponse:
     """A 500 from pypi.org: a body that parses fine, behind a failing status.
 
     The body deliberately carries a plausible-looking version, so a
     `_fetch_latest_version` that skipped `raise_for_status()` would advertise an
     error page's contents as the latest release.
     """
-    response = Mock()
-    response.raise_for_status.side_effect = RuntimeError("500 Server Error")
-    response.json.return_value = {"info": {"version": "9.9.9"}, "releases": {}}
-    return response
+    return _FakeResponse(
+        json.dumps({"info": {"version": "9.9.9"}, "releases": {}}).encode(),
+        status_error=RuntimeError("500 Server Error"),
+    )
 
 
 def _configure_inputs(monkeypatch, cache_root: Path):
@@ -409,7 +499,7 @@ def test_update_check_opt_out_ignores_values_that_do_not_mean_yes(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert "A new version of praetorian-cli is available: 1.2.0" in result.output
 
 
@@ -447,7 +537,7 @@ def test_update_check_refreshes_stale_cached_result_once_with_short_timeout(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert json.loads(cache_path.read_text(encoding="utf-8"))["latest_version"] == "1.3.0"
 
 
@@ -492,7 +582,7 @@ def test_update_check_timeout_failure_is_fail_open(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert result.exception is None
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
 
 
 def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_path):
@@ -518,7 +608,7 @@ def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_
     )
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     request_repr = repr(request.call_args)
     assert all(sentinel not in request_repr for sentinel in sentinels)
 
@@ -711,7 +801,7 @@ def test_update_check_records_the_attempt_before_making_the_request(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert snapshots == [{"checked_at": CHECKED_AT, "latest_version": "1.2.0"}]
     # And the second record lands afterwards, carrying the fetched answer.
     assert json.loads(cache_path.read_text(encoding="utf-8")) == {
@@ -887,7 +977,7 @@ def test_update_check_failed_refresh_retains_the_previous_version(
 
     assert result.exit_code == 0
     assert result.exception is None
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert result.output.count(ADVISORY_LEAD) == 1
     assert "A new version of praetorian-cli is available: 1.2.0" in result.output
     # Nothing about the failure itself reaches the user.
@@ -933,7 +1023,7 @@ def test_update_check_fresh_unparseable_entry_is_silent_until_the_ttl_expires(
     after_ttl = CliRunner().invoke(_successful_command(), obj=object())
 
     assert after_ttl.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert "A new version of praetorian-cli is available: 1.8.0" in after_ttl.output
 
 
@@ -1023,7 +1113,7 @@ def test_update_check_requires_both_streams_to_be_a_terminal(
     assert result.exit_code == 0
     assert result.exception is None
     if expect_request:
-        request.assert_called_once_with(UPDATE_URL, timeout=2)
+        _assert_fetched_once(request)
         assert "A new version of praetorian-cli is available: 1.9.0" in result.output
     else:
         request.assert_not_called()
@@ -1081,7 +1171,7 @@ def test_update_check_future_timestamp_is_treated_as_stale(monkeypatch, tmp_path
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     # The future-dated entry was neither served to the user nor left in place.
     assert "9.9.9" not in result.output
     assert "1.5.0" in result.output
@@ -1138,7 +1228,7 @@ def test_update_check_advises_exactly_once_for_a_succeeding_subcommand(
     assert events == ["group", "leaf"]
     for fragment in ADVISORY_FRAGMENTS:
         assert result.output.count(fragment) == 1
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
 
 
 def test_update_check_advises_once_for_a_bare_group_invocation(monkeypatch, tmp_path):
@@ -1161,7 +1251,88 @@ def test_update_check_advises_once_for_a_bare_group_invocation(monkeypatch, tmp_
     assert events == ["group", "group-default"]
     for fragment in ADVISORY_FRAGMENTS:
         assert result.output.count(fragment) == 1
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
+
+
+class _SentinelBaseException(BaseException):
+    """A `BaseException` that is nothing else: not process control, not `Exception`.
+
+    Its only job is to prove the fetch's guard is written against `BaseException`
+    and not against a list of known classes -- an `except Exception` there, or an
+    `except (Exception, KeyboardInterrupt, SystemExit)`, would let this one out.
+    """
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        RuntimeError("boom"),
+        OSError("offline"),
+        KeyboardInterrupt(),
+        SystemExit(73),
+        CancelledError("cancelled"),
+        _SentinelBaseException("stop"),
+    ],
+    ids=[
+        "runtime-error",
+        "os-error",
+        "keyboard-interrupt",
+        "system-exit",
+        "cancelled",
+        "base-exception",
+    ],
+)
+@pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")
+def test_update_check_abandons_a_fetch_that_raises_anything(monkeypatch, tmp_path, exception):
+    """Whatever class the fetch raises, the fetch is abandoned and the command is untouched.
+
+    This is the guarantee the fetch seam actually offers, and it is unconditional
+    in the exception's class. The fetch runs on a worker thread
+    (`_fetch_latest_version_within_deadline`) whose body is
+    `except BaseException: pass`, so an advisory that cannot answer simply does
+    not answer: no version, no advisory, and nothing raised into the command's
+    result. The alternative -- re-raising the worker's exception in the main
+    thread -- would let an unreachable PyPI turn every successful command into a
+    failure, which is the whole reason the advisory is fail-open.
+
+    The class list is the point rather than decoration. `RuntimeError` and
+    `OSError` are what a real fetch fails with; the next three are the classes the
+    suite used to assert *propagate* from here (they do not, and cannot: SIGINT is
+    delivered to the main thread only, `SystemExit` in a non-main thread ends that
+    thread alone, and there is no future or event loop in a raw `threading.Thread`
+    to inject a `CancelledError`); and `_SentinelBaseException` covers the rest of
+    the hierarchy, so narrowing the guard to any enumerated set fails here.
+
+    `result.output == ""` pins that nothing reached the user: no advisory, because
+    there is no version to advise about, and no error either.
+
+    The `filterwarnings` mark is the other half, and it is load-bearing rather
+    than hygiene. If the worker's guard were narrowed, the exception would escape
+    the thread instead of the command -- so every assertion above would still
+    hold, and the test would pass over the regression. What actually happens then
+    is `threading.excepthook`, which on the real CLI prints a bare traceback onto
+    the user's stderr after a command that succeeded (and for `SystemExit` prints
+    nothing at all, killing the fetch thread silently). Under pytest that hook is
+    replaced by the threadexception plugin, which turns an escaped thread
+    exception into a warning; promoting that warning to an error is what lets this
+    test see it. Measured: narrowing `except BaseException` to `except Exception`
+    reddens the `keyboard-interrupt`, `system-exit` and `base-exception` cases and
+    is silent without the mark.
+
+    Where each of these *is* still expected to surface is pinned separately: at
+    the main-thread cache read below, at the cache write after that, and at the
+    CLI boundary in test_cli_errors.py.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=exception)
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+    _assert_fetched_once(request)
 
 
 @pytest.mark.parametrize(
@@ -1169,36 +1340,68 @@ def test_update_check_advises_once_for_a_bare_group_invocation(monkeypatch, tmp_
     [KeyboardInterrupt(), SystemExit(73), CancelledError("cancelled")],
     ids=["keyboard-interrupt", "system-exit", "cancelled"],
 )
-def test_update_check_propagates_process_control_exceptions(
+def test_update_check_propagates_process_control_from_the_cache_read(
     monkeypatch, tmp_path, exception
 ):
     """The fail-open arms swallow failures, not process control.
 
-    `except Exception` already lets `KeyboardInterrupt` and `SystemExit` through
-    (both are `BaseException`), which is why it is written that way rather than as
-    a bare `except:`. `concurrent.futures.CancelledError` is `Exception`-derived on
-    this runtime, so the dedicated `except CancelledError: raise` arm is the only
-    thing that keeps a cancelled command from being reported as a success.
+    `_read_update_check_cache` narrows its arm to
+    `except (KeyError, OSError, TypeError, ValueError)`, and all three of these
+    fall outside it. Widening it to `except Exception` would swallow the
+    cancellation; a bare `except:` would swallow all three and report a cancelled
+    or exiting command as a clean success.
+
+    Anchored on the cache read because the read is a MAIN-THREAD step and the
+    fetch is not. This test used to inject at `requests.get`, which is now the
+    wrong seam twice over: the worker discards whatever it raises (see
+    `test_update_check_abandons_a_fetch_that_raises_anything`), and none of these
+    three can arise inside a worker blocked in a socket read in the first place.
+    The read is where a Ctrl-C, a `sys.exit()` from a signal handler, or a
+    cancellation of the surrounding task genuinely can land.
+
+    The record is seeded so the read has something to parse -- a missing file
+    returns before `json.loads` is reached. Seeding it STALE and arming the fetch
+    to fail loudly makes `request.assert_not_called()` a real guard: if the read
+    ever stopped raising, control would fall through to the refresh and the test
+    would fail at the fetch rather than passing vacuously.
 
     Called directly rather than through `CliRunner`, because the claim is about
-    what leaves `_check_for_update` -- Click's standalone mode would translate
-    each of these into an exit status and hide which one escaped.
+    what leaves `_check_for_update`; Click's standalone mode would translate each
+    of these into an exit status and hide which one escaped. What the CLI then
+    does with each is a separate contract, pinned in test_cli_errors.py:
+    `SystemExit` and `CancelledError` become the exit status, while
+    `KeyboardInterrupt` is caught by `upgrade_check` so a command that already
+    succeeded still exits 0.
     """
     decorators = _configure_update_check(monkeypatch, tmp_path)
-    monkeypatch.setattr(decorators.requests, "get", Mock(side_effect=exception))
+    _write_cache_record(
+        _cache_path(tmp_path), CHECKED_AT - UPDATE_CHECK_CACHE_TTL_SECONDS - 1, "1.1.0"
+    )
+    request = Mock(side_effect=AssertionError("must not be reached"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def raise_during_the_read(*_args, **_kwargs):
+        raise exception
+
+    monkeypatch.setattr(decorators.json, "loads", raise_during_the_read)
 
     with pytest.raises(type(exception)) as raised:
         decorators._check_for_update()
 
     assert raised.value is exception
+    request.assert_not_called()
 
 
 def test_update_check_propagates_cancellation_from_the_cache_write(monkeypatch, tmp_path):
-    """Cancellation during the *write* propagates too, not just during the fetch.
+    """Cancellation during the *write* propagates too, not just during the read.
 
     The write has its own fail-open arm (it returns False rather than raising, so
     the caller can treat a failed write as "stay off the network"), which is
     exactly the shape that would turn a cancelled command into a silent success.
+
+    The write is the second main-thread step of the advisory, after the read
+    pinned above; the fetch is not one at all, so it is deliberately not the
+    comparison here.
     """
     decorators = _configure_update_check(monkeypatch, tmp_path)
     cancelled = CancelledError("cancelled")
@@ -1293,378 +1496,13 @@ def test_update_check_advisory_is_silent_when_local_version_is_current(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     # `output` is the interleaved stdout+stderr stream and the command itself
     # prints nothing, so total emptiness is assertable -- a stronger claim than
     # the absence of the three fragments alone.
     assert result.output == ""
     for fragment in ADVISORY_FRAGMENTS:
         assert fragment not in result.output
-
-
-# --------------------------------------------------------------------------- #
-# Concurrent refresh exclusion.
-#
-# One exclusive-create marker beside the cache record elects one refresher out of
-# N simultaneous invocations. Real concurrency cannot be scheduled deterministically
-# in one process, so these tests drive the two halves of the race separately: the
-# LOSER's half by pre-creating the marker, and the WINNER-that-arrived-late half by
-# letting a peer land its record between the claim and the re-read.
-# --------------------------------------------------------------------------- #
-
-
-@pytest.mark.parametrize(
-    "marker_age",
-    [0, UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS],
-    ids=["just-claimed", "at-the-staleness-boundary"],
-)
-def test_update_check_lost_refresh_claim_makes_no_request(
-    monkeypatch, tmp_path, marker_age
-):
-    """Whoever loses the claim does not fetch: N invocations, one probe.
-
-    Both ages are held by another invocation. The boundary case is the one an
-    off-by-one reclaim would get wrong: a marker exactly at the staleness constant
-    is *not* yet stale, so treating the comparison as `<` instead of `<=` would let
-    a second invocation reclaim it and probe concurrently with the holder.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    # Stale, so the refresh branch is the one taken and the claim is attempted.
-    _write_cache_record(cache_path, 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"")
-    os.utime(marker, (CHECKED_AT - marker_age, CHECKED_AT - marker_age))
-    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert result.exit_code == 0
-    assert result.exception is None
-    request.assert_not_called()
-
-
-def test_update_check_lost_refresh_claim_still_advises(monkeypatch, tmp_path):
-    """Losing the claim skips the REFRESH, not the whole check.
-
-    The cached version is still compared against the local one and still printed.
-    An implementation that returned early on a lost claim would silence the
-    advisory for every invocation that happens to collide with a refresh -- and
-    under a shell that runs several `guard` commands at once, that is most of them.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"")
-    os.utime(marker, (CHECKED_AT, CHECKED_AT))
-    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
-    assert result.exit_code == 0
-    request.assert_not_called()
-
-
-def test_update_check_lost_refresh_claim_leaves_the_holders_marker(monkeypatch, tmp_path):
-    """The loser does not release a marker it never claimed.
-
-    This is the whole exclusion: a loser that unlinked the holder's marker in its
-    own `finally` would hand the claim straight back to the next arrival, and N
-    invocations would probe N times again -- with the added hazard that the holder
-    is still mid-fetch and will release a marker that by then belongs to someone
-    else.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"held")
-    os.utime(marker, (CHECKED_AT, CHECKED_AT))
-    request = Mock(side_effect=AssertionError("a lost refresh claim must not probe"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert marker.exists()
-    assert marker.read_bytes() == b"held"
-    assert result.exit_code == 0
-    request.assert_not_called()
-
-
-def test_update_check_stale_refresh_marker_is_reclaimed(monkeypatch, tmp_path):
-    """A marker left behind by a killed invocation cannot wedge refreshes forever.
-
-    One second past the staleness constant is enough: the marker is only an
-    election, so the recovery window is deliberately short compared to the cache
-    TTL. Without the reclaim, a single `SIGKILL` during a fetch would suppress
-    every future refresh for the lifetime of the cache directory.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"")
-    abandoned_at = CHECKED_AT - (UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS + 1)
-    os.utime(marker, (abandoned_at, abandoned_at))
-    assert UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS < UPDATE_CHECK_CACHE_TTL_SECONDS
-    request = Mock(return_value=_response("1.8.0"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
-    assert result.exit_code == 0
-    assert "A new version of praetorian-cli is available: 1.8.0" in result.output
-
-
-def test_update_check_future_dated_refresh_marker_is_reclaimed(monkeypatch, tmp_path):
-    """A marker stamped in the FUTURE ages out too, instead of wedging refreshes.
-
-    A negative age is what a filesystem clock running ahead of ours, a restored
-    backup, or a copied home directory leaves behind, and it is unbounded in a way
-    a positive age is not: a marker a day in the future suppresses every refresh
-    for that whole day plus the staleness window if the bound only looks at the
-    positive side. The assertion is on the fetch count rather than on the claim's
-    return value, because the fetch is the behaviour the user loses.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"stamped ahead")
-    a_day_ahead = CHECKED_AT + 24 * 60 * 60
-    os.utime(marker, (a_day_ahead, a_day_ahead))
-    request = Mock(return_value=_response("1.9.0"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
-    assert result.exit_code == 0
-    assert "A new version of praetorian-cli is available: 1.9.0" in result.output
-    # Reclaimed, used, and released -- not merely reclaimed.
-    assert not marker.exists()
-
-
-@pytest.mark.parametrize(
-    "skew_seconds",
-    [5, 30, UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS],
-    ids=["five-seconds-ahead", "thirty-seconds-ahead", "at-the-negative-boundary"],
-)
-def test_update_check_refresh_marker_stamped_by_a_fast_clock_still_holds(
-    monkeypatch, tmp_path, skew_seconds
-):
-    """A LIVE holder's marker is not reclaimed merely for reading as future-dated.
-
-    The tolerance is symmetric by policy, not by accident. A network filesystem
-    whose clock runs a few seconds ahead of this host stamps every marker in our
-    future, and a bound that tolerated only the positive side (`0 <= age <= S`)
-    would reclaim all of them the moment they were created -- the exclusion
-    failing open, N invocations probing together, which is the one thing the
-    marker exists to prevent. Modest skew is therefore *held*, and the negative
-    edge is inclusive, so a skew of exactly the staleness constant still holds.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    # Stale, so the refresh branch is the one taken and the claim is attempted.
-    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
-    marker = _refresh_marker_path(tmp_path)
-    marker.write_bytes(b"held")
-    stamped_ahead = CHECKED_AT + skew_seconds
-    os.utime(marker, (stamped_ahead, stamped_ahead))
-    request = Mock(side_effect=AssertionError("a live holder's marker must not be reclaimed"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert result.exit_code == 0
-    assert result.exception is None
-    request.assert_not_called()
-    # The holder's marker is left exactly as it was, mtime included.
-    assert marker.read_bytes() == b"held"
-    assert marker.stat().st_mtime == stamped_ahead
-
-
-def test_update_check_refresh_marker_is_released_when_the_fetch_raises(
-    monkeypatch, tmp_path
-):
-    """The claim is released on the failure paths too, not only on success.
-
-    The release lives in a `finally`, which is what this asserts: a marker left
-    behind by a raising fetch would suppress refreshes until it aged out of the
-    staleness window, turning one unreachable index into a stall on every
-    invocation in that window.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    _write_cache_record(_cache_path(tmp_path), 0, None)
-    marker = _refresh_marker_path(tmp_path)
-    request = Mock(side_effect=OSError("name or service not known"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert not marker.exists()
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert request.call_count == 1
-
-
-def test_update_check_released_marker_lets_the_next_stale_invocation_refresh(
-    monkeypatch, tmp_path
-):
-    """The consequence of the release: the next stale invocation can still refresh.
-
-    The TTL throttle is deliberately stepped over between the two invocations, so
-    the only thing that could stop the second refresh is a marker the first one
-    failed to release -- and under the frozen clock any leftover marker is inside
-    the staleness window, so the claim would be lost and the request count would
-    stay at one.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    _write_cache_record(cache_path, 0, None)
-    request = Mock(side_effect=OSError("name or service not known"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    first = CliRunner().invoke(_successful_command(), obj=object())
-    assert first.exit_code == 0
-    assert request.call_count == 1
-
-    # Age the throttle record back out of the TTL window, so the second
-    # invocation reaches the claim at all.
-    _write_cache_record(cache_path, 0, None)
-    request.side_effect = None
-    request.return_value = _response("1.9.0")
-
-    second = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert request.call_count == 2
-    assert second.exit_code == 0
-    assert "A new version of praetorian-cli is available: 1.9.0" in second.output
-
-
-def _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, peer_at, peer_version):
-    """Win the claim, then let a peer land `peer_version` before the re-read.
-
-    This is the late-arrival half of the race: two invocations read the same stale
-    record, one wins the claim and fetches, and the other wins it *afterwards* --
-    by which point the answer it needs is already on disk. Patching the claim is
-    the only deterministic seam for it, because the peer's write has to land
-    strictly between this invocation's claim and its re-read.
-    """
-    real_claim = decorators._claim_update_refresh_marker
-
-    def claim_then_peer_refreshes(path):
-        claimed = real_claim(path)
-        _write_cache_record(cache_path, peer_at, peer_version)
-        return claimed
-
-    monkeypatch.setattr(
-        decorators, "_claim_update_refresh_marker", claim_then_peer_refreshes
-    )
-
-
-def test_update_check_claim_winner_stands_down_for_a_peers_fresh_record(
-    monkeypatch, tmp_path
-):
-    """A claim won *after* a peer refreshed makes ZERO requests.
-
-    Without the re-read inside the claim, the exclusion only narrows the race
-    window instead of closing it: every invocation that queues up behind the
-    holder claims the marker in turn the moment it is released, and each one
-    fetches on the strength of the stale record it read before it ever waited.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    _write_cache_record(cache_path, 0, "1.2.0")
-    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-    _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, CHECKED_AT, "1.5.0")
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    request.assert_not_called()
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert not _refresh_marker_path(tmp_path).exists()
-
-
-def test_update_check_claim_winner_advises_the_peers_version(monkeypatch, tmp_path):
-    """Standing down still advises -- with the PEER's version, not the stale one.
-
-    The invocation read 1.2.0 at entry and the peer replaced it with 1.5.0 while
-    the claim was being taken. Serving the entry-time value would advertise a
-    version the process already knows to be superseded, and would keep doing so
-    for as long as invocations kept colliding.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    _write_cache_record(cache_path, 0, "1.2.0")
-    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-    _claim_then_let_a_peer_refresh(decorators, monkeypatch, cache_path, CHECKED_AT, "1.5.0")
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    assert "A new version of praetorian-cli is available: 1.5.0" in result.output
-    assert "1.2.0" not in result.output
-    assert result.exit_code == 0
-    request.assert_not_called()
-
-
-def test_update_check_peer_record_freshness_is_judged_by_the_clock_read_after_the_claim(
-    monkeypatch, tmp_path
-):
-    """The re-read samples the clock AGAIN; it must not reuse the pre-claim `now`.
-
-    Time passes while an invocation waits for the claim, so the peer's record can
-    carry a timestamp *later* than the `now` this invocation captured on entry.
-    Judged against that stale `now`, the age is negative, the future-timestamp rule
-    scores the peer's record as stale, and the invocation refetches -- which is the
-    exact stampede the re-read exists to prevent, restored in the one case where
-    contention is highest. Judged against a fresh reading, the age is positive and
-    the invocation stands down.
-
-    The clock is keyed on whether the peer has written rather than on call order,
-    so the discrimination does not depend on how many times `time.time()` happens
-    to be consulted.
-    """
-    decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    _write_cache_record(cache_path, 0, "1.2.0")
-    request = Mock(side_effect=AssertionError("a peer's fresh record must not be re-fetched"))
-    monkeypatch.setattr(decorators.requests, "get", request)
-
-    peer_written = []
-    monkeypatch.setattr(
-        decorators.time, "time", lambda: CHECKED_AT + 10 if peer_written else CHECKED_AT
-    )
-
-    real_claim = decorators._claim_update_refresh_marker
-
-    def claim_then_peer_refreshes(path):
-        claimed = real_claim(path)
-        # Written 5s after this invocation's entry -- ahead of the pre-claim `now`,
-        # behind the clock as it reads once the claim has been taken.
-        _write_cache_record(cache_path, CHECKED_AT + 5, "1.5.0")
-        peer_written.append(True)
-        return claimed
-
-    monkeypatch.setattr(
-        decorators, "_claim_update_refresh_marker", claim_then_peer_refreshes
-    )
-
-    result = CliRunner().invoke(_successful_command(), obj=object())
-
-    request.assert_not_called()
-    assert "A new version of praetorian-cli is available: 1.5.0" in result.output
-    assert result.exit_code == 0
-    # The peer's record is left exactly as the peer wrote it: standing down writes
-    # nothing, so the peer's timestamp is not walked backwards to this
-    # invocation's older `now`.
-    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
-        "checked_at": CHECKED_AT + 5,
-        "latest_version": "1.5.0",
-    }
 
 
 # --------------------------------------------------------------------------- #
@@ -1708,7 +1546,7 @@ def test_update_check_non_absolute_xdg_cache_home_falls_back_to_the_home_cache(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert "A new version of praetorian-cli is available: 2.0.0" in result.output
     assert json.loads(resolved.read_text(encoding="utf-8"))["latest_version"] == "2.0.0"
     # Nothing was resolved against the working directory.
@@ -1829,7 +1667,7 @@ def test_update_check_symlinked_cache_ancestor_still_works(monkeypatch, tmp_path
 
     result = CliRunner().invoke(_successful_command(), obj=object())
 
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert result.exit_code == 0
     assert "A new version of praetorian-cli is available: 2.1.0" in result.output
     assert json.loads(
@@ -2060,7 +1898,7 @@ def test_update_check_cache_record_symlinked_to_a_valid_record_is_refused(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    _assert_fetched_once(request)
     assert "A new version of praetorian-cli is available: 1.9.0" in result.output
     # The record was replaced, not written *through* the link.
     assert json.loads(planted.read_text(encoding="utf-8"))["latest_version"] == LOCAL_VERSION

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -2,11 +2,25 @@
 
 Offline only: every test redirects `XDG_CACHE_HOME` at `tmp_path` and replaces
 `requests.get`, so no test reaches pypi.org or the real user cache directory.
+
+Three properties carry most of the weight here, because each of them was a real
+defect that reached a release:
+
+* the advisory is *throttled by the record of the attempt*, not by the record of
+  a success -- so the count of `requests.get` calls, not the presence of a cache
+  file, is what these tests assert,
+* the interactivity gate reads BOTH stdout and stderr, so `guard ... | jq` (a
+  piped stdout with stderr still a tty) is skipped,
+* a group callback that is merely delegating to a subcommand does not advise --
+  otherwise the advisory prints before the work the user asked for, and prints
+  twice when that subcommand succeeds.
 """
 
 import json
 import os
 import stat
+from concurrent.futures import CancelledError
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -20,6 +34,7 @@ from praetorian_cli.handlers.cli_decorators import UPDATE_CHECK_CACHE_TTL_SECOND
 UPDATE_URL = "https://pypi.org/pypi/praetorian-cli/json"
 DISABLE_ENV = "PRAETORIAN_CLI_DISABLE_UPDATE_CHECK"
 CHECKED_AT = 1_700_000_000.0
+LOCAL_VERSION = "1.0.0"
 
 # The three lines the advisory prints when pypi is ahead of the local install.
 ADVISORY_FRAGMENTS = (
@@ -27,34 +42,100 @@ ADVISORY_FRAGMENTS = (
     "You are currently running",
     'pip install --upgrade praetorian-cli',
 )
+# The one fragment that appears exactly once per advisory, so counting it counts
+# advisories.
+ADVISORY_LEAD = ADVISORY_FRAGMENTS[0]
+
+# The 0700/0600 guarantees are POSIX mode bits. Windows has no equivalent, and
+# `Path.chmod` there is close to a no-op -- so these are skipped rather than
+# deleted, which would drop the guarantee on the platforms that do enforce it.
+posix_modes_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX mode bits are not enforced on this platform"
+)
 
 
 def _cache_path(cache_root: Path) -> Path:
     return cache_root / "praetorian-cli" / "update-check.json"
 
 
-def _response(latest: str = "1.1.0") -> Mock:
+def _response(latest: str = "1.1.0", releases=None) -> Mock:
+    """A PyPI payload whose `releases` block is a decoy for `info.version`.
+
+    The default decoy carries a prerelease that outranks `info.version` and a key
+    `packaging` cannot parse at all, so an implementation that ranks release keys
+    instead of reading `info.version` either advertises the prerelease or raises
+    `InvalidVersion` into the fail-open arm -- and every test that uses this
+    fixture notices, not just the one that names the behaviour.
+    """
     response = Mock()
-    response.json.return_value = {"releases": {latest: {}}}
+    if releases is None:
+        releases = ["0.9.0", latest, "9.9.9rc1", "not-a-version"]
+    response.json.return_value = {
+        "info": {"version": latest},
+        "releases": {key: [] for key in releases},
+    }
     return response
 
 
-def _configure_update_check(monkeypatch, cache_root: Path, interactive: bool = True):
-    """Pin every input the advisory reads: cache root, opt-out, clock, version, TTY.
+def _response_without_info() -> Mock:
+    """The payload shape that raises `KeyError` inside `_fetch_latest_version`."""
+    response = Mock()
+    response.json.return_value = {"releases": {"9.9.9": []}}
+    return response
 
-    The TTY force is the load-bearing part. `CliRunner` replaces stderr with a
-    non-tty buffer, so `_stderr_is_interactive()` returns False inside *any*
-    `CliRunner.invoke` and the advisory returns at its first gate. Without this,
-    every test below would pass because the check never ran -- including the two
-    that assert the request is *not* made, which would then prove nothing at all.
+
+def _error_response() -> Mock:
+    """A 500 from pypi.org: a body that parses fine, behind a failing status.
+
+    The body deliberately carries a plausible-looking version, so a
+    `_fetch_latest_version` that skipped `raise_for_status()` would advertise an
+    error page's contents as the latest release.
+    """
+    response = Mock()
+    response.raise_for_status.side_effect = RuntimeError("500 Server Error")
+    response.json.return_value = {"info": {"version": "9.9.9"}, "releases": {}}
+    return response
+
+
+def _configure_inputs(monkeypatch, cache_root: Path):
+    """Pin every input except the interactivity gate: cache root, opt-out, clock, version.
+
+    The environment variables the gate itself reads are cleared here too, so an
+    ambient `CI=true` on a developer's shell cannot silently turn a positive
+    assertion below into a vacuous one.
     """
     import praetorian_cli.handlers.cli_decorators as decorators
 
     monkeypatch.setenv("XDG_CACHE_HOME", str(cache_root))
     monkeypatch.delenv(DISABLE_ENV, raising=False)
-    monkeypatch.setattr(decorators, "version", lambda _package: "1.0.0")
+    for name in ("CI", "GITHUB_ACTIONS", "TERM"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(decorators, "version", lambda _package: LOCAL_VERSION)
     monkeypatch.setattr(decorators.time, "time", lambda: CHECKED_AT)
-    monkeypatch.setattr(decorators, "_stderr_is_interactive", lambda: interactive)
+    return decorators
+
+
+def _configure_update_check(monkeypatch, cache_root: Path, interactive: bool = True):
+    """`_configure_inputs`, plus a forced answer for the interactivity gate.
+
+    The gate force is the load-bearing part, and it belongs in this shared helper
+    rather than in each test. `_session_is_interactive()` requires BOTH
+    `sys.stdout.isatty()` and `sys.stderr.isatty()`, and `CliRunner` replaces both
+    with non-tty buffers -- so inside *any* `CliRunner.invoke` the real gate is
+    closed and the advisory returns before it does anything. A helper that forced
+    only one of the two streams would leave it closed and every positive assertion
+    below would pass vacuously, including the ones asserting that a request is
+    *not* made, which would then prove nothing at all. Replacing the whole
+    predicate also means a future third condition cannot silently reopen that
+    hole.
+
+    The real predicate is not left untested by this: it has its own tests, which
+    deliberately do not use this helper -- see
+    `test_update_check_requires_both_streams_to_be_a_terminal` and
+    `test_update_check_skipped_by_non_interactive_environment`.
+    """
+    decorators = _configure_inputs(monkeypatch, cache_root)
+    monkeypatch.setattr(decorators, "_session_is_interactive", lambda: interactive)
     return decorators
 
 
@@ -69,6 +150,63 @@ def _successful_command(events=None):
         return "done"
 
     return command
+
+
+def _group_with_leaf(events, leaf_fails=False):
+    """A real Click group in the shape production uses, plus one subcommand.
+
+    Mirrors `praetorian_cli/handlers/aegis.py`: `invoke_without_command=True` so
+    the bare group runs an interactive default, `@cli_handler` on the group
+    callback *and* on the leaf, and `@click.pass_context` so the callback can read
+    `ctx.invoked_subcommand`. That decorator stack is what puts two
+    `upgrade_check` wrappers on the path of a single `guard aegis list`.
+    """
+    from praetorian_cli.handlers.cli_decorators import cli_handler
+
+    @click.group(invoke_without_command=True)
+    @cli_handler
+    @click.pass_context
+    def group(ctx, _sdk):
+        events.append("group")
+        if ctx.invoked_subcommand is None:
+            events.append("group-default")
+
+    @group.command("leaf")
+    @cli_handler
+    def leaf(_sdk):
+        events.append("leaf")
+        if leaf_fails:
+            raise click.ClickException("leaf failed")
+
+    return group
+
+
+class _Stream:
+    """The one method `_session_is_interactive` calls on `sys.stdout`/`sys.stderr`."""
+
+    def __init__(self, tty):
+        self._tty = tty
+
+    def isatty(self):
+        if self._tty == "raise":
+            raise ValueError("detached stream")
+        return self._tty
+
+
+class _SysShim:
+    """Stands in for the `sys` module so a tty can be simulated in-process.
+
+    `CliRunner` owns the real `sys.stdout`/`sys.stderr` for the duration of an
+    `invoke`, and there is no way to make its buffers report `isatty() is True`.
+    `_session_is_interactive` reads both streams off the module-global `sys`, so
+    replacing that global is how the tty cases become reachable at all -- and it
+    is what makes the *positive* case of these tests (a request IS made) real
+    rather than an artefact of a closed gate.
+    """
+
+    def __init__(self, stdout_tty, stderr_tty):
+        self.stdout = _Stream(stdout_tty)
+        self.stderr = _Stream(stderr_tty)
 
 
 def test_update_check_runs_after_success(monkeypatch, tmp_path):
@@ -119,6 +257,57 @@ def test_update_check_disabled_by_explicit_environment_switch(monkeypatch, tmp_p
     request.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "TRUE", " yes ", "on"],
+    ids=["one", "true", "upper-true", "padded-yes", "on"],
+)
+def test_update_check_opt_out_accepts_conventional_truthy_values(
+    monkeypatch, tmp_path, value
+):
+    """This is a privacy opt-out, so it accepts what a user would plausibly export.
+
+    A user who exports `=true` and still gets network requests has been silently
+    overruled by a parsing detail. Case and surrounding whitespace are normalized
+    for the same reason.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, value)
+    request = Mock(side_effect=AssertionError("opted-out update request must not run"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_not_called()
+    # Opting out is not merely quiet: nothing is written under the cache root
+    # either, because the check returns before the cache path is computed.
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    "value", ["0", "false", ""], ids=["zero", "false", "empty"]
+)
+def test_update_check_opt_out_ignores_values_that_do_not_mean_yes(
+    monkeypatch, tmp_path, value
+):
+    """The complement of the case above: a falsy value must not disable anything.
+
+    Without this, `="0"` reading as "set, therefore disabled" would silently
+    switch the advisory off for every user who wrote the value out explicitly.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setenv(DISABLE_ENV, value)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+
+
 def test_update_check_uses_fresh_cached_result_without_network(monkeypatch, tmp_path):
     decorators = _configure_update_check(monkeypatch, tmp_path)
     cache_path = _cache_path(tmp_path)
@@ -155,6 +344,38 @@ def test_update_check_refreshes_stale_cached_result_once_with_short_timeout(
     assert result.exit_code == 0
     request.assert_called_once_with(UPDATE_URL, timeout=2)
     assert json.loads(cache_path.read_text(encoding="utf-8"))["latest_version"] == "1.3.0"
+
+
+def test_update_check_reads_info_version_and_ignores_release_keys(monkeypatch, tmp_path):
+    """`info.version` is PyPI's latest STABLE release; the `releases` keys are not.
+
+    `max(Version(k) for k in releases)` ranks `2.0.0rc1` above `1.1.0`, so it would
+    nag every user to "upgrade" to a release candidate; and one unparseable key
+    (PyPI has them) raises `InvalidVersion` into the fail-open arm and silences the
+    advisory entirely. This payload contains both hazards, and the assertion is
+    that neither one is what gets advertised.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(
+        return_value=_response(
+            "1.1.0", releases=["1.1.0", "2.0.0rc1", "3.0.0.dev1", "not-a-version"]
+        )
+    )
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "A new version of praetorian-cli is available: 1.1.0" in result.output
+    assert "2.0.0rc1" not in result.output
+    assert "3.0.0.dev1" not in result.output
+    # The prerelease is not merely unadvertised, it is not cached either -- a
+    # cached prerelease would be served on every subsequent invocation for a day.
+    assert (
+        json.loads(_cache_path(tmp_path).read_text(encoding="utf-8"))["latest_version"]
+        == "1.1.0"
+    )
 
 
 def test_update_check_timeout_failure_is_fail_open(monkeypatch, tmp_path):
@@ -197,14 +418,19 @@ def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_
     assert all(sentinel not in request_repr for sentinel in sentinels)
 
 
-def test_update_check_cached_payload_is_private_and_atomically_replaced(
-    monkeypatch, tmp_path
-):
+def test_update_check_cached_payload_is_atomically_replaced_twice(monkeypatch, tmp_path):
+    """A refresh replaces the cache file TWICE, and every replace is atomic.
+
+    Two by design, not by accident: the first records the attempt *before* the
+    request goes out (which is what throttles a failing refresh), the second
+    records its result. Both go through `mkstemp` in the destination directory
+    plus `os.replace`, so a reader never sees a partially written file, and
+    neither leaves the temp entry behind.
+    """
     decorators = _configure_update_check(monkeypatch, tmp_path)
     cache_path = _cache_path(tmp_path)
-    cache_path.parent.mkdir(mode=0o755)
+    cache_path.parent.mkdir()
     cache_path.write_text("malformed", encoding="utf-8")
-    cache_path.chmod(0o644)
     request = Mock(return_value=_response("1.4.0"))
     monkeypatch.setattr(decorators.requests, "get", request)
     real_replace = os.replace
@@ -219,28 +445,244 @@ def test_update_check_cached_payload_is_private_and_atomically_replaced(
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
-    assert len(replacements) == 1
-    temporary_path, destination = replacements[0]
-    assert destination == cache_path
-    assert temporary_path.parent == cache_path.parent
-    assert temporary_path != cache_path
-    assert not temporary_path.exists()
-    assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
-    assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+    assert len(replacements) == 2
+    for temporary_path, destination in replacements:
+        assert destination == cache_path
+        assert temporary_path.parent == cache_path.parent
+        assert temporary_path != cache_path
+        assert not temporary_path.exists()
+    # No debris of any kind left beside the destination.
+    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
     payload = json.loads(cache_path.read_text(encoding="utf-8"))
     assert set(payload) == {"checked_at", "latest_version"}
     assert isinstance(payload["checked_at"], (int, float))
     assert payload["latest_version"] == "1.4.0"
 
 
-def test_update_check_malformed_cache_and_network_failure_preserve_success(
+@posix_modes_only
+def test_update_check_cache_is_private_to_the_user(monkeypatch, tmp_path):
+    """0700 directory, 0600 file -- and the directory mode is *repaired*, not assumed.
+
+    The directory is pre-created world-readable, which is what a `mkdir` whose mode
+    was masked by the user's umask leaves behind. The explicit `chmod` after the
+    `mkdir` is the only thing that closes it, so this asserts the end state rather
+    than the call.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(mode=0o755)
+    request = Mock(return_value=_response("1.4.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert cache_path.exists()
+    assert stat.S_IMODE(cache_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_update_check_records_the_attempt_before_making_the_request(
     monkeypatch, tmp_path
 ):
+    """The throttle record is on disk *before* `requests.get` is entered.
+
+    Asserted from inside the mocked `get`, because the ordering is the whole
+    mechanism: a record written only after a successful response cannot throttle
+    the failures -- a timeout, an HTTP error, an unparseable payload, or a cache
+    directory that cannot be written -- which is how this reached pypi.org on
+    every single invocation. The previous known version rides along in that first
+    record, so a refresh that then fails keeps advertising what was already known.
+    """
     decorators = _configure_update_check(monkeypatch, tmp_path)
     cache_path = _cache_path(tmp_path)
     cache_path.parent.mkdir()
-    cache_path.write_text("not-json", encoding="utf-8")
-    request = Mock(side_effect=OSError("offline"))
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    snapshots = []
+
+    def snapshot_then_respond(*_args, **_kwargs):
+        snapshots.append(json.loads(cache_path.read_text(encoding="utf-8")))
+        return _response("1.4.0")
+
+    request = Mock(side_effect=snapshot_then_respond)
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert snapshots == [{"checked_at": CHECKED_AT, "latest_version": "1.2.0"}]
+    # And the second record lands afterwards, carrying the fetched answer.
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": "1.4.0",
+    }
+
+
+def test_update_check_network_failure_is_throttled_across_invocations(
+    monkeypatch, tmp_path
+):
+    """An unreachable index is probed ONCE per TTL, not once per invocation.
+
+    The assertion is the request count across three separate invocations, not the
+    existence of a cache file: a cache written only on success leaves a file
+    behind on the *next* success while still probing on every failure, which is
+    exactly the defect this pins.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(side_effect=OSError("name or service not known"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert ADVISORY_LEAD not in result.output
+
+    assert request.call_count == 1
+    assert json.loads(_cache_path(tmp_path).read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": None,
+    }
+
+
+@posix_modes_only
+@pytest.mark.skipif(
+    getattr(os, "geteuid", lambda: 1)() == 0, reason="root ignores directory permissions"
+)
+def test_update_check_unwritable_cache_directory_stays_off_the_network(
+    monkeypatch, tmp_path
+):
+    """Where the cache cannot be created at all, ZERO requests are made -- ever.
+
+    Not one per invocation, and not one-then-stop: an environment whose probe rate
+    cannot be limited is one that must not be probed. The read-only parent is a
+    read-only `$XDG_CACHE_HOME`, an immutable container image layer, or a cache
+    directory owned by another user.
+    """
+    read_only_root = tmp_path / "read-only"
+    read_only_root.mkdir(mode=0o500)
+    decorators = _configure_update_check(monkeypatch, read_only_root)
+    request = Mock(side_effect=AssertionError("unthrottleable environment must not probe"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    try:
+        for _ in range(3):
+            result = CliRunner().invoke(_successful_command(), obj=object())
+            assert result.exit_code == 0
+            assert result.exception is None
+
+        request.assert_not_called()
+        assert not _cache_path(read_only_root).parent.exists()
+    finally:
+        # Restore write permission so pytest's tmp_path cleanup can remove it.
+        read_only_root.chmod(0o700)
+
+
+def test_update_check_unwritable_cache_makes_no_request(monkeypatch, tmp_path):
+    """A cache write that fails mid-way stops the refresh AND leaves no debris.
+
+    Zero requests, not one: the write is the throttle, so a write that cannot
+    complete is the signal to stay off the network. The `finally:
+    temp_path.unlink(missing_ok=True)` is what keeps the failure from
+    accumulating a `mkstemp` leftover in the user's cache directory on every
+    invocation, and the previous cache file is left byte-for-byte intact because
+    `os.replace` was never reached.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    # Stale, so the refresh branch is the one taken and a write is attempted.
+    original_bytes = json.dumps({"checked_at": 0, "latest_version": "1.0.0"}).encode()
+    cache_path.write_bytes(original_bytes)
+    request = Mock(return_value=_response("1.6.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    def failing_dump(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(decorators.json, "dump", failing_dump)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    # Fail open: the write failure never reaches the user or the exit status.
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
+    assert cache_path.read_bytes() == original_bytes
+
+
+def test_update_check_survives_a_platform_without_os_fchmod(monkeypatch, tmp_path):
+    """`os.fchmod` is POSIX-only, and the advisory must not depend on it.
+
+    Windows is simulated rather than skipped, because a skip is what let this
+    ship: an `os.fchmod` after `mkstemp` raised `AttributeError` there, the
+    fail-open arm swallowed it, the cache was therefore never written, and the
+    advisory hit pypi.org on every invocation while printing nothing at all.
+    `mkstemp` already creates its file 0600 regardless of umask, so nothing is
+    lost by not calling it.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    assert not hasattr(os, "fchmod")
+    request = Mock(return_value=_response("1.7.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    advisories = 0
+    for _ in range(3):
+        result = CliRunner().invoke(_successful_command(), obj=object())
+        assert result.exit_code == 0
+        assert result.exception is None
+        advisories += result.output.count(ADVISORY_LEAD)
+
+    # Every invocation advises (the first from the network, the rest from the
+    # cache it wrote), and only the first one reaches the network.
+    assert advisories == 3
+    assert request.call_count == 1
+    assert (
+        json.loads(_cache_path(tmp_path).read_text(encoding="utf-8"))["latest_version"]
+        == "1.7.0"
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["os-error", "runtime-error", "http-error", "payload-without-info"],
+)
+def test_update_check_failed_refresh_retains_the_previous_version(
+    monkeypatch, tmp_path, failure
+):
+    """A refresh that fails keeps advertising the version already known.
+
+    Every failure shape must behave identically, and each is a different arm of
+    the fetch: an `OSError` and a `RuntimeError` out of the request itself, a
+    non-2xx response (`raise_for_status`), and a payload whose `info` key is
+    missing (a `KeyError` from inside `_fetch_latest_version`). In each case the
+    exception is swallowed -- the command still succeeds and says nothing about it
+    -- the stale `1.2.0` is retained rather than dropped (dropping it would
+    silence a real, still-valid advisory for a full TTL every time pypi.org
+    hiccuped), and `checked_at` still advances, so the failure is throttled just
+    like a success.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": 0, "latest_version": "1.2.0"}),
+        encoding="utf-8",
+    )
+    if failure == "os-error":
+        request = Mock(side_effect=OSError("connection reset by peer"))
+    elif failure == "runtime-error":
+        request = Mock(side_effect=RuntimeError("connection pool exhausted"))
+    elif failure == "http-error":
+        request = Mock(return_value=_error_response())
+    else:
+        request = Mock(return_value=_response_without_info())
     monkeypatch.setattr(decorators.requests, "get", request)
 
     result = CliRunner().invoke(_successful_command(), obj=object())
@@ -248,17 +690,89 @@ def test_update_check_malformed_cache_and_network_failure_preserve_success(
     assert result.exit_code == 0
     assert result.exception is None
     request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert result.output.count(ADVISORY_LEAD) == 1
+    assert "A new version of praetorian-cli is available: 1.2.0" in result.output
+    # Nothing about the failure itself reaches the user.
+    assert "9.9.9" not in result.output
+    assert "Error" not in result.output
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "checked_at": CHECKED_AT,
+        "latest_version": "1.2.0",
+    }
 
 
-def test_update_check_skipped_when_stderr_is_not_interactive(monkeypatch, tmp_path):
-    """The advisory never runs for a command whose stderr is not a terminal.
+def test_update_check_fresh_unparseable_entry_is_silent_until_the_ttl_expires(
+    monkeypatch, tmp_path
+):
+    """An unparseable cached version throttles like any other record, then recovers.
+
+    A record whose version cannot be parsed is still a record of an attempt, so it
+    must not be treated as "no cache" -- that would probe on every invocation for
+    as long as the bad entry survived. It costs one TTL of silence, and no more:
+    once the entry ages out the refresh runs and the advisory returns.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": "not-a-version"}),
+        encoding="utf-8",
+    )
+    request = Mock(return_value=_response("1.8.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    inside_ttl = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert inside_ttl.exit_code == 0
+    assert inside_ttl.exception is None
+    assert inside_ttl.output == ""
+    request.assert_not_called()
+
+    # Age the entry past its TTL: the refresh now runs and the advisory recovers.
+    expired = CHECKED_AT + UPDATE_CHECK_CACHE_TTL_SECONDS + 1
+    monkeypatch.setattr(decorators.time, "time", lambda: expired)
+
+    after_ttl = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert after_ttl.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert "A new version of praetorian-cli is available: 1.8.0" in after_ttl.output
+
+
+def test_update_check_fresh_null_version_entry_throttles(monkeypatch, tmp_path):
+    """`"latest_version": null` is a valid throttle record, not a corrupt one.
+
+    It is exactly what a failed refresh with nothing previously known writes, so
+    reading it as "unusable, refresh now" would turn every such failure into an
+    unthrottled probe on the very next invocation.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        json.dumps({"checked_at": CHECKED_AT, "latest_version": None}),
+        encoding="utf-8",
+    )
+    request = Mock(side_effect=AssertionError("a null-version record still throttles"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
+    request.assert_not_called()
+
+
+def test_update_check_skipped_when_session_is_not_interactive(monkeypatch, tmp_path):
+    """The advisory never runs for a session that is not a terminal.
 
     ENG-6643's "never runs where it is inappropriate" criterion: a piped or
-    redirected stderr (a script, a cron job, a `2>` capture) must get no network
+    redirected session (a script, a cron job, a `2>` capture) must get no network
     call and no cache file -- the advisory is for humans at a terminal only.
     """
     decorators = _configure_update_check(monkeypatch, tmp_path, interactive=False)
-    request = Mock(side_effect=AssertionError("non-interactive stderr must not check"))
+    request = Mock(side_effect=AssertionError("non-interactive session must not check"))
     monkeypatch.setattr(decorators.requests, "get", request)
 
     result = CliRunner().invoke(_successful_command(), obj=object())
@@ -269,6 +783,82 @@ def test_update_check_skipped_when_stderr_is_not_interactive(monkeypatch, tmp_pa
     # Not merely no *fresh* cache: the check returns before the cache path is
     # even computed, so nothing under XDG_CACHE_HOME is created or read.
     assert not _cache_path(tmp_path).exists()
+    assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("stdout_tty", "stderr_tty", "expect_request"),
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+        ("raise", True, False),
+    ],
+    ids=[
+        "both-tty",
+        "stdout-piped",
+        "stderr-redirected",
+        "neither-tty",
+        "isatty-raises",
+    ],
+)
+def test_update_check_requires_both_streams_to_be_a_terminal(
+    monkeypatch, tmp_path, stdout_tty, stderr_tty, expect_request
+):
+    """BOTH streams must be a terminal -- an stderr-only gate does not hold.
+
+    `guard list assets | jq` redirects stdout and leaves stderr a tty, which is
+    the piped, scripted, high-volume case whose cadence the gate exists to stop
+    leaking. This test deliberately does NOT use the shared gate force: it drives
+    the real `_session_is_interactive` through a substituted `sys`, so the
+    `both-tty` row is a genuine positive (a request IS made) and the other rows
+    are genuine negatives.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "sys", _SysShim(stdout_tty, stderr_tty))
+    request = Mock(return_value=_response("1.9.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    if expect_request:
+        request.assert_called_once_with(UPDATE_URL, timeout=2)
+        assert "A new version of praetorian-cli is available: 1.9.0" in result.output
+    else:
+        request.assert_not_called()
+        assert result.output == ""
+        assert not _cache_path(tmp_path).parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [("CI", "1"), ("CI", "true"), ("GITHUB_ACTIONS", "1"), ("TERM", "dumb")],
+    ids=["ci-one", "ci-true", "github-actions", "term-dumb"],
+)
+def test_update_check_skipped_by_non_interactive_environment(
+    monkeypatch, tmp_path, name, value
+):
+    """A runner that allocates a pty is still not a human at a terminal.
+
+    Both streams are forced to report a tty here, so the tty gate is open and each
+    environment variable is the *only* thing that can close it -- which is what
+    makes each row independent rather than incidentally passing on the tty check.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "sys", _SysShim(True, True))
+    monkeypatch.setenv(name, value)
+    request = Mock(side_effect=AssertionError("CI session must not check for updates"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    assert result.output == ""
     assert not _cache_path(tmp_path).parent.exists()
 
 
@@ -301,38 +891,187 @@ def test_update_check_future_timestamp_is_treated_as_stale(monkeypatch, tmp_path
     assert payload == {"checked_at": CHECKED_AT, "latest_version": "1.5.0"}
 
 
-def test_update_check_write_failure_leaves_no_temporary_file(monkeypatch, tmp_path):
-    """A failed cache write is swallowed, and leaves no debris behind.
+def test_update_check_skipped_when_group_delegates_to_a_failing_subcommand(
+    monkeypatch, tmp_path
+):
+    """A group callback delegating to a subcommand advises NOT AT ALL.
 
-    `_write_update_check_cache` creates its temp file with `mkstemp` in the
-    destination directory; the `finally: temp_path.unlink(missing_ok=True)` is
-    what keeps a mid-write failure from accumulating a temp file per invocation
-    in the user's cache directory.
+    Click runs a group callback BEFORE its subcommand, so without this gate
+    `guard aegis list` printed the advisory ahead of the work the user asked for
+    -- and still printed it when that work then failed, which is the one moment a
+    user least wants an unrelated nag. Measured on the ungated code: the advisory
+    appeared before the leaf ran and the request went out even though the command
+    exited non-zero.
     """
     decorators = _configure_update_check(monkeypatch, tmp_path)
-    cache_path = _cache_path(tmp_path)
-    cache_path.parent.mkdir()
-    # Stale, so the network path runs and a write is attempted.
-    original_bytes = json.dumps({"checked_at": 0, "latest_version": "1.0.0"}).encode()
-    cache_path.write_bytes(original_bytes)
-    request = Mock(return_value=_response("1.6.0"))
+    request = Mock(return_value=_response("1.2.0"))
     monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
 
-    def failing_dump(*_args, **_kwargs):
-        raise OSError("no space left on device")
+    result = CliRunner().invoke(_group_with_leaf(events, leaf_fails=True), ["leaf"], obj=object())
 
-    monkeypatch.setattr(decorators.json, "dump", failing_dump)
+    assert result.exit_code == 1
+    assert "leaf failed" in result.output
+    assert events == ["group", "leaf"]
+    request.assert_not_called()
+    for fragment in ADVISORY_FRAGMENTS:
+        assert fragment not in result.output
+
+
+def test_update_check_advises_exactly_once_for_a_succeeding_subcommand(
+    monkeypatch, tmp_path
+):
+    """Two `upgrade_check` wrappers on one invocation must still advise once.
+
+    `guard aegis list` runs the group callback's check and the leaf's check. The
+    group's is the one that is skipped, so the user gets exactly one advisory --
+    measured on the ungated code, the same invocation printed all three lines
+    twice.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
+
+    result = CliRunner().invoke(_group_with_leaf(events), ["leaf"], obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert events == ["group", "leaf"]
+    for fragment in ADVISORY_FRAGMENTS:
+        assert result.output.count(fragment) == 1
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+
+
+def test_update_check_advises_once_for_a_bare_group_invocation(monkeypatch, tmp_path):
+    """Skipping delegation does not silence the group's own default path.
+
+    `invoke_without_command=True` groups do real work when called bare (the TUI
+    entry points), so that invocation is a leaf as far as the advisory is
+    concerned. A gate keyed on "is a group" rather than "is delegating" would lose
+    it.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    request = Mock(return_value=_response("1.2.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+    events = []
+
+    result = CliRunner().invoke(_group_with_leaf(events), [], obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert events == ["group", "group-default"]
+    for fragment in ADVISORY_FRAGMENTS:
+        assert result.output.count(fragment) == 1
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [KeyboardInterrupt(), SystemExit(73), CancelledError("cancelled")],
+    ids=["keyboard-interrupt", "system-exit", "cancelled"],
+)
+def test_update_check_propagates_process_control_exceptions(
+    monkeypatch, tmp_path, exception
+):
+    """The fail-open arms swallow failures, not process control.
+
+    `except Exception` already lets `KeyboardInterrupt` and `SystemExit` through
+    (both are `BaseException`), which is why it is written that way rather than as
+    a bare `except:`. `concurrent.futures.CancelledError` is `Exception`-derived on
+    this runtime, so the dedicated `except CancelledError: raise` arm is the only
+    thing that keeps a cancelled command from being reported as a success.
+
+    Called directly rather than through `CliRunner`, because the claim is about
+    what leaves `_check_for_update` -- Click's standalone mode would translate
+    each of these into an exit status and hide which one escaped.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators.requests, "get", Mock(side_effect=exception))
+
+    with pytest.raises(type(exception)) as raised:
+        decorators._check_for_update()
+
+    assert raised.value is exception
+
+
+def test_update_check_propagates_cancellation_from_the_cache_write(monkeypatch, tmp_path):
+    """Cancellation during the *write* propagates too, not just during the fetch.
+
+    The write has its own fail-open arm (it returns False rather than raising, so
+    the caller can treat a failed write as "stay off the network"), which is
+    exactly the shape that would turn a cancelled command into a silent success.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cancelled = CancelledError("cancelled")
+    monkeypatch.setattr(
+        decorators.requests, "get", Mock(side_effect=AssertionError("must not be reached"))
+    )
+
+    def cancelling_dump(*_args, **_kwargs):
+        raise cancelled
+
+    monkeypatch.setattr(decorators.json, "dump", cancelling_dump)
+
+    with pytest.raises(CancelledError) as raised:
+        decorators._check_for_update()
+
+    assert raised.value is cancelled
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [PackageNotFoundError("praetorian-cli"), RuntimeError("boom"), OSError("offline")],
+    ids=["package-not-found", "runtime-error", "os-error"],
+)
+def test_update_check_failure_after_the_fetch_is_still_fail_open(
+    monkeypatch, tmp_path, exception
+):
+    """A failure raised OUTSIDE the fetch is swallowed too -- by the outer arm.
+
+    This is the complement of the propagation test above, and it needs a failure
+    that is not network-shaped: the fetch has its own guard, so every request-side
+    failure is caught before the outer arm is reachable, which would leave that
+    arm -- the one that decides whether the advisory can break a command at all --
+    with nothing pinning it.
+
+    Reading the local version is the realistic somewhere-else.
+    `importlib.metadata.version` raises `PackageNotFoundError` whenever the CLI
+    runs from a source tree with no installed distribution, which is the normal
+    state of a developer checkout; that must not turn a command the user already
+    completed into a failure.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators.requests, "get", Mock(return_value=_response("1.2.0")))
+
+    def failing_version(_package):
+        raise exception
+
+    monkeypatch.setattr(decorators, "version", failing_version)
 
     result = CliRunner().invoke(_successful_command(), obj=object())
 
-    # Fail open: the write failure never reaches the user or the exit status.
     assert result.exit_code == 0
     assert result.exception is None
-    request.assert_called_once_with(UPDATE_URL, timeout=2)
-    # No temp entry left in the destination directory, and the previous cache
-    # file is byte-for-byte intact -- the aborted write replaced nothing.
-    assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
-    assert cache_path.read_bytes() == original_bytes
+    assert result.output == ""
+
+
+def test_update_check_unparseable_local_version_is_silent(monkeypatch, tmp_path):
+    """An unparseable *local* version is swallowed as well, not raised.
+
+    Editable installs and vendored builds produce version strings `packaging`
+    rejects, and the comparison against them is outside the fetch guard -- so
+    `InvalidVersion` would escape as a command failure without the outer arm.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    monkeypatch.setattr(decorators, "version", lambda _package: "not-a-version")
+    monkeypatch.setattr(decorators.requests, "get", Mock(return_value=_response("1.2.0")))
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == ""
 
 
 @pytest.mark.parametrize(

--- a/praetorian_cli/sdk/test/test_update_check.py
+++ b/praetorian_cli/sdk/test/test_update_check.py
@@ -19,6 +19,8 @@ defect that reached a release:
 import json
 import os
 import stat
+import threading
+from collections import namedtuple
 from concurrent.futures import CancelledError
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
@@ -29,6 +31,7 @@ import pytest
 from click.testing import CliRunner
 
 from praetorian_cli.handlers.cli_decorators import (
+    UPDATE_CHECK_CACHE_MAX_BYTES,
     UPDATE_CHECK_CACHE_TTL_SECONDS,
     UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS,
 )
@@ -69,6 +72,40 @@ fd_counting_only = pytest.mark.skipif(
     not os.path.isdir("/dev/fd"), reason="descriptor counting needs /dev/fd"
 )
 
+# The cache write has two arms, chosen by `_cache_dir_descriptor_supported()`: a
+# directory-descriptor arm, and a path fallback for the platforms without the
+# descriptor primitives. The fallback is always reachable -- deleting `os.fchmod`
+# simulates it -- but the descriptor arm cannot be simulated where the primitives
+# do not exist, so cases specific to it are skipped there.
+descriptor_writes_only = pytest.mark.skipif(
+    not (hasattr(os, "O_NOFOLLOW") and hasattr(os, "fchmod")),
+    reason="the directory-descriptor arm needs os.O_NOFOLLOW and os.fchmod",
+)
+
+# A planted FIFO at the cache path is the availability vector that has no
+# exception to catch: it parks `open()` in the kernel until a writer arrives.
+fifos_only = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="planting a FIFO needs os.mkfifo"
+)
+
+# `os.mknod` is not available unprivileged, so the device vector is reached with a
+# symlink to a device that already exists. `/dev/zero` is the worst case on
+# purpose: an unbounded read of it returns bytes forever.
+DEVICE_PATH = "/dev/zero"
+
+
+def _is_character_device(path: str) -> bool:
+    try:
+        return stat.S_ISCHR(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+
+character_devices_only = pytest.mark.skipif(
+    not _is_character_device(DEVICE_PATH),
+    reason=f"{DEVICE_PATH} is not a character device on this platform",
+)
+
 
 def _cache_path(cache_root: Path) -> Path:
     return cache_root / "praetorian-cli" / "update-check.json"
@@ -94,6 +131,23 @@ def _write_cache_record(cache_path: Path, checked_at, latest_version) -> None:
     )
 
 
+def _victim_directory(tmp_path: Path) -> Path:
+    """A directory this user owns, world-readable and non-empty.
+
+    Owned and writable ON PURPOSE: nothing but the module's own refusal stands
+    between a refresh and writing in here, so a missing refusal shows up as a
+    changed mode or a changed file rather than as an `OSError` the fail-open arm
+    would have swallowed. The mode is set explicitly, not left to umask, because
+    it is asserted afterwards.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keepme").write_bytes(b"not ours")
+    (victim / "keepme").chmod(0o644)
+    victim.chmod(0o755)
+    return victim
+
+
 def _symlinked_leaf_cache(tmp_path: Path):
     """A cache root whose `praetorian-cli` leaf is a pre-created symlink.
 
@@ -102,10 +156,7 @@ def _symlinked_leaf_cache(tmp_path: Path):
     refresh and writing into it -- and it is world-readable and non-empty, so both
     its mode and its contents are observable afterwards.
     """
-    victim = tmp_path / "victim"
-    victim.mkdir()
-    victim.chmod(0o755)
-    (victim / "keepme").write_bytes(b"not ours")
+    victim = _victim_directory(tmp_path)
     cache_root = tmp_path / "cache"
     cache_root.mkdir()
     _cache_path(cache_root).parent.symlink_to(victim, target_is_directory=True)
@@ -472,39 +523,132 @@ def test_update_check_privacy_request_excludes_command_context(monkeypatch, tmp_
     assert all(sentinel not in request_repr for sentinel in sentinels)
 
 
-def test_update_check_cached_payload_is_atomically_replaced_twice(monkeypatch, tmp_path):
+_Replacement = namedtuple(
+    "_Replacement",
+    "mechanism raw_source raw_destination source_name destination_name "
+    "source_directory destination_directory",
+)
+
+
+def _directory_identity(entry) -> tuple:
+    """`(device, inode)` for a path or an open descriptor, or None for neither."""
+    if entry is None:
+        return None
+    info = os.stat(entry)
+    return (info.st_dev, info.st_ino)
+
+
+def _record_atomic_cache_replacements(monkeypatch):
+    """Record every atomic replacement a cache write performs, on either arm.
+
+    The two arms replace the record by different primitives -- `os.rename`
+    against a directory descriptor, and `os.replace` against full paths -- so
+    both are patched and each call is normalised to one shape. `source_directory`
+    and `destination_directory` are `(device, inode)` identities rather than path
+    strings, because "the same directory, so the rename is atomic" is a statement
+    about the directory the entry name is resolved against, which on the
+    descriptor arm is a descriptor and has no path at all.
+
+    The primitive actually used is recorded too, so a test can pin which arm ran
+    rather than merely that *something* replaced the file.
+    """
+    replacements = []
+    real_rename = os.rename
+    real_replace = os.replace
+
+    def record_rename(source, destination, *, src_dir_fd=None, dst_dir_fd=None):
+        replacements.append(
+            _Replacement(
+                "os.rename",
+                str(source),
+                str(destination),
+                Path(source).name,
+                Path(destination).name,
+                _directory_identity(src_dir_fd),
+                _directory_identity(dst_dir_fd),
+            )
+        )
+        real_rename(source, destination, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+
+    def record_replace(source, destination):
+        replacements.append(
+            _Replacement(
+                "os.replace",
+                str(source),
+                str(destination),
+                Path(source).name,
+                Path(destination).name,
+                _directory_identity(Path(source).parent),
+                _directory_identity(Path(destination).parent),
+            )
+        )
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "rename", record_rename)
+    monkeypatch.setattr(os, "replace", record_replace)
+    return replacements
+
+
+@pytest.mark.parametrize(
+    "descriptor_support",
+    [
+        pytest.param(True, marks=descriptor_writes_only, id="directory-descriptor"),
+        pytest.param(False, id="path-fallback"),
+    ],
+)
+def test_update_check_cached_payload_is_atomically_replaced_twice(
+    monkeypatch, tmp_path, descriptor_support
+):
     """A refresh replaces the cache file TWICE, and every replace is atomic.
 
     Two by design, not by accident: the first records the attempt *before* the
     request goes out (which is what throttles a failing refresh), the second
-    records its result. Both go through `mkstemp` in the destination directory
-    plus `os.replace`, so a reader never sees a partially written file, and
-    neither leaves the temp entry behind.
+    records its result. Each one writes a temporary entry beside the destination
+    and then renames it over the destination in a single same-directory
+    operation, so a reader never sees a partially written file and neither leaves
+    the temp entry behind.
+
+    Both write arms are exercised, because the property is the atomicity and not
+    the call. Where the directory-descriptor primitives exist, the temporary is
+    created and renamed *relative to an open descriptor on the cache directory*
+    (`os.rename` with `src_dir_fd`/`dst_dir_fd`, which takes bare entry names and
+    never resolves the path a second time -- that second resolution is the TOCTOU
+    window). Where they do not -- Windows -- the fallback keeps `tempfile.mkstemp`
+    plus `os.replace` on full paths. Windows is simulated rather than skipped, for
+    the reason spelled out in
+    `test_update_check_survives_a_platform_without_os_fchmod`.
     """
     decorators = _configure_update_check(monkeypatch, tmp_path)
+    if not descriptor_support:
+        monkeypatch.delattr(os, "fchmod", raising=False)
+    assert decorators._cache_dir_descriptor_supported() == descriptor_support
     cache_path = _cache_path(tmp_path)
     cache_path.parent.mkdir()
     cache_path.write_text("malformed", encoding="utf-8")
+    cache_directory = _directory_identity(cache_path.parent)
     request = Mock(return_value=_response("1.4.0"))
     monkeypatch.setattr(decorators.requests, "get", request)
-    real_replace = os.replace
-    replacements = []
-
-    def record_replace(source, destination):
-        replacements.append((Path(source), Path(destination)))
-        real_replace(source, destination)
-
-    monkeypatch.setattr(os, "replace", record_replace)
+    replacements = _record_atomic_cache_replacements(monkeypatch)
 
     result = CliRunner().invoke(_successful_command(), obj=object())
 
     assert result.exit_code == 0
     assert len(replacements) == 2
-    for temporary_path, destination in replacements:
-        assert destination == cache_path
-        assert temporary_path.parent == cache_path.parent
-        assert temporary_path != cache_path
-        assert not temporary_path.exists()
+    for replacement in replacements:
+        assert replacement.mechanism == ("os.rename" if descriptor_support else "os.replace")
+        assert replacement.destination_name == cache_path.name
+        assert replacement.source_name != replacement.destination_name
+        assert replacement.source_directory == cache_directory
+        assert replacement.destination_directory == cache_directory
+        assert not (cache_path.parent / replacement.source_name).exists()
+        if descriptor_support:
+            # A descriptor-relative rename takes BARE entry names; a full path
+            # here would be resolved against the process cwd, not the descriptor.
+            assert replacement.raw_source == replacement.source_name
+            assert replacement.raw_destination == cache_path.name
+        else:
+            assert Path(replacement.raw_destination) == cache_path
+            assert Path(replacement.raw_source).parent == cache_path.parent
     # No debris of any kind left beside the destination.
     assert sorted(p.name for p in cache_path.parent.iterdir()) == [cache_path.name]
     payload = json.loads(cache_path.read_text(encoding="utf-8"))
@@ -1274,6 +1418,72 @@ def test_update_check_stale_refresh_marker_is_reclaimed(monkeypatch, tmp_path):
     assert "A new version of praetorian-cli is available: 1.8.0" in result.output
 
 
+def test_update_check_future_dated_refresh_marker_is_reclaimed(monkeypatch, tmp_path):
+    """A marker stamped in the FUTURE ages out too, instead of wedging refreshes.
+
+    A negative age is what a filesystem clock running ahead of ours, a restored
+    backup, or a copied home directory leaves behind, and it is unbounded in a way
+    a positive age is not: a marker a day in the future suppresses every refresh
+    for that whole day plus the staleness window if the bound only looks at the
+    positive side. The assertion is on the fetch count rather than on the claim's
+    return value, because the fetch is the behaviour the user loses.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"stamped ahead")
+    a_day_ahead = CHECKED_AT + 24 * 60 * 60
+    os.utime(marker, (a_day_ahead, a_day_ahead))
+    request = Mock(return_value=_response("1.9.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert result.exit_code == 0
+    assert "A new version of praetorian-cli is available: 1.9.0" in result.output
+    # Reclaimed, used, and released -- not merely reclaimed.
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "skew_seconds",
+    [5, 30, UPDATE_CHECK_REFRESH_MARKER_STALE_SECONDS],
+    ids=["five-seconds-ahead", "thirty-seconds-ahead", "at-the-negative-boundary"],
+)
+def test_update_check_refresh_marker_stamped_by_a_fast_clock_still_holds(
+    monkeypatch, tmp_path, skew_seconds
+):
+    """A LIVE holder's marker is not reclaimed merely for reading as future-dated.
+
+    The tolerance is symmetric by policy, not by accident. A network filesystem
+    whose clock runs a few seconds ahead of this host stamps every marker in our
+    future, and a bound that tolerated only the positive side (`0 <= age <= S`)
+    would reclaim all of them the moment they were created -- the exclusion
+    failing open, N invocations probing together, which is the one thing the
+    marker exists to prevent. Modest skew is therefore *held*, and the negative
+    edge is inclusive, so a skew of exactly the staleness constant still holds.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    # Stale, so the refresh branch is the one taken and the claim is attempted.
+    _write_cache_record(_cache_path(tmp_path), 0, "1.2.0")
+    marker = _refresh_marker_path(tmp_path)
+    marker.write_bytes(b"held")
+    stamped_ahead = CHECKED_AT + skew_seconds
+    os.utime(marker, (stamped_ahead, stamped_ahead))
+    request = Mock(side_effect=AssertionError("a live holder's marker must not be reclaimed"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    request.assert_not_called()
+    # The holder's marker is left exactly as it was, mtime included.
+    assert marker.read_bytes() == b"held"
+    assert marker.stat().st_mtime == stamped_ahead
+
+
 def test_update_check_refresh_marker_is_released_when_the_fetch_raises(
     monkeypatch, tmp_path
 ):
@@ -1628,6 +1838,294 @@ def test_update_check_symlinked_cache_ancestor_still_works(monkeypatch, tmp_path
 
 
 # --------------------------------------------------------------------------- #
+# The leaf directory swapped for a symlink MID-FLIGHT.
+#
+# The section above plants the symlink before the run starts, which a check
+# ordered before the first write already catches. These two plant it in the
+# window the module opens itself: between creating the leaf and using it. Anything
+# that names the leaf BY PATH after that point resolves the attacker's link, so
+# what is asserted here is the VICTIM -- its mode and its bytes -- and not merely
+# the returned False, which one of the two windows already returned before the fix.
+# --------------------------------------------------------------------------- #
+
+
+def _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, leaf: Path, victim: Path):
+    """Hand the race to the attacker: swap `leaf` for a symlink as its `mkdir` returns.
+
+    `Path.mkdir` is the moment the leaf comes into existence and the last moment
+    before anything looks at it, so it is the window a racing attacker actually
+    gets. Returns the (single-element) record of the swap, so a test can prove the
+    race was RUN -- a swap that never fired would leave every assertion below
+    passing over an ordinary directory.
+
+    Fires once, deliberately: the module tolerates `FileExistsError` and retries
+    against whatever now sits at the path, and that second look must refuse it too.
+    """
+    real_mkdir = Path.mkdir
+    swapped = []
+
+    def mkdir(self, *args, **kwargs):
+        real_mkdir(self, *args, **kwargs)
+        if not swapped and self == leaf:
+            self.rmdir()
+            self.symlink_to(victim, target_is_directory=True)
+            swapped.append(str(self))
+
+    monkeypatch.setattr(Path, "mkdir", mkdir)
+    return swapped
+
+
+@symlinks_only
+@posix_modes_only
+@descriptor_writes_only
+def test_update_check_leaf_swapped_after_mkdir_leaves_the_targets_mode(
+    monkeypatch, tmp_path
+):
+    """Losing the race at `mkdir` refuses -- and does NOT re-mode the target.
+
+    The 0700 repair is the payload here. Validating the leaf by PATH and then
+    re-moding it by PATH resolves it twice, and the swap lands between the two: the
+    repair reaches through the link and locks a directory that is none of our
+    business down to 0700 (measured on the pre-fix code: 0o755 -> 0o700). Holding a
+    DESCRIPTOR across both steps is what closes it -- `os.fstat` and `os.fchmod`
+    address the inode that was vetted, and cannot be redirected by a later swap.
+
+    The mode is the assertion, not the return value: the return was already False
+    in this window before the fix, while the victim had already been re-moded.
+
+    Scoped to the descriptor arm because that is the only arm that CAN close this
+    window -- measured, forcing `_cache_dir_descriptor_supported()` false fails
+    both of these -- and every platform with POSIX mode bits has the primitives.
+    """
+    victim = _victim_directory(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    cache_path = _cache_path(cache_root)
+    swapped = _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, cache_path.parent, victim)
+
+    prepared = decorators._prepare_update_check_cache_dir(cache_path)
+
+    assert swapped, "the race never ran: the leaf mkdir was not reached"
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    assert sorted(p.name for p in victim.iterdir()) == ["keepme"]
+    assert not prepared
+
+
+@symlinks_only
+@posix_modes_only
+@descriptor_writes_only
+def test_update_check_leaf_swapped_after_mkdir_leaves_the_targets_file(
+    monkeypatch, tmp_path
+):
+    """The same swap through the WRITE: the target's own file survives it untouched.
+
+    A cache record the attacker has aimed elsewhere is not only a write in the
+    wrong directory -- it OVERWRITES whatever already answers to that name there,
+    with our bytes and our 0600 (measured on the pre-fix code: `b"not ours"` at
+    0o644 became our JSON at 0o600, destroying a file and closing it to its own
+    group). The write therefore re-validates on its own terms rather than trusting
+    its caller, and addresses the record by `dir_fd` so the directory it vetted is
+    the directory it writes in.
+    """
+    victim = _victim_directory(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    decorators = _configure_update_check(monkeypatch, cache_root)
+    cache_path = _cache_path(cache_root)
+    # Same NAME the record would be written under, so an unvalidated write
+    # clobbers it rather than landing beside it.
+    planted = victim / cache_path.name
+    planted.write_bytes(b"not ours")
+    planted.chmod(0o644)
+    swapped = _swap_the_leaf_for_a_symlink_after_mkdir(monkeypatch, cache_path.parent, victim)
+
+    written = decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+
+    assert swapped, "the race never ran: the leaf mkdir was not reached"
+    assert planted.read_bytes() == b"not ours"
+    assert stat.S_IMODE(planted.stat().st_mode) == 0o644
+    assert stat.S_IMODE(victim.stat().st_mode) == 0o755
+    # No temporary left behind in the target either, which is where `mkstemp`
+    # would have put it.
+    assert sorted(p.name for p in victim.iterdir()) == sorted(["keepme", cache_path.name])
+    assert not written
+
+
+# --------------------------------------------------------------------------- #
+# A hostile cache RECORD.
+#
+# The cache path is a predictable name under `$XDG_CACHE_HOME`, so anything that
+# can create one entry there chooses what `_read_update_check_cache` opens. Three
+# distinct consequences, and they are not interchangeable: two are availability
+# (the read never returns) and one is integrity (the read returns an attacker's
+# answer). Every case below therefore asserts on the *return*, bounded by a
+# deadline -- not on which guard rejected it.
+# --------------------------------------------------------------------------- #
+
+
+def _read_cache_within(decorators, cache_path: Path, seconds: float = 5.0):
+    """`_read_update_check_cache(cache_path)`, on a thread, under a deadline.
+
+    The availability vectors here fail by BLOCKING rather than by raising: a
+    planted FIFO parks `open()` in the kernel with nothing raised, so neither the
+    read's own `except (KeyError, OSError, TypeError, ValueError)` nor the
+    advisory's outer fail-open arm can turn it into a skipped check. An
+    unhardened implementation must therefore fail this call rather than hang the
+    suite, which is what the deadline is for -- and the thread is a daemon so a
+    hung mutant cannot keep the interpreter alive at exit either.
+    """
+    outcome = []
+
+    def call():
+        try:
+            outcome.append(("returned", decorators._read_update_check_cache(cache_path)))
+        except BaseException as error:  # reported below, never swallowed
+            outcome.append(("raised", error))
+
+    worker = threading.Thread(target=call, daemon=True)
+    worker.start()
+    worker.join(seconds)
+    assert not worker.is_alive(), f"the cache read did not return within {seconds}s"
+    kind, value = outcome[0]
+    assert kind == "returned", f"the cache read raised {value!r}"
+    return value
+
+
+@fifos_only
+def test_update_check_cache_record_that_is_a_fifo_is_refused_promptly(monkeypatch, tmp_path):
+    """A FIFO at the cache path returns None instead of blocking the CLI forever.
+
+    This is the one vector with no exception to catch: with a FIFO and no writer,
+    a blocking `open()` never returns and never raises, so `guard <anything>`
+    simply stops before running the user's command. The failure mode this pins is
+    a HANG, not a raise -- which is why the read is bounded by a deadline here
+    rather than merely asserted to be None.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    os.mkfifo(cache_path)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+@symlinks_only
+@character_devices_only
+def test_update_check_cache_record_symlinked_to_a_device_is_refused(monkeypatch, tmp_path):
+    """A cache path linked at a device returns None without reading the device.
+
+    `/dev/zero` yields bytes for as long as anything asks, so a reader that treats
+    whatever it opened as a small JSON file resolves the link and then allocates
+    until the process dies. The deadline is the assertion that matters: it fails
+    on an implementation that reads to completion, where a plain `is None` would
+    wait for the OOM killer.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.symlink_to(DEVICE_PATH)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+@symlinks_only
+def test_update_check_cache_record_symlinked_to_a_valid_record_is_refused(
+    monkeypatch, tmp_path
+):
+    """A symlinked record is refused even when the target parses -- the INTEGRITY vector.
+
+    Distinct from the availability cases above, and the reason the refusal cannot
+    be softened for targets that look harmless. An attacker who can create the
+    cache path but not write our directory plants a link to a record of their own,
+    stamped now and naming the installed version as the latest: the advisory is
+    then pinned off and the user is never told about a security release. The
+    consequence is asserted twice -- the record is not read, and the check
+    therefore is not fresh, so the refresh goes ahead and reaches the real index.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    planted = tmp_path / "planted-record.json"
+    _write_cache_record(planted, CHECKED_AT, LOCAL_VERSION)
+    cache_path.symlink_to(planted)
+    request = Mock(return_value=_response("1.9.0"))
+    monkeypatch.setattr(decorators.requests, "get", request)
+
+    assert _read_cache_within(decorators, cache_path) is None
+    assert not decorators._update_check_cache_is_fresh(
+        decorators._read_update_check_cache(cache_path), CHECKED_AT
+    )
+
+    result = CliRunner().invoke(_successful_command(), obj=object())
+
+    assert result.exit_code == 0
+    request.assert_called_once_with(UPDATE_URL, timeout=2)
+    assert "A new version of praetorian-cli is available: 1.9.0" in result.output
+    # The record was replaced, not written *through* the link.
+    assert json.loads(planted.read_text(encoding="utf-8"))["latest_version"] == LOCAL_VERSION
+
+
+@pytest.mark.parametrize(
+    "padded_to, accepted",
+    [
+        pytest.param(None, True, id="an-ordinary-record"),
+        pytest.param(UPDATE_CHECK_CACHE_MAX_BYTES, True, id="exactly-at-the-size-cap"),
+        pytest.param(
+            UPDATE_CHECK_CACHE_MAX_BYTES + 1, False, id="one-byte-over-the-size-cap"
+        ),
+    ],
+)
+def test_update_check_cache_record_is_read_only_up_to_the_size_cap(
+    monkeypatch, tmp_path, padded_to, accepted
+):
+    """The cap is pinned from BOTH sides: at the cap parses, one byte over does not.
+
+    A cap asserted only from above is satisfied by refusing everything, which
+    would disable the cache and restore the unthrottled probe -- so the accepted
+    cases are as load-bearing as the refused one. Trailing whitespace is valid
+    JSON, so between the two boundary cases the only thing that differs is the
+    byte count.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    record = json.dumps({"checked_at": CHECKED_AT, "latest_version": "1.2.0"}).encode()
+    if padded_to is not None:
+        record += b" " * (padded_to - len(record))
+        assert len(record) == padded_to
+    cache_path.write_bytes(record)
+
+    cached = _read_cache_within(decorators, cache_path)
+
+    if accepted:
+        assert cached == (CHECKED_AT, decorators._parse_version("1.2.0"))
+    else:
+        assert cached is None
+
+
+@posix_modes_only
+def test_update_check_cache_record_owned_by_another_user_is_refused(monkeypatch, tmp_path):
+    """A record this user does not own is refused, rather than parsed.
+
+    Only root can actually chown a file to somebody else, so the *other* half of
+    the comparison is moved instead: the effective uid the read checks against is
+    replaced, which is indistinguishable from the record's point of view and needs
+    no privilege. A shared or pre-seeded `$XDG_CACHE_HOME` -- a container image
+    layer, a multi-user build agent -- is where a foreign-owned record comes from,
+    and it is the same integrity problem as the symlink above without the symlink.
+    """
+    decorators = _configure_inputs(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+    cache_path.parent.mkdir(parents=True)
+    _write_cache_record(cache_path, CHECKED_AT, "1.2.0")
+    owner = os.stat(cache_path).st_uid
+    monkeypatch.setattr(decorators.os, "geteuid", lambda: owner + 1)
+
+    assert _read_cache_within(decorators, cache_path) is None
+
+
+# --------------------------------------------------------------------------- #
 # Descriptor accounting on the cache-write failure path.
 # --------------------------------------------------------------------------- #
 
@@ -1671,3 +2169,57 @@ def test_update_check_leaks_no_descriptor_when_fdopen_raises(monkeypatch, tmp_pa
     request.assert_not_called()
     # No `mkstemp` leftover, and no cache record: the write never completed.
     assert list(cache_path.parent.iterdir()) == []
+
+
+@fd_counting_only
+@descriptor_writes_only
+@pytest.mark.parametrize(
+    "operation",
+    ["prepare", "write", "failed-write"],
+    ids=["preparing-the-directory", "writing-the-record", "a-write-that-raises"],
+)
+def test_update_check_reclaims_the_cache_directory_descriptor(
+    monkeypatch, tmp_path, operation
+):
+    """The DIRECTORY descriptor is reclaimed too -- on success and on failure.
+
+    Validating the directory by descriptor rather than by path means there is now
+    a second long-lived descriptor per invocation, opened before the record is
+    written and useless afterwards. On a long-lived `guard` process this path runs
+    once per invocation, so a directory descriptor held one iteration too long is
+    a slow file-descriptor exhaustion that ends with the CLI unable to open
+    anything -- the advisory taking the whole tool down, which is the failure mode
+    this module exists to avoid.
+
+    All three arms count, because they close at three different places: the
+    preparation opens one only to answer a question and must drop it immediately,
+    the write must drop it after a successful record, and a write that RAISES must
+    drop it on the way out -- the arm a `try`/`finally` is there for.
+    """
+    decorators = _configure_update_check(monkeypatch, tmp_path)
+    cache_path = _cache_path(tmp_path)
+
+    if operation == "prepare":
+        def once():
+            assert decorators._prepare_update_check_cache_dir(cache_path)
+    elif operation == "write":
+        def once():
+            assert decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+    else:
+        def refuse_to_wrap(*_args, **_kwargs):
+            raise OSError("too many open files")
+
+        monkeypatch.setattr(decorators.os, "fdopen", refuse_to_wrap)
+
+        def once():
+            assert not decorators._write_update_check_cache(cache_path, CHECKED_AT, "1.2.0")
+
+    # One call before the baseline, so a one-time allocation on this path is
+    # counted as setup rather than as a leak.
+    once()
+    baseline = len(os.listdir("/dev/fd"))
+
+    for _ in range(200):
+        once()
+
+    assert len(os.listdir("/dev/fd")) == baseline


### PR DESCRIPTION
Closes ENG-6643.

PR 4 of 7 in the ENG-6569 OSS-readiness split. Predecessors: #273 (ENG-6571), #274 (ENG-6641), #275 (ENG-6570) — all merged.

## Premise verdict: PROCEED

Posted on ENG-6643 before implementation. Grading the ticket's four claims against `422e0fd`:

| Claim | Verdict | Evidence |
|---|---|---|
| The check fires on every invocation | VERIFIED | 106 `@cli_handler` sites; `cli_handler` applies `upgrade_check` unconditionally |
| It adds blocking latency to the success path | VERIFIED | synchronous `requests.get(..., timeout=3)`, `cli_decorators.py:66` |
| There is no way to disable it | VERIFIED | the only non-test `os.environ` reads in the package are `CHARIOT_PROXY` (`sdk/chariot.py:70`) and `CHARIOT_AEGIS_VERBOSE` (`ui/aegis/menu.py:15`) |
| ...even when the command just failed | **FALSE** | `upgrade_check` is composed **outermost** (`cli_decorators.py:82-86`), so a failing command's exception — including the `click.ClickException` `handle_error` raises — propagates past `result = func(...)` before the check runs |

The false claim does not weaken the ticket: the success-path stall and the cadence leak are the whole cost, and both are real. Restated layer-first, the problem is **a network side effect attached unconditionally to the CLI's success path with no cadence limit and no consent mechanism** — which makes `upgrade_check` the right layer and matches the ticket's declared scope.

Three alternatives considered and rejected on the record:

- **Delete the feature.** Out of scope; the ticket asks for it to be well-behaved, not gone.
- **Move it to a background thread or detached subprocess** (the AC's own suggestion). Rejected: once the result is cached, there is no network I/O left on the critical path to move. A thread buys orphan risk and output interleaving for nothing.
- **Exempt specific commands at `cli_handler`'s application site.** Rejected as the primary mechanism (it enumerates by hand and goes stale), retained as a component.

## What changed

`praetorian_cli/handlers/cli_decorators.py` — **366 insertions / 14 deletions** after round 2 (was 113/12 as first opened). `upgrade_check` now delegates to `_check_for_update()`, which in order:

1. returns early when **stderr is not a TTY**;
2. returns early when `PRAETORIAN_CLI_DISABLE_UPDATE_CHECK=1`;
3. reads a **24h-TTL** cache at `${XDG_CACHE_HOME:-~/.cache}/praetorian-cli/update-check.json`;
4. only on a cache miss reaches pypi.org, with the timeout cut **3s → 2s**;
5. writes the cache privately: `0700` directory, `0600` file, temp file in the **same** directory so `os.replace` is an atomic rename;

   **5b — added in round 2:** claims an exclusive-create (`O_EXCL`) marker before recording the attempt and re-checks freshness inside the claim, so N simultaneous invocations perform one refresh rather than N — measured 1 at n=8/16/32 across fetch durations of 0 ms, 50 ms, 200 ms and an immediately-failing request.

6. emits the advisory to stderr only when the remote version is strictly newer.

Cadence, opt-out, endpoint and timeout are named module constants. The old bare `except:` is now `except CancelledError: raise` / `except Exception: pass`.

`README.md` — **62 insertions** (36 as first opened; round 2 added the marker, path-validation and privacy wording): a `## Update checks` section (cadence, cache path, the three "never" properties) with `### Disabling it` and `### Privacy` subsections, plus its TOC entry.

## Acceptance criteria

- **AC1 — rate-limited/cached.** 24h TTL, timestamp file, atomic private write. A `checked_at` in the **future** is treated as stale (`0 <= age < TTL`), so a bad clock cannot pin a stale answer forever.
- **AC2 — no blocking latency on the common path, and never runs where inappropriate.** The common path is now a local JSON read; the network call happens at most once per 24h. The second clause is discharged by the **TTY gate**: an advisory no human reads is pure telemetry, and CI/scripted runs are exactly the high-volume invocations whose cadence the ticket objects to leaking. This is pip's, npm's update-notifier's, and homebrew's mechanism for the same feature.
- **AC3 — documented way to disable, and the privacy implication documented.** `PRAETORIAN_CLI_DISABLE_UPDATE_CHECK=1`, documented in README with the privacy note. Env var only, no root flag: the AC reads "flag and/or env var", and a root option would mean editing the root group in `handlers/chariot.py`, outside the ticket's stated scope.

## The one thing I most want a reviewer to challenge

**The TTY gate is novel for this repo** — there are zero `isatty` calls anywhere in the package before this PR. It is the right mechanism in my judgment and it is what comparable tools do, but it is a behavior change beyond the literal words of AC1/AC3, and it means the advisory silently stops appearing in any context that pipes stderr. If you would rather see an explicit command allow/deny list instead, say so and I will swap it.

## Known non-changes (deliberate, not oversights)

- **Pre-release versions are now cached for 24h too.** Previously every run re-derived `max(Version(...))` fresh. If a pre-release is published and then yanked, a user can see the advisory for up to a day after. Accepted: the cadence limit is the point of the ticket.
- ~~**A symlinked cache path is not rejected.**~~ **Superseded in round 2** (`656102e`). A probe showed the symlinked *directory* case is exploitable here and now — the victim's mode went `0755 -> 0700` and our file landed inside it — so deferring it to ENG-6636 was wrong: this PR authored the code that follows the link. The leaf component is now refused. The *destination-file* case turned out **not** to be exploitable (`os.replace` replaces the link rather than writing through it), so nothing was added there.
- ~~**A relative `XDG_CACHE_HOME` is used as given.**~~ **Superseded in round 2** (`656102e`). "Not worth a branch" was wrong, and wrong on cadence grounds rather than the spec-compliance grounds I argued: a relative value resolves the cache against the *current working directory*, so every invocation from a new directory sees a cold cache and refetches. AC1's rate limit simply does not exist for such a user. A non-absolute value is now ignored in favour of `~/.cache`.

## One out-of-scope fix rides this PR, disclosed

`praetorian_cli/sdk/test/test_sdk_exceptions.py` — the child-process helper `_cli_child` passes `env={"HOME": str(home)}` to isolate the keychain. Python locates the **user** site-packages relative to `$HOME`, so overriding HOME relocates it and takes the package's own dependencies with it: the child dies on `ModuleNotFoundError: No module named 'click'` unless the deps happen to be installed outside `$HOME` (i.e. in a venv). Two tests fail as a result.

Measured provenance — this is **not** PR 4's defect:

```
$ git diff --name-status origin/main            # in the PR 4 worktree
M  README.md
M  praetorian_cli/handlers/cli_decorators.py
M  praetorian_cli/sdk/test/test_cli_errors.py   # test_sdk_exceptions.py absent -> untouched
```

and the same two tests fail identically on the **primary checkout at `origin/main` (`422e0fd`)** with none of this PR present. Pre-existing by baseline, not just by `git status`.

It is fixed here rather than filed, for a reason specific to this repo: **there is no test CI**, so every correctness claim in this 7-PR series is a hand-quoted local run. A suite that exits 1 on a stock developer machine means neither this PR nor the three remaining ones can make a verification claim worth reading. The fix keeps the HOME isolation intact (`Path('~').expanduser()` still resolves to the temporary home) and only tells the child where the parent's packages live:

```python
env={"HOME": str(home), "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
```

Measured: `HOME`-only → `ModuleNotFoundError: No module named 'click'`; `HOME` + `PYTHONPATH` → imports resolve, isolation preserved. It ships as its own commit, separate from the ENG-6643 work.

**A correction that follows from this.** `test_sdk_exceptions.py` was created by #275 (ENG-6570), where I reported the suite green. These two tests live in that file and fail on `main` today, so that green claim was not sound — I cannot reconstruct whether I ran these two cases at all. Treat #275's verification line as suspect; this commit is what makes the claim true going forward.

## Verification

`praetorian-cli` has **no test CI** (measured at `422e0fd`: no non-reviewer check runs), so the numbers below are a local measurement, quoted by hand.

```
347 passed, 144 deselected in 2.09s
SUITE_EXIT_STATUS=0
```

Exit status was captured directly into a variable, not read after a pipeline — a zsh pipeline reports only its last stage and would have printed `EXIT=0` over a failing run.

Before the helper fix in the second commit, the same command gave `2 failed, 287 passed` at exit 1.

**33 update-check cases** were added in `praetorian_cli/sdk/test/test_update_check.py` (14 as first opened, 19 more in round 2), plus 4 in `test_cli_errors.py`. Round 2's 19 carry 11 mutation witnesses of their own, including two over-reach mutations aimed at the cases that must NOT change; the full table is in the round-2 adjudication comment. Each new assertion carries a RED witness — the implementation already existed, so a passing run proves nothing on its own. Mutating the implementation in memory reddened exactly the intended case:

| Mutation | Test that went RED |
|---|---|
| the `_stderr_is_interactive` early return deleted | `..._skipped_when_stderr_is_not_interactive` |
| `0 <= age < TTL` → `age < TTL` | `..._future_timestamp_is_treated_as_stale` |
| the `finally: temp_path.unlink(...)` neutralized | `..._write_failure_leaves_no_temporary_file` |
| `pypi > local` → `pypi >= local` / `!=` | the two `..._advisory_is_silent...` parametrizations, one each |
| `except CancelledError: raise` → `except BaseException: pass` | the KeyboardInterrupt case + both `..._process_control_exceptions_propagate` params |
| `except Exception: pass` → `raise` | `..._ordinary_update_advisory_failure_remains_fail_open` |

The TTY force in the shared test helper is itself load-bearing, measured: with it neutralized, 11 of the 14 fail. The three survivors are exactly the two that assert the request is *not* made plus the one that legitimately wants a non-TTY — i.e. without the force those two would have passed vacuously.

Provenance for the second commit, for the record:

```
$ base=$(git merge-base HEAD origin/main); echo $base
422e0fd4071b85b7007c2399fbd6de9c439aa819

$ git diff --numstat "${base}..73e9f69" -- praetorian_cli/sdk/test/test_sdk_exceptions.py
                    # empty: untouched by the ENG-6643 commit

$ git diff --name-status -M "${base}..HEAD" -- praetorian_cli/sdk/test/test_sdk_exceptions.py
M	praetorian_cli/sdk/test/test_sdk_exceptions.py      # +30/-3, the deliberate fix
```

Nothing is deferred in this PR, so no follow-up ticket is owed.

Both suites were run with the safe filter only:

```
python -m pytest -c praetorian_cli/sdk/test/pytest.ini \
  -m "not coherence and not cli and not tui" \
  --ignore=praetorian_cli/sdk/test/ui praetorian_cli/sdk/test/
```

The `coherence`, `cli` and `tui` markers create, modify and delete real entities in a live backend account and were never run.

