### PR TITLE
fix(sdk): deny secret-bearing tools in the MCP server's default allow-list (ENG-6639)

### DIFF
--- a/praetorian_cli/handlers/agent.py
+++ b/praetorian_cli/handlers/agent.py
@@ -7,6 +7,11 @@ from praetorian_cli.handlers.chariot import chariot
 from praetorian_cli.handlers.cli_decorators import cli_handler
 from praetorian_cli.handlers.utils import error
 
+# Default MCP tool allow profile: read-only query/list/get tools. Sensitive
+# tools (see praetorian_cli.sdk.mcp_server.SENSITIVE_TOOL_PATTERNS) are never
+# matched by these wildcards — they require an exact-name -a entry.
+DEFAULT_MCP_TOOLS = ['search_by_query', '*_list', '*_get']
+
 
 @chariot.group()
 def agent():
@@ -38,19 +43,26 @@ def mcp():
 
 @mcp.command()
 @cli_handler
-@click.option('--allowed', '-a', type=str, multiple=True, default=['search_by_query', '*_list', '*_get'])
+@click.option('--allowed', '-a', type=str, multiple=True, default=DEFAULT_MCP_TOOLS)
 def start(sdk, allowed):
     """ Starts the Guard MCP server
+
+    The default profile exposes read-only query/list/get tools. Tools that
+    return or manage secrets (accounts_*, credentials_*, integrations_*,
+    keys_*, webhook_*) are never matched by wildcard patterns — the default
+    profile included — and are only exposed by passing the exact tool name
+    with -a (e.g. -a credentials_get).
 
     \b
     Example usages:
         - guard agent mcp start
         - guard agent mcp start -a search_by_term -a risk_add
         - guard agent mcp start -a search_* -a risk_add
+        - guard agent mcp start -a credentials_get # exact name required for sensitive tools
 
     \b
     Claude code configuration/usage:
-        - claude mcp add chariot -- guard agent mcp start # read-only
+        - claude mcp add chariot -- guard agent mcp start # default read-only, non-sensitive tools
         - claude mcp add chariot -- guard agent mcp start -a search_by_query -a risk_add -a asset_add # select write tools
         - claude "show me my chariot assets from the example.com domain"
         - claude "show me my chariot assets with port 22 open"
@@ -61,10 +73,14 @@ def start(sdk, allowed):
     sdk.agents.start_mcp_server(allowed)
 
 @mcp.command()
-@click.option('--allowed', '-a', type=str, multiple=True, default=['search_by_query', '*_list', '*_get'])
+@click.option('--allowed', '-a', type=str, multiple=True, default=DEFAULT_MCP_TOOLS)
 @cli_handler
 def tools(sdk, allowed):
     """ Lists available mcp tools
+
+    Sensitive tools (accounts_*, credentials_*, integrations_*, keys_*,
+    webhook_*) never match wildcard patterns and appear only when named
+    exactly with -a.
 
     \b
     Example usages:

--- a/praetorian_cli/handlers/agent.py
+++ b/praetorian_cli/handlers/agent.py
@@ -51,7 +51,9 @@ def start(sdk, allowed):
     return or manage secrets (accounts_*, credentials_*, integrations_*,
     keys_*, webhook_*) are never matched by wildcard patterns — the default
     profile included — and are only exposed by passing the exact tool name
-    with -a (e.g. -a credentials_get).
+    with -a (e.g. -a credentials_get). Opting in accounts_assume_role is
+    higher-consequence than a read tool: it switches the session's tenant for
+    all subsequent tool calls.
 
     \b
     Example usages:

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -297,7 +297,7 @@ class Chariot:
         """ Start MCP server exposing SDK methods as tools
         
         Arguments:
-        allowable_tools: list
+        allowable_tools: list or tuple of str
             Optional list of tool names to expose. Tool names are in format
             'entity_method' (e.g., 'assets_add', 'risks_list'). If None, all
             non-sensitive tools are exposed; sensitive tools (see

--- a/praetorian_cli/sdk/chariot.py
+++ b/praetorian_cli/sdk/chariot.py
@@ -298,8 +298,11 @@ class Chariot:
         
         Arguments:
         allowable_tools: list
-            Optional list of tool names to expose. If None, all tools are exposed.
-            Tool names should be in format 'entity.method' (e.g., 'assets.add', 'risks.list')
+            Optional list of tool names to expose. Tool names are in format
+            'entity_method' (e.g., 'assets_add', 'risks_list'). If None, all
+            non-sensitive tools are exposed; sensitive tools (see
+            praetorian_cli.sdk.mcp_server.SENSITIVE_TOOL_PATTERNS) require an
+            exact-name allow entry and never match wildcard patterns.
         """
         from praetorian_cli.sdk.mcp_server import MCPServer
         import anyio

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -8,6 +8,24 @@ from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import Tool, TextContent
 
