### PR TITLE
fix(sdk): store the keychain owner-only and require HTTPS for the backend URL (ENG-6636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ export PRAETORIAN_CLI_API_KEY_ID=your-api-key-id-here
 export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-here
 ```
 
+The backend API URL must be HTTPS; the CLI refuses to send credentials over
+plaintext HTTP. For local development against a loopback endpoint (`localhost`,
+`127.0.0.1`, `::1`), set `PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1`.
+
 For more advanced configuration options or managing access in SSO organizations see
 [the documentation on configuration](https://github.com/praetorian-inc/praetorian-cli/blob/main/docs/configure.md).
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ export PRAETORIAN_CLI_API_KEY_ID=your-api-key-id-here
 export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-here
 ```
 
-The backend API URL must be HTTPS; the CLI refuses to send credentials over
-plaintext HTTP. For local development against a loopback endpoint (`localhost`,
+The backend API URL and the Cognito emulator endpoint (`aws_endpoint_url`)
+must be HTTPS; the CLI refuses to send credentials over plaintext HTTP. For local development against a loopback endpoint (`localhost`,
 `127.0.0.1`, `::1`), set `PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1`.
 
 For more advanced configuration options or managing access in SSO organizations see

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -52,8 +52,9 @@ export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-secret-here
 
 Environment variables take precedence over keychain file settings.
 
-The backend URL (the `api` field, or `PRAETORIAN_CLI_API`) must be an HTTPS URL;
-the CLI refuses to send credentials over plaintext HTTP. The one exception is a
+The backend URL (the `api` field, or `PRAETORIAN_CLI_API`) and the Cognito
+emulator endpoint (the `aws_endpoint_url` field) must be HTTPS URLs; the CLI
+refuses to send credentials over plaintext HTTP. The one exception is a
 loopback endpoint (`localhost`, `127.0.0.1`, `::1`) for local development, which
 requires an explicit opt-in:
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -52,6 +52,15 @@ export PRAETORIAN_CLI_API_KEY_SECRET=your-api-key-secret-here
 
 Environment variables take precedence over keychain file settings.
 
+The backend URL (the `api` field, or `PRAETORIAN_CLI_API`) must be an HTTPS URL;
+the CLI refuses to send credentials over plaintext HTTP. The one exception is a
+loopback endpoint (`localhost`, `127.0.0.1`, `::1`) for local development, which
+requires an explicit opt-in:
+
+```bash
+export PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1
+```
+
 ## Multiple profiles
 
 Similar to the pattern used in AWS CLI configuration files, the keychain file is

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -1,8 +1,11 @@
+import os
 from configparser import ConfigParser
+from ipaddress import ip_address
 from os import environ
 from os.path import join, split
 from pathlib import Path
 from time import time
+from urllib.parse import urlsplit
 
 import boto3
 import requests
@@ -17,7 +20,61 @@ DEFAULT_KEYCHAIN_FILEPATH = join(Path.home(), '.praetorian', 'keychain.ini')
 
 API_KEY_ID = 'api_key_id'
 API_KEY_SECRET = 'api_key_secret'
-    
+
+HTTP_LOOPBACK_OPT_IN_ENV = 'PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK'
+
+
+def _is_loopback_host(hostname):
+    """ True for localhost or a loopback IP address (127.0.0.0/8, ::1). """
+    if not hostname:
+        return False
+    if hostname.lower() == 'localhost':
+        return True
+    # DNS names other than localhost (e.g. localhost.example.com) resolve to
+    # arbitrary addresses, so only a literal loopback IP counts.
+    try:
+        return ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _validated_backend_url(api):
+    """ Return `api` unchanged when it is safe to send credentials to; raise otherwise.
+        HTTPS only, except plaintext HTTP to a loopback endpoint (the local dev
+        emulator) under the explicit opt-in. """
+    try:
+        parsed = urlsplit(api or '')
+        # urlsplit defers port parsing; touching .port is what raises on a URL
+        # like https://host:not-a-port/x.
+        parsed.port
+    except ValueError:
+        raise ConfigurationError(
+            f'Invalid backend URL "{api}". Credentials are only sent over HTTPS; use an https:// URL.')
+
+    if parsed.scheme == 'https' and parsed.hostname:
+        return api
+
+    if parsed.scheme == 'http' and _is_loopback_host(parsed.hostname):
+        if environ.get(HTTP_LOOPBACK_OPT_IN_ENV) == '1':
+            return api
+        raise ConfigurationError(
+            f'Refusing to send credentials to the plaintext HTTP backend "{api}". Credentials are only '
+            f'sent over HTTPS. For local development against a loopback endpoint, set {HTTP_LOOPBACK_OPT_IN_ENV}=1.')
+
+    raise ConfigurationError(
+        f'Invalid backend URL "{api}". Credentials are only sent over HTTPS; use an https:// URL.')
+
+
+def _tighten_to_owner_only(path):
+    """ Repair a keychain file written group- or world-accessible by an older CLI. """
+    # Best-effort: the file is being read, not written, and configure() remains
+    # the authoritative enforcement point, so a keychain on a filesystem that
+    # refuses chmod must not brick every CLI command.
+    try:
+        if os.stat(path).st_mode & 0o077:
+            os.chmod(path, 0o600)
+    except OSError:
+        pass
 
 
 class Keychain:
@@ -61,6 +118,7 @@ class Keychain:
                 self.config.set(DEFAULT_PROFILE, 'api', DEFAULT_API)
                 self.config.set(DEFAULT_PROFILE, 'client_id', DEFAULT_CLIENT_ID)
             else:
+                _tighten_to_owner_only(self.filepath)
                 self.config.read(self.filepath)
 
         if not self.config.sections():
@@ -136,7 +194,7 @@ class Keychain:
 
     def base_url(self):
         """ Get the base URL for the backend. It is the "api" field in the keychain file. """
-        return self.get_option('api')
+        return _validated_backend_url(self.get_option('api'))
 
     def username(self):
         """ Get the username field from the keychain profile """
@@ -178,6 +236,9 @@ class Keychain:
                   account=None, api_key_id=None, api_key_secret=None):
         """ Update or insert a new profile to the keychain file at the default location.
             If the keychain file does not exist, create it. """
+        # Reject a plaintext backend before the keychain file is created or modified.
+        _validated_backend_url(api)
+
         new_profile = {
             'name': 'chariot',
             'client_id': client_id,
@@ -204,6 +265,23 @@ class Keychain:
 
         config[profile] = new_profile
 
-        Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(exist_ok=True, parents=True)
-        with open(DEFAULT_KEYCHAIN_FILEPATH, 'w') as f:
+        # mkdir's mode leaves a pre-existing directory alone; a new one is created
+        # owner-only to match the file it holds.
+        Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(mode=0o700, exist_ok=True, parents=True)
+        # O_CREAT's 0o600 applies to new files only; the fchmod is what tightens a
+        # pre-existing looser file. Secrets are about to be written, so an fchmod
+        # failure propagates rather than writing them into a world-readable file.
+        fd = os.open(DEFAULT_KEYCHAIN_FILEPATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            if hasattr(os, 'fchmod'):
+                os.fchmod(fd, 0o600)
+            f = os.fdopen(fd, 'w')
+        except BaseException:
+            os.close(fd)
+            raise
+        with f:
             config.write(f)
+        if not hasattr(os, 'fchmod'):
+            # os.fchmod is POSIX-only; on Windows chmod is close to a no-op but
+            # keeps the code path defined.
+            os.chmod(DEFAULT_KEYCHAIN_FILEPATH, 0o600)

--- a/praetorian_cli/sdk/keychain.py
+++ b/praetorian_cli/sdk/keychain.py
@@ -1,8 +1,9 @@
 import os
+import tempfile
 from configparser import ConfigParser
 from ipaddress import ip_address
 from os import environ
-from os.path import join, split
+from os.path import join
 from pathlib import Path
 from time import time
 from urllib.parse import urlsplit
@@ -163,12 +164,18 @@ class Keychain:
         """ Authenticate using API key or AWS Cognito and get the token. Cache the token until expiry. """
         if not self.token_cache or time() >= (self.token_expiry - 10):
             if self.has_api_key():
+                # requests preserves custom headers across redirects (only the
+                # standard Authorization header is stripped), so following a
+                # redirect off the validated HTTPS URL could leak the key
+                # headers. With redirects disabled, a redirect response lands
+                # in the fail-closed status_code check below.
                 response = requests.get(
                     f"{self.base_url()}/token",
                     headers={
                         'X-GUARD-API-KEY-ID': self.api_key_id(),
                         'X-GUARD-API-KEY-SECRET': self.api_key_secret(),
                     },
+                    allow_redirects=False,
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
                 if response.status_code != 200:
@@ -182,8 +189,13 @@ class Keychain:
                 # LocalStack) for local dev; None (unset) uses real AWS.
                 # USER_PASSWORD_AUTH is an unsigned Cognito operation, so no AWS
                 # credentials are needed for either endpoint.
+                aws_endpoint_url = self.get_option('aws_endpoint_url')
+                if aws_endpoint_url is not None:
+                    # Same transport policy as base_url(): initiate_auth below
+                    # sends the password, which must not cross plaintext HTTP.
+                    aws_endpoint_url = _validated_backend_url(aws_endpoint_url)
                 cognito = boto3.client('cognito-idp', region_name='us-east-2',
-                                       endpoint_url=self.get_option('aws_endpoint_url'))
+                                       endpoint_url=aws_endpoint_url)
                 response = cognito.initiate_auth(
                     AuthFlow='USER_PASSWORD_AUTH',
                     AuthParameters=dict(USERNAME=self.username(), PASSWORD=self.password()),
@@ -265,23 +277,25 @@ class Keychain:
 
         config[profile] = new_profile
 
+        keychain_dir = Path(DEFAULT_KEYCHAIN_FILEPATH).parent
         # mkdir's mode leaves a pre-existing directory alone; a new one is created
         # owner-only to match the file it holds.
-        Path(split(Path(DEFAULT_KEYCHAIN_FILEPATH))[0]).mkdir(mode=0o700, exist_ok=True, parents=True)
-        # O_CREAT's 0o600 applies to new files only; the fchmod is what tightens a
-        # pre-existing looser file. Secrets are about to be written, so an fchmod
-        # failure propagates rather than writing them into a world-readable file.
-        fd = os.open(DEFAULT_KEYCHAIN_FILEPATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        keychain_dir.mkdir(mode=0o700, exist_ok=True, parents=True)
+        # Write to a same-directory temp file (mkstemp creates it 0600 at the open
+        # syscall, regardless of umask) and atomically replace the keychain: a
+        # failure at any point leaves an existing keychain intact rather than
+        # truncated, and os.replace swaps out a symlink planted at the final path
+        # instead of following it.
+        fd, tmp_path = tempfile.mkstemp(dir=keychain_dir, prefix='.keychain.', suffix='.tmp')
         try:
-            if hasattr(os, 'fchmod'):
-                os.fchmod(fd, 0o600)
-            f = os.fdopen(fd, 'w')
+            with os.fdopen(fd, 'w') as f:
+                config.write(f)
+                f.flush()
+                os.fsync(fd)
+            os.replace(tmp_path, DEFAULT_KEYCHAIN_FILEPATH)
         except BaseException:
-            os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
             raise
-        with f:
-            config.write(f)
-        if not hasattr(os, 'fchmod'):
-            # os.fchmod is POSIX-only; on Windows chmod is close to a no-op but
-            # keeps the code path defined.
-            os.chmod(DEFAULT_KEYCHAIN_FILEPATH, 0o600)

--- a/praetorian_cli/sdk/test/test_keychain.py
+++ b/praetorian_cli/sdk/test/test_keychain.py
@@ -1,0 +1,190 @@
+"""Keychain storage-permission and backend-URL scheme tests (ENG-6636).
+
+Two properties, both purely local (no backend access):
+
+1. At rest: the keychain file holding passwords / API keys is created with
+   owner-only permissions, and a pre-existing file written looser by an older
+   CLI is tightened whenever the keychain is written or read.
+2. In transit: credentials are only ever sent to an HTTPS backend. A plaintext
+   ``http://`` backend is rejected before any request is made; the sole
+   exception is a loopback endpoint (the local Cognito/LocalStack dev flow)
+   under the explicit ``PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1`` opt-in.
+"""
+
+import os
+import stat
+import sys
+from configparser import ConfigParser
+
+import pytest
+
+import praetorian_cli.sdk.keychain as keychain_module
+from praetorian_cli.sdk.exceptions import ConfigurationError
+from praetorian_cli.sdk.keychain import Keychain
+
+# The documented opt-in interface. A literal on purpose: renaming the variable
+# in keychain.py must fail these tests, since the old name is what operators
+# have in their dev environments.
+OPT_IN_ENV = 'PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK'
+
+posix_modes = pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason='POSIX file modes; on Windows chmod is close to a no-op',
+)
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _profile(api='https://api.example.com/chariot', extra=''):
+    return f'[United States]\napi = {api}\nclient_id = test-client-id\n{extra}'
+
+
+@pytest.fixture(autouse=True)
+def _clean_cli_environment(monkeypatch):
+    """PRAETORIAN_CLI_* variables in the operator's real environment override
+    keychain fields inside load(); strip them so tests see only their own."""
+    for name in list(os.environ):
+        if name.startswith('PRAETORIAN_CLI_'):
+            monkeypatch.delenv(name)
+
+
+@pytest.fixture
+def keychain_path(tmp_path, monkeypatch):
+    path = tmp_path / '.praetorian' / 'keychain.ini'
+    monkeypatch.setattr(keychain_module, 'DEFAULT_KEYCHAIN_FILEPATH', str(path))
+    return path
+
+
+@pytest.fixture
+def permissive_umask():
+    previous = os.umask(0)
+    yield
+    os.umask(previous)
+
+
+# ---------------------------------------------------------------- at rest
+
+
+@posix_modes
+def test_configure_creates_keychain_owner_only_under_permissive_umask(
+        keychain_path, permissive_umask):
+    """A plain open(path, 'w') under umask 0 would land at 0666; the mode must
+    come from the code, not from whatever umask the operator happens to run."""
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    assert _mode(keychain_path) == 0o600
+
+
+@posix_modes
+def test_configure_tightens_pre_existing_world_readable_keychain(keychain_path):
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text(_profile())
+    keychain_path.chmod(0o644)
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    assert _mode(keychain_path) == 0o600
+
+
+@posix_modes
+def test_load_tightens_pre_existing_world_readable_keychain(keychain_path):
+    """Existing installs have 0644 keychains from older CLI versions and may
+    never re-run configure; any read of the keychain repairs the mode."""
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text(_profile())
+    keychain_path.chmod(0o644)
+    Keychain(filepath=str(keychain_path)).load()
+    assert _mode(keychain_path) == 0o600
+
+
+def test_configure_preserves_other_profiles(keychain_path):
+    keychain_path.parent.mkdir(parents=True)
+    keychain_path.write_text('[Other]\napi = https://other.example.com\nclient_id = other\n')
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    config = ConfigParser()
+    config.read(keychain_path)
+    assert 'Other' in config
+    assert 'United States' in config
+    assert config.get('United States', 'api_key_secret') == 'ksecret'
+
+
+# ------------------------------------------------------------- in transit
+
+
+def test_base_url_returns_https_backend_verbatim():
+    api = 'https://d0qcl2e18h.execute-api.us-east-2.amazonaws.com/chariot'
+    assert Keychain(data=_profile(api)).base_url() == api
+
+
+def test_http_loopback_is_rejected_without_opt_in():
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile('http://localhost:3000/chariot')).base_url()
+
+
+@pytest.mark.parametrize('api', [
+    'http://localhost:3000/chariot',
+    'http://127.0.0.1:8010',
+    'http://[::1]:9000/chariot',
+])
+def test_opt_in_allows_loopback_http(monkeypatch, api):
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    assert Keychain(data=_profile(api)).base_url() == api
+
+
+@pytest.mark.parametrize('api', [
+    'http://api.example.com/chariot',
+    'http://192.168.1.10:8000',
+    'http://localhost.example.com',
+])
+def test_opt_in_never_allows_non_loopback_http(monkeypatch, api):
+    """The opt-in is for the local dev emulator only; a plaintext backend on a
+    real network stays rejected even with the variable set."""
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile(api)).base_url()
+
+
+@pytest.mark.parametrize('value', ['true', 'yes', '0', ''])
+def test_opt_in_value_must_be_exactly_1(monkeypatch, value):
+    monkeypatch.setenv(OPT_IN_ENV, value)
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile('http://localhost:3000/chariot')).base_url()
+
+
+@pytest.mark.parametrize('api', [
+    'ftp://api.example.com/chariot',
+    'api.example.com/chariot',
+    'https://',
+    'https://api.example.com:not-a-port/chariot',
+])
+def test_malformed_or_non_http_backends_are_rejected(api):
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile(api)).base_url()
+
+
+def test_token_never_sends_api_key_to_plaintext_backend(monkeypatch):
+    """The property the ticket actually cares about: a poisoned profile must
+    fail before the API-key id/secret headers leave the process."""
+    calls = []
+    monkeypatch.setattr(keychain_module.requests, 'get',
+                        lambda *args, **kwargs: calls.append((args, kwargs)))
+    keychain = Keychain(data=_profile(
+        'http://api.example.com/chariot',
+        extra='api_key_id = kid\napi_key_secret = ksecret\n'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_env_var_backend_override_is_validated(monkeypatch):
+    """PRAETORIAN_CLI_API takes precedence over the keychain file, so it is a
+    second injection point for a plaintext endpoint."""
+    monkeypatch.setenv('PRAETORIAN_CLI_API', 'http://api.example.com/chariot')
+    with pytest.raises(ConfigurationError):
+        Keychain(data=_profile()).base_url()
+
+
+def test_configure_rejects_plaintext_backend_before_writing(keychain_path):
+    with pytest.raises(ConfigurationError):
+        Keychain.configure(None, None, api='http://api.example.com/chariot',
+                           api_key_id='kid', api_key_secret='ksecret')
+    assert not keychain_path.exists()

--- a/praetorian_cli/sdk/test/test_keychain.py
+++ b/praetorian_cli/sdk/test/test_keychain.py
@@ -107,6 +107,45 @@ def test_configure_preserves_other_profiles(keychain_path):
     assert config.get('United States', 'api_key_secret') == 'ksecret'
 
 
+def test_failed_configure_write_preserves_existing_keychain(keychain_path, monkeypatch):
+    """The O_TRUNC regression: writing the final path directly would zero the
+    existing keychain before the new content lands, so a failure mid-write
+    destroys the operator's credentials. The atomic tmp-file + os.replace path
+    must leave the old keychain byte-identical when the swap fails, and must
+    not litter the directory with the temp file."""
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+    original = keychain_path.read_bytes()
+
+    def broken_replace(src, dst):
+        raise OSError('simulated')
+
+    monkeypatch.setattr(keychain_module.os, 'replace', broken_replace)
+    with pytest.raises(OSError):
+        Keychain.configure('someone@example.com', 'hunter2', profile='Other')
+    assert keychain_path.read_bytes() == original
+    assert list(keychain_path.parent.glob('.keychain.*.tmp')) == []
+
+
+@posix_modes
+def test_configure_replaces_symlinked_keychain_instead_of_following_it(
+        keychain_path, permissive_umask):
+    """A symlink planted at the keychain path must not trick configure into
+    writing credentials wherever the link points; os.replace swaps the link
+    out for a regular owner-only file and leaves the target untouched."""
+    keychain_path.parent.mkdir(parents=True)
+    target = keychain_path.parent.parent / 'symlink-target.ini'
+    target_content = '[Other]\napi = https://other.example.com\nclient_id = other\n'
+    target.write_text(target_content)
+    keychain_path.symlink_to(target)
+
+    Keychain.configure(None, None, api_key_id='kid', api_key_secret='ksecret')
+
+    assert not keychain_path.is_symlink()
+    assert keychain_path.is_file()
+    assert target.read_text() == target_content
+    assert _mode(keychain_path) == 0o600
+
+
 # ------------------------------------------------------------- in transit
 
 
@@ -188,3 +227,95 @@ def test_configure_rejects_plaintext_backend_before_writing(keychain_path):
         Keychain.configure(None, None, api='http://api.example.com/chariot',
                            api_key_id='kid', api_key_secret='ksecret')
     assert not keychain_path.exists()
+
+
+def test_token_sends_api_key_with_redirects_disabled(monkeypatch):
+    """requests preserves the custom API-key headers across redirects, so the
+    token request must not follow one off the validated HTTPS URL."""
+    calls = []
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {'token': 'x'}
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _Response()
+
+    monkeypatch.setattr(keychain_module.requests, 'get', record)
+    keychain = Keychain(data=_profile(
+        extra='api_key_id = kid\napi_key_secret = ksecret\n'))
+    assert keychain.token() == 'x'
+    assert len(calls) == 1
+    assert calls[0][1]['allow_redirects'] is False
+
+
+# The Cognito username/password branch: aws_endpoint_url points initiate_auth
+# (which carries the password) at a local emulator, so it is a third injection
+# point for a plaintext endpoint alongside the keychain api field and
+# PRAETORIAN_CLI_API.
+
+
+def _cognito_profile(aws_endpoint_url=None):
+    extra = 'username = user\npassword = secret\n'
+    if aws_endpoint_url:
+        extra += f'aws_endpoint_url = {aws_endpoint_url}\n'
+    return _profile(extra=extra)
+
+
+def _record_boto3_client(monkeypatch):
+    """Replace boto3.client with a recorder returning a stub Cognito client."""
+    calls = []
+
+    class _StubCognito:
+        @staticmethod
+        def initiate_auth(**kwargs):
+            return {'AuthenticationResult': {'ExpiresIn': 3600, 'IdToken': 't'}}
+
+    def record(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _StubCognito()
+
+    monkeypatch.setattr(keychain_module.boto3, 'client', record)
+    return calls
+
+
+def test_cognito_emulator_endpoint_rejected_without_opt_in(monkeypatch):
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://localhost:4566'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_opt_in_allows_loopback_cognito_emulator(monkeypatch):
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://localhost:4566'))
+    assert keychain.token() == 't'
+    assert len(calls) == 1
+    assert calls[0][1]['endpoint_url'] == 'http://localhost:4566'
+
+
+def test_opt_in_never_allows_non_loopback_cognito_emulator(monkeypatch):
+    """Same policy as base_url(): the opt-in admits loopback only, so a
+    plaintext emulator URL on a real network stays rejected even when set."""
+    monkeypatch.setenv(OPT_IN_ENV, '1')
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile('http://198.51.100.7:4566'))
+    with pytest.raises(ConfigurationError):
+        keychain.token()
+    assert calls == []
+
+
+def test_absent_aws_endpoint_url_still_means_real_aws(monkeypatch):
+    """Unset must keep meaning real AWS: the validation of a configured
+    emulator URL must not turn None into a rejected or mangled endpoint."""
+    calls = _record_boto3_client(monkeypatch)
+    keychain = Keychain(data=_cognito_profile())
+    assert keychain.token() == 't'
+    assert len(calls) == 1
+    assert calls[0][1]['endpoint_url'] is None


### PR DESCRIPTION
Fixes [ENG-6636](https://linear.app/praetorianlabs/issue/ENG-6636/guard-cli-keychain-credentials-are-insecure-at-rest-no-0600-and-in) — PR 5 of the [ENG-6569](https://linear.app/praetorianlabs/issue/ENG-6569) per-ticket split (after #273, #274, #275, #276).

## Problem

`praetorian_cli/sdk/keychain.py` mishandled credential material in two independent ways:

1. **At rest — world-readable.** `Keychain.configure()` wrote `~/.praetorian/keychain.ini` (which can hold `password`, `api_key_id`, `api_key_secret`) with a plain `open(path, 'w')`. Under the default umask 022 the file lands at 0644, readable by every local user — in contrast to `credentials._process_credential_output`, which already chmods its outputs to 0600.
2. **In transit — no scheme enforcement.** The backend base URL (profile `api` field or `PRAETORIAN_CLI_API`) was used verbatim. `token()` sends the long-lived API-key id/secret as `X-GUARD-API-KEY-ID` / `X-GUARD-API-KEY-SECRET` headers to `{base_url}/token`, so an `http://` endpoint received them in cleartext with no warning.

## Fix

**At rest**

- `configure()` writes the keychain via a same-directory `tempfile.mkstemp` temp file — 0600 at the open syscall, which umask can never loosen — then atomically `os.replace`s it onto `keychain.ini`. A failure at any point leaves an existing keychain intact (no in-place `O_TRUNC`), the `fchmod`/`hasattr` platform forks disappear, and a symlink planted at the final path is swapped out rather than followed. (Reworked from an in-place `os.open`+`fchmod` write after the codex/gemini review round — see the adjudication comments. Behavior note: a deliberately symlinked `keychain.ini` becomes a regular file on the next `configure`.)
- `load()` best-effort repairs a group/world-accessible keychain (`st_mode & 0o077` → chmod 0600) before reading it, so existing installs with 0644 files from older CLI versions are fixed on first use of any command, without re-running `configure`. Best-effort because the file is being read, not written, and a filesystem that refuses chmod must not brick the CLI; `configure()` remains the authoritative enforcement point.
- A newly created `~/.praetorian` directory is 0700; a pre-existing directory's mode is left alone.

**In transit**

- `base_url()` now returns `_validated_backend_url(self.get_option('api'))`. This is the single choke point: `token()`, `chariot.url()`, `account_discovery`, and `webhook` all resolve the backend through it, and the `PRAETORIAN_CLI_API` env override lands in the config via `load_env` before `get_option` reads it — so every credentialed request path is covered.
- Validation: HTTPS with a hostname passes verbatim. Plaintext HTTP is allowed only toward loopback (`localhost`, `127.0.0.0/8`, `::1` — literal IPs only; `localhost.example.com` does not count) and only when `PRAETORIAN_CLI_ALLOW_HTTP_LOOPBACK=1` is set exactly, which keeps the local Cognito/LocalStack dev flow usable (AC 3). Everything else — public HTTP even with the opt-in, other schemes, missing scheme/host, unparsable port — raises `ConfigurationError` before any request is made.
- `token()` no longer follows redirects (`allow_redirects=False`): requests preserves the custom `X-GUARD-API-KEY-*` headers across redirects (only the standard `Authorization` header is stripped), so a redirect off the validated HTTPS URL could have leaked them. A redirect response lands in the fail-closed status-code check.
- The Cognito emulator endpoint (`aws_endpoint_url`) goes through the same `_validated_backend_url` policy before `boto3.client` is constructed — `initiate_auth` sends the password, which must not cross plaintext HTTP. Unset still means real AWS.
- `configure()` validates the URL before any file I/O, so a plaintext backend is rejected before the keychain is created or modified.
- Documented in `README.md` and `docs/configure.md` (AC 2's "explicit, documented opt-in").

**Out of scope per the ticket:** routing `/token` through the proxy (ENG-6635 sibling) and the secrets-in-argv leak (separate sibling).

## Premise

PROCEED — the ticket's frame was verified against the code before implementation: the cited `open(path, 'w')` write and verbatim `base_url()` passthrough both reproduce at `praetorian-cli` main (bd6822d), and the fix sits at the right layer (the file-write site and the URL choke point, not per-caller patching). The diff builds no new subsystem: one validation helper, one repair helper, and mode-correct file creation. Re-affirmed after the review round: the atomic-write rework is a mechanism swap inside the same choke point, not a redesign.

## Tests

`praetorian_cli/sdk/test/test_keychain.py` (30 tests, unit-only, no backend), written RED-first (18 failed / 5 passed pre-fix; the 5 pin the post-fix contract so it cannot over-block), plus 7 review-round tests:

- mode 0600 on create under umask 0 (a plain `open` would land 0666), tighten-on-configure and tighten-on-load of a pre-existing 0644 file — AC 1's mode assertion
- HTTPS passes verbatim; loopback HTTP rejected without opt-in; opt-in admits `localhost`/`127.0.0.1`/`[::1]` but never public HTTP; opt-in value must be exactly `1`; malformed URLs rejected
- the leak witness: with a plaintext backend and API keys configured, `token()` raises before `requests.get` is ever called
- `PRAETORIAN_CLI_API` override is validated; `configure()` rejects a plaintext URL before writing; other profiles survive a rewrite
- review round: a failed write preserves the existing keychain byte-for-byte and leaves no temp file; a symlinked `keychain.ini` is replaced, not followed; `token()` passes `allow_redirects=False`; `aws_endpoint_url` rejected without opt-in, loopback-only under opt-in, absent still means real AWS

```
praetorian_cli/sdk/test/test_keychain.py                       30 passed
test_update_check + test_sdk_exceptions + test_cli_errors
  + test_credential_process (regression smoke)                131 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