+# Tool-name patterns classified as sensitive: their tools return or manage
+# secret material (credential-broker payloads, API-key secrets, the webhook
+# auth PIN, integration records that embed that PIN) or change account
+# membership. A sensitive tool never matches a wildcard allow pattern: it is
+# exposed only when an allow entry names it exactly.
+SENSITIVE_TOOL_PATTERNS = (
+    'accounts_*',
+    'credentials_*',
+    'integrations_*',
+    'keys_*',
+    'webhook_*',
+)
+
+
+def is_sensitive_tool(tool_name: str) -> bool:
+    return any(fnmatch.fnmatch(tool_name, pattern) for pattern in SENSITIVE_TOOL_PATTERNS)
+
+
 class MCPServer:
     def __init__(self, chariot_instance, allowable_tools: Optional[List[str]] = None):
         self.chariot = chariot_instance
@@ -18,17 +36,18 @@ class MCPServer:
         self._register_tools()
 
     def _is_tool_allowed(self, tool_name: str) -> bool:
-        """Check if tool_name matches any of the allowed patterns using wildcards"""
-        if fnmatch.fnmatch(tool_name, "*accounts*"):
-            return False
+        """Two-tier allow check: sensitive tools (SENSITIVE_TOOL_PATTERNS) are
+        exposed only by an exact-name allow entry — wildcards never match them,
+        and a None/empty allowlist exposes none of them; non-sensitive tools keep the
+        original semantics (no allowlist means allowed, otherwise fnmatch
+        against the allow patterns)."""
+        if is_sensitive_tool(tool_name):
+            return bool(self.allowable_tools) and tool_name in self.allowable_tools
 
         if not self.allowable_tools:
             return True
-        
-        for pattern in self.allowable_tools:
-            if fnmatch.fnmatch(tool_name, pattern):
-                return True
-        return False
+
+        return any(fnmatch.fnmatch(tool_name, pattern) for pattern in self.allowable_tools)
 
     def _discover_tools(self):
         excluded_methods = {'start_mcp_server', 'api'}

--- a/praetorian_cli/sdk/mcp_server.py
+++ b/praetorian_cli/sdk/mcp_server.py
@@ -12,7 +12,10 @@ from mcp.types import Tool, TextContent
 # secret material (credential-broker payloads, API-key secrets, the webhook
 # auth PIN, integration records that embed that PIN) or change account
 # membership. A sensitive tool never matches a wildcard allow pattern: it is
-# exposed only when an allow entry names it exactly.
+# exposed only when an allow entry names it exactly. When adding a new entity
+# or method to the SDK that returns or manages secret material, add its family
+# to this tuple — nothing detects an unclassified secret-bearing tool
+# automatically.
 SENSITIVE_TOOL_PATTERNS = (
     'accounts_*',
     'credentials_*',

--- a/praetorian_cli/sdk/test/test_mcp.py
+++ b/praetorian_cli/sdk/test/test_mcp.py
@@ -1,7 +1,221 @@
 import pytest
 
+from praetorian_cli.handlers.agent import DEFAULT_MCP_TOOLS
 from praetorian_cli.sdk.mcp_server import MCPServer
 from praetorian_cli.sdk.test.utils import selected_test_target, setup_chariot, make_test_values, clean_test_entities
+
+# Sensitive tool names that MCPServer discovery would build from the fake
+# chariot below. Every one of these returns or embeds secret material
+# (broker credentials, API keys, webhook auth PINs, account assumption).
+SENSITIVE_SAMPLES = (
+    'credentials_get',
+    'credentials_list',
+    'credentials_add',
+    'keys_get',
+    'keys_list',
+    'keys_add',
+    'integrations_get',
+    'integrations_list',
+    'webhook_get_url',
+    'webhook_upsert',
+    'accounts_list',
+    'accounts_assume_role',
+)
+
+
+class _FakeSearch:
+    def __init__(self):
+        self.api = object()
+
+    def by_query(self, query):
+        """Search entities by query."""
+        return []
+
+
+class _FakeAssets:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an asset."""
+        return {}
+
+    def list(self, offset=None):
+        """List assets."""
+        return []
+
+
+class _FakeRisks:
+    def __init__(self):
+        self.api = object()
+
+    def add(self, name):
+        """Add a risk."""
+        return {}
+
+    def list(self, offset=None):
+        """List risks."""
+        return []
+
+
+class _FakeCredentials:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, credential_id):
+        """Get a credential, including its raw secret."""
+        return {}
+
+    def list(self, offset=None):
+        """List credentials."""
+        return []
+
+    def add(self, resource_key):
+        """Add a credential."""
+        return {}
+
+
+class _FakeKeys:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an API key."""
+        return {}
+
+    def list(self, offset=None):
+        """List API keys."""
+        return []
+
+    def add(self, name):
+        """Add an API key."""
+        return {}
+
+
+class _FakeIntegrations:
+    def __init__(self):
+        self.api = object()
+
+    def get(self, key):
+        """Get an integration, whose record embeds the webhook auth PIN."""
+        return {}
+
+    def list(self, offset=None):
+        """List integrations."""
+        return []
+
+
+class _FakeWebhook:
+    def __init__(self):
+        self.api = object()
+
+    def get_url(self):
+        """Get the webhook URL, which embeds the auth PIN."""
+        return ''
+
+    def upsert(self):
+        """Create or rotate the webhook."""
+        return ''
+
+
+class _FakeAccounts:
+    def __init__(self):
+        self.api = object()
+
+    def list(self, offset=None):
+        """List accounts."""
+        return []
+
+    def assume_role(self, account_email):
+        """Assume the role of another account."""
+        return None
+
+
+class _FakeChariot:
+    """Offline stand-in for the Chariot SDK object MCP discovery walks."""
+
+    def __init__(self):
+        self.search = _FakeSearch()
+        self.assets = _FakeAssets()
+        self.risks = _FakeRisks()
+        self.credentials = _FakeCredentials()
+        self.keys = _FakeKeys()
+        self.integrations = _FakeIntegrations()
+        self.webhook = _FakeWebhook()
+        self.accounts = _FakeAccounts()
+
+
+def _discovered(allowed):
+    """Discovered tool names for a fake chariot under the given allowlist."""
+    return MCPServer(_FakeChariot(), allowed).discovered_tools
+
+
+class TestMCPSensitiveTools:
+    """ENG-6639: sensitive tools must be deny-by-default in the MCP server.
+
+    Contract under test:
+    - mcp_server.SENSITIVE_TOOL_PATTERNS names the sensitive families
+      ('accounts_*', 'credentials_*', 'integrations_*', 'keys_*',
+      'webhook_*').
+    - A tool matching a sensitive pattern is NEVER exposed by wildcard
+      allow patterns, and NEVER exposed when allowable_tools is
+      None/empty; it is exposed ONLY when an allow entry equals the tool
+      name exactly (explicit opt-in, e.g. 'credentials_get').
+    - Non-sensitive tools keep current semantics: no allowlist means
+      allowed; otherwise fnmatch against the allow patterns.
+    - The CLI default profile (handlers.agent.DEFAULT_MCP_TOOLS =
+      ['search_by_query', '*_list', '*_get']) must therefore expose only
+      non-sensitive read tools.
+    """
+
+    def test_default_profile_exposes_read_tools(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS))
+        assert 'search_by_query' in tools
+        assert 'assets_get' in tools
+        assert 'assets_list' in tools
+        assert 'risks_list' in tools
+
+    def test_default_profile_denies_all_sensitive_tools(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS))
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed under the default read-only MCP profile'
+            )
+
+    def test_no_allowlist_still_denies_sensitive_tools(self):
+        tools = _discovered(None)
+        assert 'assets_list' in tools
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed with no allowlist configured'
+            )
+
+    def test_wildcards_never_match_sensitive_tools(self):
+        tools = _discovered(
+            ['credentials_*', 'keys_*', 'integrations_*', 'webhook_*', 'accounts_*', '*']
+        )
+        for name in SENSITIVE_SAMPLES:
+            assert name not in tools, (
+                f'{name} is exposed via a wildcard allow pattern'
+            )
+
+    def test_exact_name_exposes_only_that_tool(self):
+        tools = _discovered(['credentials_get'])
+        assert 'credentials_get' in tools
+        assert 'credentials_list' not in tools
+        assert 'keys_get' not in tools
+
+    def test_exact_name_composes_with_default_profile(self):
+        tools = _discovered(list(DEFAULT_MCP_TOOLS) + ['credentials_list'])
+        assert 'credentials_list' in tools
+        assert 'credentials_get' not in tools
+        assert 'assets_list' in tools
+
+    def test_wildcards_still_match_non_sensitive_tools(self):
+        tools = _discovered(['risks_*'])
+        assert 'risks_add' in tools
+        assert 'risks_list' in tools
+        assert 'assets_list' not in tools
 
 
 @pytest.mark.coherence


### PR DESCRIPTION
Implements [ENG-6639](https://linear.app/praetorianlabs/issue/ENG-6639): the MCP server exposed credential retrieval to the connected LLM under its documented read-only default profile.

## Problem

`MCPServer._is_tool_allowed` was fail-open for secrets: the only hard deny was the pattern `*accounts*`. The default allow profile for `guard agent mcp start` — `['search_by_query', '*_list', '*_get']`, documented as read-only — therefore matched and exposed:

- `credentials_get` / `credentials_list` — raw secret material from the credential broker
- `keys_get` / `keys_list` — API-key entities
- `integrations_get` / `integrations_list` — integration records that embed the webhook auth PIN (`webhook.get_record` is implemented over `integrations.list`)

Measured on the pre-change code: the default profile exposed exactly those 6 secret-bearing tools.

## Fix — two-tier allow model

`praetorian_cli/sdk/mcp_server.py` now carries an explicit classification, `SENSITIVE_TOOL_PATTERNS = ('accounts_*', 'credentials_*', 'integrations_*', 'keys_*', 'webhook_*')`, and `_is_tool_allowed` becomes:

- **Sensitive tool** (matches a sensitive pattern): exposed **only** when an allow entry names it exactly (e.g. `-a credentials_get`). Wildcard allow patterns never match it, and a `None`/empty allow-list exposes none of them.
- **Non-sensitive tool**: unchanged semantics — no allow-list means allowed; otherwise `fnmatch` against the allow patterns.

Supporting changes:

- `praetorian_cli/handlers/agent.py`: the duplicated default profile is hoisted into `DEFAULT_MCP_TOOLS`, and the `guard agent mcp start` / `guard agent mcp tools` help text now states the sensitive-tool contract (exact name required, default profile excluded).
- `praetorian_cli/sdk/chariot.py`: `start_mcp_server` docstring corrected (tool names are `entity_method`, not `entity.method`; `None` no longer means "everything").

## Deliberate behavior change: `accounts_*`

Previously `*accounts*` was unconditionally denied — unexposable even explicitly. It now follows the same exact-name opt-in as every other sensitive family (e.g. `-a accounts_list`), making the model uniform: an operator who explicitly and knowingly names a tool gets it, per the ticket's goal. The default remains denied, and the existing coherence test's `'assume_role' not in mcp.discovered_tools` assertion still holds under both the default and `['risks_*']` profiles.

## Why `settings_*` / `configurations_*` are not classified sensitive

They were reviewed and deliberately excluded: both return platform configuration and neither demonstrably returns secret material (no broker payloads, key secrets, or PINs in their entity code paths). Classifying them sensitive would break the documented read-only profile for no demonstrated secret exposure. If a secret-bearing field is later demonstrated there, the fix is one line in `SENSITIVE_TOOL_PATTERNS`.

## Tests (TDD)

New offline unit tests in `praetorian_cli/sdk/test/test_mcp.py` (`TestMCPSensitiveTools`, fake Chariot object, no backend) pin the contract:

- default profile exposes read tools but **none** of 12 sensitive sample names
- no allow-list still denies all sensitive tools
- wildcards — including `credentials_*` and bare `*` — never match a sensitive tool
- an exact name exposes only that tool, and composes with the default profile
- non-sensitive wildcard matching is unchanged (`risks_*` still works)

**RED** (pre-change): behavioral probe showed the default profile exposing the 6 secret-bearing tools above; the new assertions fail against the old `_is_tool_allowed`.
**GREEN**: `python3 -m pytest praetorian_cli/sdk/test/test_mcp.py -q -m 'not coherence'` → `7 passed, 2 deselected`. Regression (offline suites): `131 passed`.

The pre-existing `@pytest.mark.coherence` live-backend tests are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
